### PR TITLE
Use a newer version of netlib-blas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.fommil.netlib</groupId>
+            <artifactId>all</artifactId>
+            <version>1.1.2</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>


### PR DESCRIPTION
Here's the performance test before:
```
     Train,      Apply,      N,      K,      B
    0.6287,     1.3247,   1024,      8,    512
    1.2826,     2.4847,   1024,      8,   1024
    2.7816,     5.2117,   1024,      8,   2048
    0.9222,     1.1737,   1024,     16,    512
    1.5393,     1.2708,   1024,     32,    512
    1.3419,     4.6968,   2048,      8,    512
    3.4380,    18.2644,   4096,      8,    512
```
and after:
```
     Train,      Apply,      N,      K,      B
    0.6724,     0.4315,   1024,      8,    512
    1.1610,     0.8089,   1024,      8,   1024
    2.6693,     1.5454,   1024,      8,   2048
    0.9332,     0.4519,   1024,     16,    512
    1.4455,     0.4929,   1024,     32,    512
    1.3272,     1.3497,   2048,      8,    512
    3.0903,     5.2056,   4096,      8,    512
```

So a bit better than 3x.  CC: @sparadiso @eantono 