### PR TITLE
Hotfix: duplicate inputs

### DIFF
--- a/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
@@ -55,8 +55,12 @@ object ClassificationSplitter {
         bestSplit = possibleSplit
       }
     }
-    val deltaImpurity = -bestImpurity
-    (bestSplit, deltaImpurity)
+    if (bestImpurity == Double.MaxValue) {
+      (new NoSplit(), 0.0)
+    } else {
+      val deltaImpurity = -bestImpurity
+      (bestSplit, deltaImpurity)
+    }
   }
 
   /**
@@ -106,7 +110,8 @@ object ClassificationSplitter {
          1) there is only one branch and
          2) it is usually false
        */
-      if (totalPurity > bestPurity && j + 1 >= minCount && thinData(j + 1)._1 > thinData(j)._1 + 1.0e-9) {
+
+      if (totalPurity > bestPurity && j + 1 >= minCount && Math.abs((thinData(j + 1)._1 - thinData(j)._1)/thinData(j)._1) > 1.0e-9) {
         bestPurity = totalPurity
         /* Try pivots at the midpoints between consecutive member values */
         bestPivot = (thinData(j + 1)._1 + thinData(j)._1) / 2.0 // thinData(j)._1 //

--- a/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
@@ -54,8 +54,12 @@ object RegressionSplitter {
         bestSplit = possibleSplit
       }
     }
-    val deltaImpurity = -bestVariance - totalSum * totalSum / totalWeight
-    (bestSplit, deltaImpurity)
+    if (bestVariance == Double.MaxValue) {
+      (new NoSplit(), 0.0)
+    } else {
+      val deltaImpurity = -bestVariance - totalSum * totalSum / totalWeight
+      (bestSplit, deltaImpurity)
+    }
   }
 
   /**
@@ -90,7 +94,7 @@ object RegressionSplitter {
          1) there is only one branch and
          2) it is usually false
        */
-      if (totalVariance < bestVariance && j + 1 >= minCount && thinData(j + 1)._1 > thinData(j)._1 + 1.0e-9) {
+      if (totalVariance < bestVariance && j + 1 >= minCount && Math.abs((thinData(j + 1)._1 - thinData(j)._1) / thinData(j)._1) > 1.0e-9) {
         bestVariance = totalVariance
         /* Try pivots at the midpoints between consecutive member values */
         bestPivot = (thinData(j + 1)._1 + thinData(j)._1) / 2.0 // thinData(j)._1 //

--- a/src/test/scala/io/citrine/lolo/PerformanceTest.scala
+++ b/src/test/scala/io/citrine/lolo/PerformanceTest.scala
@@ -43,7 +43,7 @@ class PerformanceTest {
     // val Ns = Seq(8192, 16384, 32768)
     val Ns = Seq(512, 1024, 2048)
     val Ks = Seq(8, 16, 32)
-    val Bs = Seq(512, 1024, 2048)
+    val Bs = Seq(1024, 2048, 4096)
     if (!quiet) println(f"${"Train"}%10s, ${"Apply"}%10s, ${"N"}%6s, ${"K"}%6s, ${"B"}%6s")
     val (bTrain, bApply) = Bs.map(b => timedTest(trainingData, Ns.head, Ks.head, b, quiet)).unzip
     val (kTrain, kApply) = (bTrain.zip(bApply).take(1) ++ Ks.tail.map(k => timedTest(trainingData, Ns.head, k, Bs.head, quiet))).unzip

--- a/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
@@ -43,6 +43,17 @@ class SplitterTest {
     assert(Math.abs(totalVariance - totalVarianceSuperShort) < 1.0e-9, s"${totalVariance} != ${totalVarianceSuperShort}")
   }
 
+  @Test
+  def testLargeDuplicates(): Unit = {
+    val base = Vector(Random.nextDouble() * 1.0e9)
+    val trainingData = Seq.fill(8){
+      (base, Random.nextDouble(), 1.0)
+    }
+
+    val (split, variance) = RegressionSplitter.getBestRealSplit(trainingData, 0.0, 8.0, 0, 1)
+    assert(variance == Double.MaxValue, "didn't expect to find a valid split")
+  }
+
 }
 
 /** Companion driver */
@@ -53,6 +64,6 @@ object SplitterTest {
     * @param argv args
     */
   def main(argv: Array[String]): Unit = {
-    new SplitterTest().testTotalVarianceCalculation()
+    new SplitterTest().testLargeDuplicates()
   }
 }

--- a/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
@@ -45,9 +45,9 @@ class SplitterTest {
 
   @Test
   def testLargeDuplicates(): Unit = {
-    val base = Vector(Random.nextDouble() * 1.0e9)
+    val base: Double = 3.0e9
     val trainingData = Seq.fill(8){
-      (base, Random.nextDouble(), 1.0)
+      (Vector(base + Random.nextDouble()), Random.nextDouble(), 1.0)
     }
 
     val (split, variance) = RegressionSplitter.getBestRealSplit(trainingData, 0.0, 8.0, 0, 1)

--- a/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
@@ -43,6 +43,12 @@ class SplitterTest {
     assert(Math.abs(totalVariance - totalVarianceSuperShort) < 1.0e-9, s"${totalVariance} != ${totalVarianceSuperShort}")
   }
 
+  /**
+    * Test that large features that are almost the same don't end up being split
+    *
+    * There are numerical issues with the features are distinct but there is no double precision
+    * value in between them to split on.  This results in post-split partitions with zero size
+    */
   @Test
   def testLargeDuplicates(): Unit = {
     val base: Double = 3.0e9


### PR DESCRIPTION
The "is this feature value larger than the last one" logic had an absolute, not relative scale, so large feature values might have been mistakenly labeled as distinct.