### PR TITLE
Hotfix - standardizer was incorrect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>0.2.3</version>
+    <version>0.2.4</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -35,7 +35,7 @@ class Standardizer(baseLearner: Learner) extends Learner() {
 
     val (inputs, labels) = trainingData.unzip
     val standardTrainingData = Standardizer.applyStandardization(inputs, inputTrans).zip(Standardizer.applyStandardization(labels, outputTrans))
-    val baseTrainingResult = baseLearner.train(standardTrainingData)
+    val baseTrainingResult = baseLearner.train(standardTrainingData, weights)
 
     new StandardizerTrainingResult(baseTrainingResult, Seq(outputTrans) ++ inputTrans, hypers)
   }

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -6,6 +6,8 @@ import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import org.junit.Test
 
+import scala.util.Random
+
 /**
   * Created by maxhutch on 2/19/17.
   */
@@ -13,6 +15,7 @@ import org.junit.Test
 class StandardizerTest {
 
   val data = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+  val weights = Vector.fill(data.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
 
   @Test
   def testStandardMeanAndVariance(): Unit = {
@@ -64,13 +67,13 @@ class StandardizerTest {
   @Test
   def testStandardLinear(): Unit = {
     val learner = new LinearRegressionLearner()
-    val model = learner.train(data).getModel()
+    val model = learner.train(data, Some(weights)).getModel()
     val result = model.transform(data.map(_._1))
     val expected = result.getExpected()
     val gradient = result.getGradient()
 
     val standardLearner = new Standardizer(learner)
-    val standardModel = standardLearner.train(data).getModel()
+    val standardModel = standardLearner.train(data, Some(weights)).getModel()
     val standardResult = standardModel.transform(data.map(_._1))
     val standardExpected = standardResult.getExpected()
     val standardGradient = standardResult.getGradient()
@@ -109,6 +112,7 @@ class StandardizerTest {
         function = Friedman.friedmanSilverman),
       responseBins = Some(2)
     )
+
     val learner = new ClassificationTreeLearner()
     val model = learner.train(trainingData).getModel()
     val result = model.transform(trainingData.map(_._1)).getExpected()


### PR DESCRIPTION
The standardizer wasn't passing the weights through, which was really important to the functioning of bagged models.