### PR TITLE
Making a small adjustment to uncertainty calculations; adding test

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -98,7 +98,7 @@ class Bagger(
       ).map { case ((f, a), (p, u)) =>
         // Math.E is only statistically correct.  It should be actualBags / Nib.transpose(i).count(_ == 0)
         // Or, better yet, filter the bags that don't include the training example
-        val bias = Math.max(Math.E * Math.abs(p.asInstanceOf[Double] - a.asInstanceOf[Double]) - u.asInstanceOf[Double], 0.0)
+        val bias = Math.E * Math.max(Math.abs(p.asInstanceOf[Double] - a.asInstanceOf[Double]) - u.asInstanceOf[Double], 0.0)
         (f, bias)
       }
       Async.canStop()

--- a/src/main/scala/io/citrine/lolo/stats/functions/Friedman.scala
+++ b/src/main/scala/io/citrine/lolo/stats/functions/Friedman.scala
@@ -16,7 +16,8 @@ object Friedman {
     * @return test function(x)
     */
   def friedmanSilverman(x: Seq[Double]): Double = {
-    0.1 * Math.exp(4.0 * x(0)) + 4.0 / (1 + Math.exp(- 20.0 * (x(1) - 0.5))) + 3.0 * x(2) + 2.0 * x(3) + x(4)
+    val x_pad = x.padTo(5, 0.0)
+    0.1 * Math.exp(4.0 * x_pad(0)) + 4.0 / (1 + Math.exp(- 20.0 * (x_pad(1) - 0.5))) + 3.0 * x_pad(2) + 2.0 * x_pad(3) + x_pad(4)
   }
 
   /**
@@ -29,6 +30,7 @@ object Friedman {
     * @return test function(x)
     */
   def friedmanGrosseSilverman(x: Seq[Double]): Double = {
-    10.0 * Math.sin(Math.PI * x(0) * x(1)) + 20.0 * Math.pow(x(2) - 0.5, 2) + 10.0 * x(3) + 5.0 * x(4)
+    val x_pad = x.padTo(5, 0.0)
+    10.0 * Math.sin(Math.PI * x_pad(0) * x_pad(1)) + 20.0 * Math.pow(x_pad(2) - 0.5, 2) + 10.0 * x_pad(3) + 5.0 * x_pad(4)
   }
 }

--- a/src/test/scala/io/citrine/lolo/TestUtils.scala
+++ b/src/test/scala/io/citrine/lolo/TestUtils.scala
@@ -32,12 +32,14 @@ object TestUtils {
                             rows: Int,
                             cols: Int,
                             function: (Seq[Double] => Double) = Friedman.friedmanGrosseSilverman,
+                            xscale: Double = 1.0,
+                            xoff: Double = 0.0,
                             noise: Double = 0.0,
                             seed: Long = 0L
                           ): Vector[(Vector[Double], Double)] = {
     val rnd = new Random(seed)
     Vector.fill(rows){
-      val input = Vector.fill(cols)(rnd.nextDouble())
+      val input = Vector.fill(cols)(xscale * rnd.nextDouble() + xoff)
       (input, function(input) + noise * rnd.nextGaussian())
     }
   }


### PR DESCRIPTION
The change in the bias calculation is minor; it didn't have a large affect but is motivated by the observation that the uncertainty in this PvA calculation is underestimated with the same ratio as the error (due to getting the exact correct answer when the training row is included).

The major addition is a test of uncertainty calibration, which is re-assuring.