### PR TITLE
Release 0.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Lolo can then be used by adding the following dependency block in your pom file:
 <dependency>
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.8</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>0.0.7</version>
+    <version>0.0.8</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
This is mostly repaying debt from the hotfixes last night.  Summary of changes: 
 *  `PredictionResult` returns gradient, uncertainty, and score as options instead of traits
 * `Bagger` can be configured to skip jackknife variance estimates, falling back on the biasModel (if set)
 * `BaggedTrainingResult` pre-computes feature importance so it can discard model meta-data