### PR TITLE
Interruptible bagger training

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -4,7 +4,7 @@ import breeze.linalg.{DenseMatrix, DenseVector, min, norm}
 import breeze.numerics.abs
 import breeze.stats.distributions.Poisson
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
-import io.citrine.lolo.util.InterruptibleExecutionContext
+import io.citrine.lolo.util.{Async, InterruptibleExecutionContext}
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 
 import scala.collection.parallel.ExecutionContextTaskSupport
@@ -64,7 +64,7 @@ class Bagger(
 
     /* Learn the actual models */
     val parIterator = (0 until actualBags).par
-    parIterator.tasksupport = new ExecutionContextTaskSupport(InterruptibleExecutionContext)
+    parIterator.tasksupport = new ExecutionContextTaskSupport(InterruptibleExecutionContext())
     val models = parIterator.map { i =>
       method.train(trainingData.toVector, Some(Nib(i).zip(weightsActual).map(p => p._1.toDouble * p._2)))
     }
@@ -78,9 +78,9 @@ class Bagger(
         }.map(_ / models.size))
       case None => None
     }
+    Async.canStop()
 
     /* Wrap the models in a BaggedModel object */
-    println("Training bias model")
     if (biasLearner.isEmpty) {
       new BaggedTrainingResult(models.map(_.getModel()), hypers, importances, Nib, trainingData, useJackknife)
     } else {
@@ -94,7 +94,9 @@ class Bagger(
         val bias = Math.max(Math.E * Math.abs(p.asInstanceOf[Double] - a.asInstanceOf[Double]) - u.asInstanceOf[Double], 0.0)
         (f, bias)
       }
+      Async.canStop()
       val biasModel = biasLearner.get.train(biasTraining).getModel()
+      Async.canStop()
 
       new BaggedTrainingResult(models.map(_.getModel()), hypers, importances, Nib, trainingData, useJackknife, Some(biasModel))
     }
@@ -331,15 +333,21 @@ class BaggedResult(
 
     /* These operations are pulled out of the loop and extra-verbose for performance */
     val JMat = NibJ.t * predMat
+    Async.canStop()
     val JMat2 = JMat :* JMat * ((Nib.size - 1.0) / Nib.size)
+    Async.canStop()
     val IJMat = NibIJ.t * predMat
+    Async.canStop()
     val IJMat2 = IJMat :* IJMat
+    Async.canStop()
     val arg = IJMat2 + JMat2
+    Async.canStop()
 
     /* Avoid division in the loop */
     val inverseSize = 1.0 / modelPredictions.head.size
 
     (0 until modelPredictions.size).map { i =>
+      Async.canStop()
       /* Compute the first order bias correction for the variance estimators */
       val correction = Math.pow(inverseSize * norm(predMat(::, i) - meanPrediction(i)), 2)
 

--- a/src/main/scala/io/citrine/lolo/util/Async.scala
+++ b/src/main/scala/io/citrine/lolo/util/Async.scala
@@ -1,11 +1,12 @@
 package io.citrine.lolo.util
 
 /**
+  * Object containing utility functions for supporting interrupts
   * Created by maxhutch on 4/20/17.
   */
 object Async {
   /**
-    * Check the thread's interuppted status, because it could stop
+    * Check the thread's interrupted status, because it could stop
     */
   def canStop(): Unit = {
     if (Thread.interrupted()) throw new InterruptedException()

--- a/src/main/scala/io/citrine/lolo/util/Async.scala
+++ b/src/main/scala/io/citrine/lolo/util/Async.scala
@@ -1,0 +1,13 @@
+package io.citrine.lolo.util
+
+/**
+  * Created by maxhutch on 4/20/17.
+  */
+object Async {
+  /**
+    * Check the thread's interuppted status, because it could stop
+    */
+  def canStop(): Unit = {
+    if (Thread.interrupted()) throw new InterruptedException()
+  }
+}

--- a/src/main/scala/io/citrine/lolo/util/InterruptibleExecutionContext.scala
+++ b/src/main/scala/io/citrine/lolo/util/InterruptibleExecutionContext.scala
@@ -8,13 +8,21 @@ import scala.concurrent.ExecutionContext
   * Thin wrapper around the global execution context
   * Created by maxhutch on 4/20/17.
   */
-object InterruptibleExecutionContext extends ExecutionContext {
+class InterruptibleExecutionContext(executionContext: ExecutionContext) extends ExecutionContext {
   override def execute(runnable: Runnable): Unit = {
-    if (Thread.interrupted()) throw new InterruptedException
-    ExecutionContext.global.execute(runnable)
+    Async.canStop()
+    executionContext.execute(runnable)
   }
 
   override def reportFailure(cause: Throwable): Unit = {
-    ExecutionContext.global.reportFailure(cause)
+    executionContext.reportFailure(cause)
   }
+}
+
+/**
+  * Provide default InterruptibleExecutionContext based on the global EC
+  */
+object InterruptibleExecutionContext {
+  private val default = new InterruptibleExecutionContext(ExecutionContext.global)
+  def apply(): InterruptibleExecutionContext = default
 }

--- a/src/main/scala/io/citrine/lolo/util/InterruptibleExecutionContext.scala
+++ b/src/main/scala/io/citrine/lolo/util/InterruptibleExecutionContext.scala
@@ -24,5 +24,6 @@ class InterruptibleExecutionContext(executionContext: ExecutionContext) extends 
   */
 object InterruptibleExecutionContext {
   private val default = new InterruptibleExecutionContext(ExecutionContext.global)
+
   def apply(): InterruptibleExecutionContext = default
 }

--- a/src/main/scala/io/citrine/lolo/util/InterruptibleExecutionContext.scala
+++ b/src/main/scala/io/citrine/lolo/util/InterruptibleExecutionContext.scala
@@ -1,0 +1,20 @@
+package io.citrine.lolo.util
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * Checks if thread was interrupted before performing a task.
+  *
+  * Thin wrapper around the global execution context
+  * Created by maxhutch on 4/20/17.
+  */
+object InterruptibleExecutionContext extends ExecutionContext {
+  override def execute(runnable: Runnable): Unit = {
+    if (Thread.interrupted()) throw new InterruptedException
+    ExecutionContext.global.execute(runnable)
+  }
+
+  override def reportFailure(cause: Throwable): Unit = {
+    ExecutionContext.global.reportFailure(cause)
+  }
+}

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.bags
 
-import java.util.concurrent.{Callable, CancellationException, Executors, Future, FutureTask}
+import java.util.concurrent.{Callable, CancellationException, Executors, Future}
 
 import io.citrine.lolo.TestUtils
 import io.citrine.lolo.stats.functions.Friedman
@@ -59,12 +59,12 @@ class BaggerTest {
 
     /* Inspect the results */
     val results = RF.transform(trainingData.map(_._1))
-    val means       = results.getExpected()
-    assert(trainingData.map(_._2).zip(means).forall{ case (a, p) => a == p})
+    val means = results.getExpected()
+    assert(trainingData.map(_._2).zip(means).forall { case (a, p) => a == p })
 
     val uncertainty = results.getUncertainty()
     assert(uncertainty.isDefined)
-    assert(trainingData.map(_._2).zip(uncertainty.get).forall{ case (a, probs) =>
+    assert(trainingData.map(_._2).zip(uncertainty.get).forall { case (a, probs) =>
       val classProbabilities = probs.asInstanceOf[Map[Any, Double]]
       val maxProb = classProbabilities(a)
       maxProb > 0.5 && maxProb < 1.0 && Math.abs(classProbabilities.values.sum - 1.0) < 1.0e-6

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -103,10 +103,10 @@ class BaggerTest {
   }
 
   /**
-    * Test the fit performance of the regression bagger
+    * Test that the bagged learner can be interrupted
     */
   @Test
-  def testInterupt(): Unit = {
+  def testInterrupt(): Unit = {
     val trainingData = TestUtils.generateTrainingData(2048, 12, noise = 0.1, function = Friedman.friedmanSilverman)
     val DTLearner = new RegressionTreeLearner(numFeatures = 3)
     val baggedLearner = new Bagger(DTLearner, numBags = trainingData.size)
@@ -122,16 +122,16 @@ class BaggerTest {
         }
       }
     )
+    assert(fut.cancel(true), "Failed to cancel future")
 
-    println(s"Cancelled? ${fut.cancel(true)}")
     try {
       fut.get()
+      assert(false, "Future completed")
     } catch {
       case _: CancellationException =>
       case _: InterruptedException =>
       case _: Throwable => assert(false)
     }
-    println("Done?")
     tmpPool.shutdown()
   }
 }

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -122,6 +122,7 @@ class BaggerTest {
         }
       }
     )
+    Thread.sleep(1000)
     assert(fut.cancel(true), "Failed to cancel future")
 
     try {

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -147,6 +147,6 @@ object BaggerTest {
     */
   def main(argv: Array[String]): Unit = {
     new BaggerTest()
-      .testInterupt()
+      .testInterrupt()
   }
 }


### PR DESCRIPTION
Bagger training can take a long time.  If its in a webservice, that can cause problems.  We should be able to interrupt it if we need to.

This PR establishes two patterns for making routines interruptible:
 * Interruptible parallel collections via the `InterruptibleExecutionContext`
 * Consistent thread status checking with `Async.canStop`

The unit test can only make sure the `train` method is interrupted _somewhere_.  I welcome suggestions for checking how quickly it stops running.

CC: @sparadiso 