### PR TITLE
Release: 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lolo
 Lolo is a [random forest](https://en.wikipedia.org/wiki/Lolo_National_Forest)-centered machine learning library in Scala.
 
 The core of Lolo is bagging simple base learners, like decision trees, to imbue robust uncertainty estimates via 
-[jackknife-style variance estimators](http://www.jmlr.org/papers/volume15/wager14a/source/wager14a.pdf) and explicit bias models.
+[jackknife-style variance estimators](http://jmlr.org/papers/volume15/wager14a/wager14a.pdf) and explicit bias models.
 
 Lolo supports:
  * continuous and categorical features

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>0.4.2</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Update from scala 2.11 to 2.12.  This is not a binary compatible change, so bump the major version number.