### PR TITLE
Hotfixes for multi-task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -128,21 +128,21 @@ class BaggedTrainingResult(
   extends TrainingResult {
   lazy val NibT = Nib.transpose
   lazy val model = new BaggedModel(models, Nib, useJackknife, biasModel)
-  lazy val rep = trainingData.head._2
+  lazy val rep = trainingData.find(_._2 != null).get._2
   lazy val predictedVsActual = trainingData.zip(NibT).flatMap { case ((f, l), nb) =>
     val oob = models.zip(nb).filter(_._2 == 0)
-    if (oob.nonEmpty) {
-      val predicted = rep match {
-        case x: Double => oob.map(_._1.transform(Seq(f)).getExpected().head.asInstanceOf[Double]).sum / oob.size
-        case x: Any => oob.map(_._1.transform(Seq(f)).getExpected().head).groupBy(identity).maxBy(_._2.size)._1
+    if (oob.isEmpty || l == null || (l.isInstanceOf[Double] && l.asInstanceOf[Double].isNaN) ) {
+      Seq()
+    } else {
+      val predicted = l match {
+        case _: Double => oob.map(_._1.transform(Seq(f)).getExpected().head.asInstanceOf[Double]).sum / oob.size
+        case _: Any => oob.map(_._1.transform(Seq(f)).getExpected().head).groupBy(identity).maxBy(_._2.size)._1
       }
       Seq((f, predicted, l))
-    } else {
-      Seq()
     }
   }
 
-  lazy val loss = rep match {
+  lazy val loss: Double = rep match {
     case x: Double => Math.sqrt(predictedVsActual.map(d => Math.pow(d._2.asInstanceOf[Double] - d._3.asInstanceOf[Double], 2)).sum / predictedVsActual.size)
     case x: Any =>
       val f1 = ClassificationMetrics.f1scores(predictedVsActual)

--- a/src/main/scala/io/citrine/lolo/trees/impurity/VarianceCalculator.scala
+++ b/src/main/scala/io/citrine/lolo/trees/impurity/VarianceCalculator.scala
@@ -68,7 +68,7 @@ object VarianceCalculator {
     // be sure to filter out "missing" labels, which are NaN
     val config: (Double, Double, Double) = labels.zip(weights).filterNot(_._1.isNaN()).map { case (l, w) =>
       (w * l, w * l * l, w)
-    }.reduce { (p1: (Double, Double, Double), p2: (Double, Double, Double)) =>
+    }.fold((0.0, 0.0, 0.0)){(p1: (Double, Double, Double), p2: (Double, Double, Double)) =>
       (p1._1 + p2._1, p1._2 + p2._2, p1._3 + p2._3)
     }
     new VarianceCalculator(config._1, config._2, config._3)

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -126,6 +126,8 @@ class MultiTaskBaggerTest {
     val RF = RFMeta.getModel()
 
     val catResults = RF.transform(inputs).getExpected()
+    val realUncertainty = trainingResult.head.getModel().transform(inputs).getUncertainty().get
+    assert(realUncertainty.forall(!_.asInstanceOf[Double].isNaN), s"Some uncertainty values were NaN")
 
     val referenceModel = new Bagger(new ClassificationTreeLearner(), numBags = inputs.size)
       .train(inputs.zip(sparseCat).filterNot(_._2 == null))

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.bags
 
 import io.citrine.lolo.TestUtils
+import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
@@ -120,7 +121,7 @@ class MultiTaskBaggerTest {
     )
 
     val DTLearner = new MultiTaskTreeLearner()
-    val baggedLearner = new MultiTaskBagger(DTLearner, numBags = inputs.size)
+    val baggedLearner = new MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new GuessTheMeanLearner))
     val trainingResult = baggedLearner.train(inputs, Seq(sparseReal, sparseCat))
     val RFMeta = trainingResult.last
     val RF = RFMeta.getModel()

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -128,9 +128,9 @@ class MultiTaskBaggerTest {
     val singleF1 = ClassificationMetrics.f1scores(reference, catLabel)
     val multiF1 = ClassificationMetrics.f1scores(catResults, catLabel)
 
+    // Make sure we can grab the loss without issue
     val singleLoss = referenceModel.getLoss().get
     val multiLoss  = RFMeta.getLoss().get
-    assert(multiLoss <= singleLoss, "Multi-task is underperforming single-task")
 
     assert(multiF1 > singleF1, s"Multi-task is under-performing single-task")
     assert(multiF1 < 1.0)

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -118,14 +118,19 @@ class MultiTaskBaggerTest {
 
     val catResults = RF.transform(inputs).getExpected()
 
-    val reference = new Bagger(new ClassificationTreeLearner(), numBags = inputs.size)
+    val referenceModel = new Bagger(new ClassificationTreeLearner(), numBags = inputs.size)
       .train(inputs.zip(sparseCat).filterNot(_._2 == null))
+    val reference = referenceModel
       .getModel()
       .transform(inputs)
       .getExpected()
 
     val singleF1 = ClassificationMetrics.f1scores(reference, catLabel)
     val multiF1 = ClassificationMetrics.f1scores(catResults, catLabel)
+
+    val singleLoss = referenceModel.getLoss().get
+    val multiLoss  = RFMeta.getLoss().get
+    assert(multiLoss <= singleLoss, "Multi-task is underperforming single-task")
 
     assert(multiF1 > singleF1, s"Multi-task is under-performing single-task")
     assert(multiF1 < 1.0)

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -113,7 +113,7 @@ class MultiTaskBaggerTest {
     )
     val sparseReal = realLabel.map(x =>
       if (Random.nextDouble() > 0.75) {
-        null
+        Double.NaN
       } else {
         x
       }

--- a/src/test/scala/io/citrine/lolo/trees/impurity/GiniCalculatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/impurity/GiniCalculatorTest.scala
@@ -1,0 +1,19 @@
+package io.citrine.lolo.trees.impurity
+
+import org.junit.Test
+
+/**
+  * Created by maxhutch on 12/1/16.
+  */
+@Test
+class GiniCalculatorTest {
+
+  /**
+    * Test that a calculator with no data has a weighted impurity of zero
+    */
+  @Test
+  def testEmpty(): Unit = {
+    val calculator = GiniCalculator.build(Seq())
+    assert(calculator.getImpurity == 0.0)
+  }
+}

--- a/src/test/scala/io/citrine/lolo/trees/impurity/VarianceCalculatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/impurity/VarianceCalculatorTest.scala
@@ -1,0 +1,19 @@
+package io.citrine.lolo.trees.impurity
+
+import org.junit.Test
+
+/**
+  * Created by maxhutch on 12/1/16.
+  */
+@Test
+class VarianceCalculatorTest {
+
+  /**
+    * Test that a calculator with no data has a weighted impurity of zero
+    */
+  @Test
+  def testEmpty(): Unit = {
+    val calculator = VarianceCalculator.build(Seq(), Seq())
+    assert(calculator.getImpurity == 0.0)
+  }
+}


### PR DESCRIPTION
There are a number of bugs:
 - Sparse regression labels are causing the `VarianceCalculator.build` method to fail on reduce on empty lists
 - The `getLoss` on a multi-bagger produced classification task fails on matching null
 - The `biasTraining` generated for sparse regression had NaN where there was a missing label

Fixes:
 - Replace `reduce` with `fold` in `VarianceCalculator.build`
 - Ignore any `null` or `NaN` actual labels in `BaggerTrainingResult.getPredictedVsActual`
 - Ignore any `null` or `NaN` in actual labels when computing `biasTraining`