### PR TITLE
Bugfix: drop constant features in linear models

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lolo
 Lolo is a [random forest](https://en.wikipedia.org/wiki/Lolo_National_Forest)-centered machine learning library in Scala.
 
 The core of Lolo is bagging simple base learners, like decision trees, to imbue robust uncertainty estimates via 
-[jackknife-style variance estimators](http://www.jmlr.org/papers/volume15/wager14a/source/wager14a.pdf) and explicit bias models.
+[jackknife-style variance estimators](http://jmlr.org/papers/volume15/wager14a/wager14a.pdf) and explicit bias models.
 
 Lolo supports:
  * continuous and categorical features

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -30,6 +30,11 @@ class LinearRegressionLearner(fitIntercept: Boolean = true) extends Learner {
       .filterNot(_._1.asInstanceOf[Double].isNaN)
       .map(_._2)
       .filterNot(i => trainingData.exists(_._1(i).asInstanceOf[Double].isNaN))
+      .filterNot{i =>
+        val unregularized = !hypers.get("regParam").exists(_.asInstanceOf[Double] > 0.0)
+        lazy val constant = trainingData.forall(_._1(i) == trainingData.head._1(i))
+        unregularized && constant // remove constant features if there's no regularization
+      }
 
 
     /* If we are fitting the intercept, add a row of 1s */

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -184,8 +184,6 @@ class StandardizerPrediction[T](baseResult: PredictionResult[T], trans: Seq[Opti
       case None => None
       case Some(x) =>
         Some(x.map(g => g.zip(trans.tail).map {
-          // Return 0.0 if trying to undo inverse of 0.0
-          case (0.0, Some((_, Double.PositiveInfinity))) => 0
           // If there was a (linear) transformer used on that input, take the slope "m" and rescale by it
           case (y: Double, Some((_, m))) => y * rescale * m
           // Otherwise, just rescale by the output transformer

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -184,6 +184,8 @@ class StandardizerPrediction[T](baseResult: PredictionResult[T], trans: Seq[Opti
       case None => None
       case Some(x) =>
         Some(x.map(g => g.zip(trans.tail).map {
+          // Return 0.0 if trying to undo inverse of 0.0
+          case (0.0, Some((_, Double.PositiveInfinity))) => 0
           // If there was a (linear) transformer used on that input, take the slope "m" and rescale by it
           case (y: Double, Some((_, m))) => y * rescale * m
           // Otherwise, just rescale by the output transformer

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -16,12 +16,11 @@ import scala.util.Random
 @Test
 class StandardizerTest {
 
-  val data = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
-  val weights = Vector.fill(data.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
+  val data: Vector[(Vector[Double], Double)] = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+  val weights: Vector[Double] = Vector.fill(data.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
 
   // Creating another dataset which has 1 feature that has 0 variance.
-  val data2 = data.map(d => (1.11 +: d._1, d._2))
-  val weights2 = Vector.fill(data2.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
+  val dataWithConstant: Vector[(Vector[Double], Double)] = data.map(d => (1.11 +: d._1, d._2))
 
   @Test
   def testStandardMeanAndVariance(): Unit = {
@@ -96,28 +95,29 @@ class StandardizerTest {
 
 
   /**
-    * @Author Astha Garg
     * When the variance of a particular feature is 0, the test for expected and gradient fails.
     *
+    * @author Astha Garg
     */
   @Test
-  def testStandardGradient(): Unit = {
+  def testStandardWithConstantFeature(): Unit = {
     val learner = new LinearRegressionLearner()
-    val model = learner.train(data2, Some(weights2)).getModel()
-    val result = model.transform(data2.map(_._1))
+    val model = learner.train(dataWithConstant, Some(weights)).getModel()
+    val result = model.transform(dataWithConstant.map(_._1))
     val expected = result.getExpected()
     val gradient = result.getGradient()
 
     val standardLearner = new Standardizer(learner)
-    val standardModel = standardLearner.train(data2, Some(weights2)).getModel()
-    val standardResult = standardModel.transform(data2.map(_._1))
+    val standardModel = standardLearner.train(dataWithConstant, Some(weights)).getModel()
+    val standardResult = standardModel.transform(dataWithConstant.map(_._1))
     val standardExpected = standardResult.getExpected()
     val standardGradient = standardResult.getGradient()
 
-     expected.zip(standardExpected).foreach { case (free: Double, standard: Double) =>
+    expected.zip(standardExpected).foreach { case (free: Double, standard: Double) =>
       assert(Math.abs(free - standard) < 1.0e-9, s"${free} and ${standard} should be the same")
     }
 
+    // The gradient wrt the first constant feature is ill-defined without regularization
     gradient.get.zip(standardGradient.get).foreach { case (free, standard) =>
       val diff = free.zip(standard).map { case (f, s) => Math.abs(f - s) }.max
       assert(diff < 1.0e-9, s"Gradients should be the same. The diff is $diff")
@@ -191,15 +191,5 @@ class StandardizerTest {
 
     // Assert some things
     assert(Math.abs(baseF1 - standardF1) < 1.0e-6, s"Expected training to be invariant the scale of the labels")
-  }
-}
-
-object StandardizerTest {
-  def main(argv: Array[String]): Unit = {
-    new StandardizerTest().testStandardMeanAndVariance()
-    new StandardizerTest().testStandardGTM()
-    new StandardizerTest().testStandardLinear()
-    new StandardizerTest().testStandardRidge()
-    new StandardizerTest().testStandardClassification()
   }
 }


### PR DESCRIPTION
The unregularized linear regression problem is ill posed if there are constant features.  This change skips constant features if there is no regularization (just like we skip NaN and non-real features).