### PR TITLE
Moving timings to the theta library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>io.citrine</groupId>
             <artifactId>theta</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.scalanlp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.citrine</groupId>
+            <artifactId>theta</artifactId>
+            <version>0.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_2.11</artifactId> <!-- or 2.11 -->
             <version>0.12</version>


### PR DESCRIPTION
Re-enabling the performance test and re-basing it on the [theta](https://github.com/CitrineInformatics/theta) performance analysis tool.