### PR TITLE
Bugtest/zero variance feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lolo
 Lolo is a [random forest](https://en.wikipedia.org/wiki/Lolo_National_Forest)-centered machine learning library in Scala.
 
 The core of Lolo is bagging simple base learners, like decision trees, to imbue robust uncertainty estimates via 
-[jackknife-style variance estimators](http://www.jmlr.org/papers/volume15/wager14a/source/wager14a.pdf) and explicit bias models.
+[jackknife-style variance estimators](http://jmlr.org/papers/volume15/wager14a/wager14a.pdf) and explicit bias models.
 
 Lolo supports:
  * continuous and categorical features

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -184,8 +184,6 @@ class StandardizerPrediction[T](baseResult: PredictionResult[T], trans: Seq[Opti
       case None => None
       case Some(x) =>
         Some(x.map(g => g.zip(trans.tail).map {
-          // Return 0.0 if trying to undo inverse of 0.0
-          case (0.0, Some((_, Double.PositiveInfinity))) => 0
           // If there was a (linear) transformer used on that input, take the slope "m" and rescale by it
           case (y: Double, Some((_, m))) => y * rescale * m
           // Otherwise, just rescale by the output transformer

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -184,6 +184,8 @@ class StandardizerPrediction[T](baseResult: PredictionResult[T], trans: Seq[Opti
       case None => None
       case Some(x) =>
         Some(x.map(g => g.zip(trans.tail).map {
+          // Return 0.0 if trying to undo inverse of 0.0
+          case (0.0, Some((_, Double.PositiveInfinity))) => 0
           // If there was a (linear) transformer used on that input, take the slope "m" and rescale by it
           case (y: Double, Some((_, m))) => y * rescale * m
           // Otherwise, just rescale by the output transformer


### PR DESCRIPTION
@maxhutch 
Here's a test that fails when a feature with 0 variance is present. My test is the same as the testStandardLinear(), I basically just tested it on an alternative dataset. 
The fix I had proposed previously does not pass the test, so it is not included in this PR. 