### PR TITLE
Fix bug in leaf importance calculation

### DIFF
--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
@@ -31,10 +31,10 @@ class RegressionTrainingLeaf(
   def getFeatureImportance(): scala.collection.mutable.ArraySeq[Double] = {
     importance match {
       case Some(x) =>
-        val expectations: (Double, Double) = trainingData.map{ case (v, l, w) =>
-          (l * w, l * l * w)
-        }.reduce((u: (Double, Double), v: (Double, Double)) => (u._1 + v._1, u._2 + v._2))
-        val impurity = expectations._2 / trainingData.size - Math.pow(expectations._1 / trainingData.size, 2.0)
+        val expectations: (Double, Double, Double) = trainingData.map{ case (v, l, w) =>
+          (l * w, l * l * w, w)
+        }.reduce((u: (Double, Double, Double), v: (Double, Double, Double)) => (u._1 + v._1, u._2 + v._2, u._3 + v._3))
+        val impurity = expectations._2 / expectations._3 - Math.pow(expectations._1 / expectations._3, 2.0)
         mutable.ArraySeq(x: _*).map(_ * impurity)
       case None => mutable.ArraySeq.fill(trainingData.head._1.size)(0.0)
     }

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
@@ -31,9 +31,11 @@ class RegressionTrainingLeaf(
   def getFeatureImportance(): scala.collection.mutable.ArraySeq[Double] = {
     importance match {
       case Some(x) =>
+        // Compute the weighted sum of the label, the square label, and the weights
         val expectations: (Double, Double, Double) = trainingData.map{ case (v, l, w) =>
           (l * w, l * l * w, w)
         }.reduce((u: (Double, Double, Double), v: (Double, Double, Double)) => (u._1 + v._1, u._2 + v._2, u._3 + v._3))
+        // Use those sums to compute the variance as E[x^2] - E[x]^2
         val impurity = expectations._2 / expectations._3 - Math.pow(expectations._1 / expectations._3, 2.0)
         mutable.ArraySeq(x: _*).map(_ * impurity)
       case None => mutable.ArraySeq.fill(trainingData.head._1.size)(0.0)

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -177,7 +177,7 @@ class RegressionTreeTest {
   }
 
   /**
-    * Test with random weights
+    * Test with random weights to ensure all feature importances of stump tree with linear leaves are non-negative
     */
   @Test
   def testWeights(): Unit = {

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -8,6 +8,8 @@ import io.citrine.lolo.stats.functions.Friedman
 import org.junit.Test
 import org.scalatest.Assertions._
 
+import scala.util.Random
+
 /**
   * Created by maxhutch on 11/29/16.
   */
@@ -154,7 +156,7 @@ class RegressionTreeTest {
     * Test a really short tree to make sure the linear model feature importance gets carried through
     */
   @Test
-  def testShortTreeWithLinearLeaf(): Unit = {
+  def testStumpWithLinearLeaf(): Unit = {
     val trainingData = TestUtils.binTrainingData(
       TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman, seed = 3L),
       inputBins = Seq((11, 8))
@@ -173,6 +175,24 @@ class RegressionTreeTest {
     /* They should have roughly the same value (linear regression has some noise in it) */
     assert(Math.abs(importances(0) - 0.30030792928576033) < 1.0e-3)
   }
+
+  /**
+    * Test with random weights
+    */
+  @Test
+  def testWeights(): Unit = {
+    val trainingData = TestUtils.generateTrainingData(32, 12, noise = 100.0, function = Friedman.friedmanSilverman, seed = 3L)
+
+    val linearLearner = new LinearRegressionLearner().setHyper("regParam", 1.0)
+    val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner)).setHyper("maxDepth", 1)
+    val DTMeta = DTLearner.train(trainingData, weights = Some(Seq.fill(trainingData.size){Random.nextInt(8)}))
+    val DT = DTMeta.getModel()
+
+    /* The first feature should be the most important */
+    val importances = DTMeta.getFeatureImportance().get
+    assert(importances.forall(_ >= 0.0), "Found negative feature importance")
+  }
+
 }
 
 /** Companion driver */
@@ -187,6 +207,6 @@ object RegressionTreeTest {
     new RegressionTreeTest().longerTest()
     new RegressionTreeTest().testCategorical()
     new RegressionTreeTest().testLinearLeaves()
-    new RegressionTreeTest().testShortTreeWithLinearLeaf()
+    new RegressionTreeTest().testWeights()
   }
 }


### PR DESCRIPTION
The local variance computation, which is used to weight the importance,
has a weights-related bug that results in negative importance.

CC: @jling11 