### PR TITLE
Hotfix: system blas can be pickier about inversion.

### DIFF
--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -61,7 +61,7 @@ class LinearRegressionLearner(fitIntercept: Boolean = true) extends Learner {
       if (fitIntercept) regVector(-1) = 0.0
       val M = At * A + diag(regVector)
       try {
-        val Mi = inv(M)
+        val Mi = pinv(M)
         /* Backsub to get the coefficients */
         Mi * At * b
       } catch {


### PR DESCRIPTION
The pseudo-inverse is always a safe choice.