### PR TITLE
Classification performance improvements

### DIFF
--- a/src/main/scala/io/citrine/lolo/trees/impurity/GiniCalculator.scala
+++ b/src/main/scala/io/citrine/lolo/trees/impurity/GiniCalculator.scala
@@ -82,6 +82,9 @@ object GiniCalculator {
   def build(data: Seq[(Char, Double)]): GiniCalculator = {
     // Be sure to filter out missing labels, which are marked as 0.toChar
     val totalCategoryWeights = data.filter(_._1 > 0).groupBy(_._1).mapValues(_.map(_._2).sum)
+    if (totalCategoryWeights.isEmpty) {
+      return new GiniCalculator(Array.empty[Double], 0.0, 0.0)
+    }
 
     val weightsArray = new Array[Double](totalCategoryWeights.keySet.max + 1)
     val totalSquareSum = totalCategoryWeights.map { case (k, v) =>

--- a/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
@@ -3,14 +3,16 @@ package io.citrine.lolo.trees.splits
 import io.citrine.lolo.TestUtils
 import io.citrine.lolo.encoders.CategoricalEncoder
 import io.citrine.theta.Stopwatch
-import org.junit.Test
 
 
 /**
-  * Created by maxhutch on 12/1/16.
+  * Hold some performance profiling routines
   */
 class ClassificationSplitterTest {
 
+  /**
+    * Evaluate the split finding performance on large and small datasets
+    */
   def testSplitterPerformance(): Unit = {
     val timeLarge = Stopwatch.time({
       ClassificationSplitter.getBestSplit(ClassificationSplitterTest.encodedData, 12, 1)
@@ -18,28 +20,39 @@ class ClassificationSplitterTest {
     println(timeLarge)
 
     val timeSmall = Stopwatch.time({
-      (0 until 256).foreach { i =>
+      (0 until ClassificationSplitterTest.nRow / ClassificationSplitterTest.nSubset).foreach { i =>
         ClassificationSplitter.getBestSplit(ClassificationSplitterTest.subset, 12, 1)
       }
     })
     println(timeSmall)
   }
 
-
 }
 
+/**
+  * Setup the test data
+  */
 object ClassificationSplitterTest {
+  val nRow = 4096
+  val nLabel = 4096
+  val nSubset = 4
+
   val testData = TestUtils.binTrainingData(
-    TestUtils.generateTrainingData(1024, 12),
-    responseBins = Some(256)
+    TestUtils.generateTrainingData(nRow, 12),
+    responseBins = Some(nLabel)
   )
+
   val encoder = CategoricalEncoder.buildEncoder(testData.map(_._2))
   val encodedData = testData.map{case (f, l) =>
     (f.asInstanceOf[Vector[AnyVal]], encoder.encode(l), 1.0)
   }
 
-  val subset = encodedData.take(4)
+  val subset = encodedData.take(nSubset)
 
+  /**
+    * Run the tests
+    * @param args foo
+    */
   def main(args: Array[String]): Unit = {
     new ClassificationSplitterTest().testSplitterPerformance()
   }

--- a/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
@@ -1,0 +1,46 @@
+package io.citrine.lolo.trees.splits
+
+import io.citrine.lolo.TestUtils
+import io.citrine.lolo.encoders.CategoricalEncoder
+import io.citrine.theta.Stopwatch
+import org.junit.Test
+
+
+/**
+  * Created by maxhutch on 12/1/16.
+  */
+class ClassificationSplitterTest {
+
+  def testSplitterPerformance(): Unit = {
+    val timeLarge = Stopwatch.time({
+      ClassificationSplitter.getBestSplit(ClassificationSplitterTest.encodedData, 12, 1)
+    })
+    println(timeLarge)
+
+    val timeSmall = Stopwatch.time({
+      (0 until 256).foreach { i =>
+        ClassificationSplitter.getBestSplit(ClassificationSplitterTest.subset, 12, 1)
+      }
+    })
+    println(timeSmall)
+  }
+
+
+}
+
+object ClassificationSplitterTest {
+  val testData = TestUtils.binTrainingData(
+    TestUtils.generateTrainingData(1024, 12),
+    responseBins = Some(256)
+  )
+  val encoder = CategoricalEncoder.buildEncoder(testData.map(_._2))
+  val encodedData = testData.map{case (f, l) =>
+    (f.asInstanceOf[Vector[AnyVal]], encoder.encode(l), 1.0)
+  }
+
+  val subset = encodedData.take(4)
+
+  def main(args: Array[String]): Unit = {
+    new ClassificationSplitterTest().testSplitterPerformance()
+  }
+}


### PR DESCRIPTION
We noticed that classification was much slower than regression, which was confusing because those classification examples didn't include jackknife or explicit bias.  Profiling the tests here indicated that the issue was in the `GiniCalculator`, which computes the Gini impurity in a streaming way.  That calculation is much more complicated than the `VarianceCalculator`, and was the source of the performance difference.

The remedy is to replace the `Map[Char, Double]` used to store the class weights with `Array[Double]`, which has much better performance.  The array is sized based on the maximum classification label that is in scope.  Because the encoder emits the lowest possible labels, we expect this to be reasonably efficient.  The only significant losses will occur when computing splits near the leaves where the labels could be very sparse, and, even then, performance seems to hold stable.

The encoder supports up to `2^16` labels, so the maximum size of each array is about `2^16 * 8 = 2^19` bytes, or a MiB total between the two arrays.  Not a big deal.

I ran the holistic `testAbsolute` performance test before and after: 33 vs 6, or about 5x speedup.