### PR TITLE
Adding standardizing meta-learner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>0.2.2</version>
+    <version>0.2.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -1,0 +1,144 @@
+package io.citrine.lolo.transformers
+
+import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
+
+/**
+  * Created by maxhutch on 2/19/17.
+  */
+class Standardizer(baseLearner: Learner) extends Learner() {
+  override var hypers: Map[String, Any] = Map()
+  override def setHypers(moreHypers: Map[String, Any]): this.type = {
+    baseLearner.setHypers(moreHypers)
+    super.setHypers(moreHypers)
+  }
+
+  /**
+    * Train a model
+    *
+    * @param trainingData to train on
+    * @param weights      for the training rows, if applicable
+    * @return training result containing a model
+    */
+  override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]]): StandardizerTrainingResult = {
+    val rep = trainingData.head._1
+    val inputTrans = Standardizer.getMultiStandardization(trainingData.map(_._1))
+    val outputTrans = trainingData.head._2 match {
+      case x: Double => Some(Standardizer.getStandardization(trainingData.map(_._2.asInstanceOf[Double])))
+      case x: Any => None
+    }
+
+    val (inputs, labels) = trainingData.unzip
+    val standardTrainingData = Standardizer.applyStandardization(inputs, inputTrans).zip(Standardizer.applyStandardization(labels, outputTrans))
+    val baseTrainingResult = baseLearner.train(standardTrainingData)
+
+    new StandardizerTrainingResult(baseTrainingResult, Seq(outputTrans) ++ inputTrans, hypers)
+  }
+}
+
+class StandardizerTrainingResult(
+                                  baseTrainingResult: TrainingResult,
+                                  trans: Seq[Option[(Double, Double)]],
+                                  hypers: Map[String, Any]
+                                ) extends TrainingResult {
+  /**
+    * Get the model contained in the training result
+    *
+    * @return the model
+    */
+  override def getModel(): Model[PredictionResult[Any]] = new StandardizerModel(baseTrainingResult.getModel(), trans)
+
+  /**
+    * Get the hyperparameters used to train this model
+    *
+    * @return hypers set for model
+    */
+  override def getHypers(): Map[String, Any] = hypers
+
+  override def getFeatureImportance(): Option[Vector[Double]] = baseTrainingResult.getFeatureImportance()
+}
+
+class StandardizerModel[T](baseModel: Model[PredictionResult[T]], trans: Seq[Option[(Double, Double)]]) extends Model[PredictionResult[T]] {
+  /**
+    * Apply the model to a seq of inputs
+    *
+    * @param inputs to apply the model to
+    * @return a predictionresult which includes, at least, the expected outputs
+    */
+  override def transform(inputs: Seq[Vector[Any]]): StandardizerPrediction[T] = {
+    val standardInputs = Standardizer.applyStandardization(inputs, trans.tail)
+    new StandardizerPrediction(baseModel.transform(standardInputs), trans.head.getOrElse((0, 0)))
+  }
+}
+
+class StandardizerPrediction[T](baseResult: PredictionResult[T], trans: (Double, Double)) extends PredictionResult[T] {
+  /**
+    * Get the expected values for this prediction
+    *
+    * @return expected value of each prediction
+    */
+  override def getExpected(): Seq[T] = {
+    baseResult.getExpected().map{
+      case x: Double => x * rescale + trans._1
+      case x: Any => x
+    }.asInstanceOf[Seq[T]]
+  }
+
+  /**
+    * Get the uncertainty of the prediction
+    *
+    * For example, in regression this is sqrt(bias^2 + variance)
+    * @return uncertainty of each prediction
+    */
+  override def getUncertainty(): Option[Seq[Any]] = {
+    baseResult.getUncertainty() match {
+      case None => None
+      case Some(x: Seq[Double]) => Some(x.map(_ * rescale))
+      case Some(x: Seq[Any]) => Some(x)
+    }
+  }
+
+  val rescale = 1.0 / trans._2
+}
+
+object Standardizer {
+  def getStandardization(values: Seq[Double]): (Double, Double) = {
+    val mean = values.sum / values.size
+    val scale = Math.sqrt(values.map(v => Math.pow(v - mean, 2)).sum / values.size)
+    (mean, 1.0/scale)
+  }
+
+  /**
+    * Get standardization for multiple values in a vector.
+    *
+    * This has a different name because scala erases the inner type of Seq[T]
+    * @param values sequence of vectors to be standardized
+    * @return sequence of standardization, each as an option
+    */
+  def getMultiStandardization(values: Seq[Vector[Any]]): Seq[Option[(Double, Double)]] = {
+    val rep = values.head
+    rep.indices.map{i =>
+      rep(i) match {
+        case x: Double =>
+          Some(getStandardization(values.map(r => r(i).asInstanceOf[Double])))
+        case x: Any => None
+      }
+    }
+  }
+
+  def applyStandardization(input: Seq[Vector[Any]], trans: Seq[Option[(Double, Double)]]): Seq[Vector[Any]] = {
+    input.map {r =>
+      r.zip(trans).map {
+        case (x: Double, Some(t)) => (x - t._1) * t._2
+        case (x: Any, None) => x
+      }
+    }
+  }
+
+  def applyStandardization(input: Seq[Any], trans: Option[(Double, Double)]): Seq[Any] = {
+    if (trans.isEmpty) return input
+
+    input.asInstanceOf[Seq[Double]].map{r =>
+      (r - trans.get._1) * trans.get._2
+    }
+  }
+}

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -1,0 +1,47 @@
+package io.citrine.lolo.transformers
+
+import io.citrine.lolo.TestUtils
+import io.citrine.lolo.stats.functions.Friedman
+import org.junit.Test
+
+/**
+  * Created by maxhutch on 2/19/17.
+  */
+@Test
+class StandardizerTest {
+
+  val data = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+
+  @Test
+  def testStandardMeanAndVariance(): Unit = {
+    val inputs = data.map(_._1)
+    val inputTransforms = Standardizer.getMultiStandardization(inputs)
+
+    val standardInputs = Standardizer.applyStandardization(inputs, inputTransforms)
+    standardInputs.head.indices.foreach{ i =>
+      val values = standardInputs.map(_(i).asInstanceOf[Double])
+      val mean = values.sum / values.size
+      assert(mean < 1.0e-9, s"Standard input ${i} has non-zero mean ${mean}")
+
+      val variance = values.map(Math.pow(_, 2)).sum / values.size
+      assert(Math.abs(variance - 1.0) < 1.0e-9, s"Standard input ${i} has non-unit variance ${variance}")
+    }
+
+    val outputs = data.map(_._2.asInstanceOf[Double])
+    val outputTransform = Standardizer.getStandardization(outputs)
+    val standardOutputs = Standardizer.applyStandardization(outputs, Some(outputTransform)).asInstanceOf[Seq[Double]]
+
+    val mean = standardOutputs.sum / standardOutputs.size
+    assert(mean < 1.0e-9, s"Standard output has non-zero mean ${mean}")
+
+    val variance = standardOutputs.map(Math.pow(_, 2)).sum / standardOutputs.size
+    assert(Math.abs(variance - 1.0) < 1.0e-9, s"Standard output has non-unit variance ${variance}")
+  }
+
+}
+
+object StandardizerTest {
+  def main(argv: Array[String]): Unit = {
+    new StandardizerTest().testStandardMeanAndVariance()
+  }
+}

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.transformers
 
 import io.citrine.lolo.TestUtils
+import io.citrine.lolo.linear.{GuessTheMeanLearner, LinearRegressionLearner}
 import io.citrine.lolo.stats.functions.Friedman
 import org.junit.Test
 
@@ -38,10 +39,66 @@ class StandardizerTest {
     assert(Math.abs(variance - 1.0) < 1.0e-9, s"Standard output has non-unit variance ${variance}")
   }
 
+  /**
+    * Guess the mean should be invariant under standardization
+    */
+  @Test
+  def testStandardGTM(): Unit = {
+    val learner = new GuessTheMeanLearner
+    val model = learner.train(data).getModel()
+    val result = model.transform(data.map(_._1)).getExpected()
+
+    val standardLearner = new Standardizer(new GuessTheMeanLearner)
+    val standardModel = standardLearner.train(data).getModel()
+    val standardResult = standardModel.transform(data.map(_._1)).getExpected()
+
+    result.zip(standardResult).foreach{ case (free: Double, standard: Double) =>
+        assert(Math.abs(free - standard) < 1.0e-9, s"${free} and ${standard} should be the same")
+    }
+  }
+
+  /**
+    * Linear regression should be invariant under standardization
+    */
+  @Test
+  def testStandardLinear(): Unit = {
+    val learner = new LinearRegressionLearner()
+    val model = learner.train(data).getModel()
+    val result = model.transform(data.map(_._1)).getExpected()
+
+    val standardLearner = new Standardizer(learner)
+    val standardModel = standardLearner.train(data).getModel()
+    val standardResult = standardModel.transform(data.map(_._1)).getExpected()
+
+    result.zip(standardResult).foreach{ case (free: Double, standard: Double) =>
+        assert(Math.abs(free - standard) < 1.0e-9, s"${free} and ${standard} should be the same")
+    }
+  }
+
+  /**
+    * Ridge regression should depend on standardization
+    */
+  @Test
+  def testStandardRidge(): Unit = {
+    val learner = new LinearRegressionLearner().setHyper("regParam", 1.0)
+    val model = learner.train(data).getModel()
+    val result = model.transform(data.map(_._1)).getExpected()
+
+    val standardLearner = new Standardizer(learner)
+    val standardModel = standardLearner.train(data).getModel()
+    val standardResult = standardModel.transform(data.map(_._1)).getExpected()
+
+    result.zip(standardResult).foreach{ case (free: Double, standard: Double) =>
+        assert(Math.abs(free - standard) > 1.0e-9, s"${free} and ${standard} should NOT be the same")
+    }
+  }
 }
 
 object StandardizerTest {
   def main(argv: Array[String]): Unit = {
     new StandardizerTest().testStandardMeanAndVariance()
+    new StandardizerTest().testStandardGTM()
+    new StandardizerTest().testStandardLinear()
+    new StandardizerTest().testStandardRidge()
   }
 }


### PR DESCRIPTION
Standardizes any continuous input features or output labels by giving them zero mean and unit variance.

CC: @sparadiso the logic is all here, but I'm still adding tests.  Please review but don't merge.