### PR TITLE
Refactor hyperparameters

### DIFF
--- a/src/main/scala/io/citrine/lolo/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/Learner.scala
@@ -7,6 +7,7 @@ trait Learner extends Serializable {
 
   /**
     * Get the hyperparameter map
+    *
     * @return map of hyperparameters
     */
   def getHypers(): Map[String, Any]

--- a/src/main/scala/io/citrine/lolo/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/Learner.scala
@@ -6,13 +6,6 @@ package io.citrine.lolo
 trait Learner extends Serializable {
 
   /**
-    * Get the hyperparameter map
-    *
-    * @return map of hyperparameters
-    */
-  def getHypers(): Map[String, Any]
-
-  /**
     * Train a model
     *
     * @param trainingData to train on

--- a/src/main/scala/io/citrine/lolo/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/Learner.scala
@@ -6,31 +6,10 @@ package io.citrine.lolo
 trait Learner extends Serializable {
 
   /**
-    * Set block of hyperparameters
-    * @param moreHypers hyperparameters to set
-    * @return this learner
-    */
-  def setHypers(moreHypers: Map[String, Any]): this.type = {
-    hypers = hypers ++ moreHypers
-    this
-  }
-  var hypers: Map[String, Any] = Map()
-
-  /**
-    * Set a single hyperparameter
-    * @param name of the hyperparameter
-    * @param value of the hyperparameter
-    * @return this learner
-    */
-  def setHyper(name: String, value: Any): this.type = {
-    setHypers(Map(name -> value))
-  }
-
-  /**
     * Get the hyperparameter map
     * @return map of hyperparameters
     */
-  def getHypers(): Map[String, Any] = hypers
+  def getHypers(): Map[String, Any]
 
   /**
     * Train a model

--- a/src/main/scala/io/citrine/lolo/Model.scala
+++ b/src/main/scala/io/citrine/lolo/Model.scala
@@ -3,7 +3,6 @@ package io.citrine.lolo
 /**
   * Created by maxhutch on 11/14/16.
   */
-@SerialVersionUID(1000L)
 trait Model[+T <: PredictionResult[Any]] extends Serializable {
 
   /**

--- a/src/main/scala/io/citrine/lolo/MultiTaskLearner.scala
+++ b/src/main/scala/io/citrine/lolo/MultiTaskLearner.scala
@@ -7,6 +7,7 @@ trait MultiTaskLearner extends Serializable {
 
   /**
     * Get the hyperparameter map
+    *
     * @return map of hyperparameters
     */
   def getHypers(): Map[String, Any]
@@ -14,8 +15,8 @@ trait MultiTaskLearner extends Serializable {
   /**
     * Train a model
     *
-    * @param inputs to train on
-    * @param labels sequence of sequences of labels
+    * @param inputs  to train on
+    * @param labels  sequence of sequences of labels
     * @param weights for the training rows, if applicable
     * @return a sequence of training results, one for each label
     */

--- a/src/main/scala/io/citrine/lolo/MultiTaskLearner.scala
+++ b/src/main/scala/io/citrine/lolo/MultiTaskLearner.scala
@@ -6,13 +6,6 @@ package io.citrine.lolo
 trait MultiTaskLearner extends Serializable {
 
   /**
-    * Get the hyperparameter map
-    *
-    * @return map of hyperparameters
-    */
-  def getHypers(): Map[String, Any]
-
-  /**
     * Train a model
     *
     * @param inputs  to train on

--- a/src/main/scala/io/citrine/lolo/MultiTaskLearner.scala
+++ b/src/main/scala/io/citrine/lolo/MultiTaskLearner.scala
@@ -6,31 +6,10 @@ package io.citrine.lolo
 trait MultiTaskLearner extends Serializable {
 
   /**
-    * Set block of hyperparameters
-    * @param moreHypers hyperparameters to set
-    * @return this learner
-    */
-  def setHypers(moreHypers: Map[String, Any]): this.type = {
-    hypers = hypers ++ moreHypers
-    this
-  }
-  var hypers: Map[String, Any] = Map()
-
-  /**
-    * Set a single hyperparameter
-    * @param name of the hyperparameter
-    * @param value of the hyperparameter
-    * @return this learner
-    */
-  def setHyper(name: String, value: Any): this.type = {
-    setHypers(Map(name -> value))
-  }
-
-  /**
     * Get the hyperparameter map
     * @return map of hyperparameters
     */
-  def getHypers(): Map[String, Any] = hypers
+  def getHypers(): Map[String, Any]
 
   /**
     * Train a model

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -30,6 +30,7 @@ trait PredictionResult[+T] {
 
   /**
     * Get the improvement (positive) or damage (negative) due to each training row on a prediction
+    *
     * @param actuals to assess the improvement or damage against
     * @return Sequence (over predictions) of sequence (over training rows) of influence
     */

--- a/src/main/scala/io/citrine/lolo/TrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/TrainingResult.scala
@@ -4,7 +4,7 @@ package io.citrine.lolo
   * Created by maxhutch on 12/4/16.
   */
 @SerialVersionUID(999L)
-abstract trait TrainingResult extends Serializable {
+trait TrainingResult extends Serializable {
 
   /**
     * Get the model contained in the training result
@@ -12,13 +12,6 @@ abstract trait TrainingResult extends Serializable {
     * @return the model
     */
   def getModel(): Model[PredictionResult[Any]]
-
-  /**
-    * Get the hyperparameters used to train this model
-    *
-    * @return hypers set for model
-    */
-  def getHypers(): Map[String, Any]
 
   /**
     * Get a measure of the importance of the model features

--- a/src/main/scala/io/citrine/lolo/TrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/TrainingResult.scala
@@ -3,7 +3,6 @@ package io.citrine.lolo
 /**
   * Created by maxhutch on 12/4/16.
   */
-@SerialVersionUID(999L)
 trait TrainingResult extends Serializable {
 
   /**

--- a/src/main/scala/io/citrine/lolo/TrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/TrainingResult.scala
@@ -8,12 +8,14 @@ abstract trait TrainingResult extends Serializable {
 
   /**
     * Get the model contained in the training result
+    *
     * @return the model
     */
   def getModel(): Model[PredictionResult[Any]]
 
   /**
     * Get the hyperparameters used to train this model
+    *
     * @return hypers set for model
     */
   def getHypers(): Map[String, Any]
@@ -27,12 +29,14 @@ abstract trait TrainingResult extends Serializable {
 
   /**
     * Get a measure of the loss of the model, e.g. RMS OOB error
+    *
     * @return
     */
   def getLoss(): Option[Double] = None
 
   /**
     * Get the predicted vs actual values, e.g. from OOB
+    *
     * @return seq of (feature vector, predicted value, and actual value)
     */
   def getPredictedVsActual(): Option[Seq[(Vector[Any], Any, Any)]] = None

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -19,11 +19,11 @@ import scala.collection.parallel.immutable.ParSeq
   * @param numBags number of models in the ensemble
   */
 case class Bagger(
-              method: Learner,
-              numBags: Int = -1,
-              useJackknife: Boolean = true,
-              biasLearner: Option[Learner] = None
-            ) extends Learner {
+                   method: Learner,
+                   numBags: Int = -1,
+                   useJackknife: Boolean = true,
+                   biasLearner: Option[Learner] = None
+                 ) extends Learner {
 
   override def getHypers(): Map[String, Any] = {
     method.getHypers() ++ Map("useJackknife" -> useJackknife, "numBags" -> numBags)
@@ -79,7 +79,9 @@ case class Bagger(
     }.unzip
 
     // Average the feature importances
-    val averageImportance: Option[Vector[Double]] = importances.reduce{combineImportance}.map(_.map(_ / importances.size))
+    val averageImportance: Option[Vector[Double]] = importances.reduce {
+      combineImportance
+    }.map(_.map(_ / importances.size))
 
     /* Wrap the models in a BaggedModel object */
     if (biasLearner.isEmpty) {
@@ -124,7 +126,7 @@ class BaggedTrainingResult(
   lazy val rep = trainingData.find(_._2 != null).get._2
   lazy val predictedVsActual = trainingData.zip(NibT).flatMap { case ((f, l), nb) =>
     val oob = models.zip(nb).filter(_._2 == 0)
-    if (oob.isEmpty || l == null || (l.isInstanceOf[Double] && l.asInstanceOf[Double].isNaN) ) {
+    if (oob.isEmpty || l == null || (l.isInstanceOf[Double] && l.asInstanceOf[Double].isNaN)) {
       Seq()
     } else {
       val predicted = l match {

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -25,11 +25,6 @@ case class Bagger(
                    biasLearner: Option[Learner] = None
                  ) extends Learner {
 
-  override def getHypers(): Map[String, Any] = {
-    method.getHypers() ++ Map("useJackknife" -> useJackknife, "numBags" -> numBags)
-  }
-
-
   private def combineImportance(v1: Option[Vector[Double]], v2: Option[Vector[Double]]): Option[Vector[Double]] = {
     (v1, v2) match {
       case (None, None) => None
@@ -86,7 +81,7 @@ case class Bagger(
     /* Wrap the models in a BaggedModel object */
     if (biasLearner.isEmpty) {
       Async.canStop()
-      new BaggedTrainingResult(models, getHypers(), averageImportance, Nib, trainingData, useJackknife)
+      new BaggedTrainingResult(models, averageImportance, Nib, trainingData, useJackknife)
     } else {
       Async.canStop()
       val baggedModel = new BaggedModel(models, Nib, useJackknife)
@@ -105,7 +100,7 @@ case class Bagger(
       val biasModel = biasLearner.get.train(biasTraining).getModel()
       Async.canStop()
 
-      new BaggedTrainingResult(models, getHypers(), averageImportance, Nib, trainingData, useJackknife, Some(biasModel))
+      new BaggedTrainingResult(models, averageImportance, Nib, trainingData, useJackknife, Some(biasModel))
     }
   }
 }
@@ -113,7 +108,6 @@ case class Bagger(
 @SerialVersionUID(999L)
 class BaggedTrainingResult(
                             models: ParSeq[Model[PredictionResult[Any]]],
-                            hypers: Map[String, Any],
                             featureImportance: Option[Vector[Double]],
                             Nib: Vector[Vector[Int]],
                             trainingData: Seq[(Vector[Any], Any)],
@@ -156,13 +150,6 @@ class BaggedTrainingResult(
   override def getPredictedVsActual(): Option[Seq[(Vector[Any], Any, Any)]] = Some(predictedVsActual)
 
   override def getLoss(): Option[Double] = Some(loss)
-
-  /**
-    * Get the hyperparameters used to train this model
-    *
-    * @return hypers set for model
-    */
-  override def getHypers(): Map[String, Any] = hypers
 }
 
 /**

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -105,7 +105,6 @@ case class Bagger(
   }
 }
 
-@SerialVersionUID(999L)
 class BaggedTrainingResult(
                             models: ParSeq[Model[PredictionResult[Any]]],
                             featureImportance: Option[Vector[Double]],
@@ -158,7 +157,6 @@ class BaggedTrainingResult(
   * @param models in this bagged model
   * @param Nib    training sample counts
   */
-@SerialVersionUID(1000L)
 class BaggedModel(
                    models: ParSeq[Model[PredictionResult[Any]]],
                    Nib: Vector[Vector[Int]],

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -26,7 +26,7 @@ case class Bagger(
             ) extends Learner {
 
   override def getHypers(): Map[String, Any] = {
-    Map("useJackknife" -> useJackknife, "numBags" -> numBags)
+    method.getHypers() ++ Map("useJackknife" -> useJackknife, "numBags" -> numBags)
   }
 
 

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -20,10 +20,6 @@ case class MultiTaskBagger(
                             biasLearner: Option[Learner] = None
                           ) extends MultiTaskLearner {
 
-  override def getHypers(): Map[String, Any] = {
-    method.getHypers() ++ Map("useJackknife" -> useJackknife, "numBags" -> numBags)
-  }
-
   private def combineImportance(v1: Option[Vector[Double]], v2: Option[Vector[Double]]): Option[Vector[Double]] = {
     (v1, v2) match {
       case (None, None) => None
@@ -84,7 +80,7 @@ case class MultiTaskBagger(
       val trainingData = inputs.zip(labels(k))
       Async.canStop()
       if (biasLearner.isEmpty || !labels(k).head.isInstanceOf[Double]) {
-        new BaggedTrainingResult(m, getHypers(), averageImportance, Nib, inputs.zip(labels(k)), useJackknife)
+        new BaggedTrainingResult(m, averageImportance, Nib, inputs.zip(labels(k)), useJackknife)
       } else {
         Async.canStop()
         val baggedModel = new BaggedModel(m, Nib, useJackknife)
@@ -107,7 +103,7 @@ case class MultiTaskBagger(
         val biasModel = biasLearner.get.train(biasTraining).getModel()
         Async.canStop()
 
-        new BaggedTrainingResult(m, getHypers(), averageImportance, Nib, trainingData, useJackknife, Some(biasModel))
+        new BaggedTrainingResult(m, averageImportance, Nib, trainingData, useJackknife, Some(biasModel))
       }
     }.seq
   }

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -14,11 +14,11 @@ import scala.collection.parallel.immutable.ParSeq
   * @param numBags number of models in the ensemble
   */
 case class MultiTaskBagger(
-                       method: MultiTaskLearner,
-                       numBags: Int = -1,
-                       useJackknife: Boolean = true,
-                       biasLearner: Option[Learner] = None
-                     ) extends MultiTaskLearner {
+                            method: MultiTaskLearner,
+                            numBags: Int = -1,
+                            useJackknife: Boolean = true,
+                            biasLearner: Option[Learner] = None
+                          ) extends MultiTaskLearner {
 
   override def getHypers(): Map[String, Any] = {
     Map("useJackknife" -> useJackknife, "numBags" -> numBags)

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -21,7 +21,7 @@ case class MultiTaskBagger(
                           ) extends MultiTaskLearner {
 
   override def getHypers(): Map[String, Any] = {
-    Map("useJackknife" -> useJackknife, "numBags" -> numBags)
+    method.getHypers() ++ Map("useJackknife" -> useJackknife, "numBags" -> numBags)
   }
 
   private def combineImportance(v1: Option[Vector[Double]], v2: Option[Vector[Double]]): Option[Vector[Double]] = {

--- a/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
@@ -6,10 +6,8 @@ import io.citrine.lolo.Learner
   * Brute force search over the grid of hypers
   *
   * Created by maxhutch on 12/7/16.
-  *
-  * @param base learner to optimize parameters for
   */
-class GridHyperOptimizer(base: Learner) extends HyperOptimizer(base) {
+case class GridHyperOptimizer() extends HyperOptimizer {
 
   /**
     * Search by enumerating every combination of hyper values
@@ -18,7 +16,7 @@ class GridHyperOptimizer(base: Learner) extends HyperOptimizer(base) {
     * @param numIterations ignored, since this is a brute force search
     * @return the best hyper map found in the search space
     */
-  override def optimize(trainingData: Seq[(Vector[Any], Any)], numIterations: Int = 1): (Map[String, Any], Double) = {
+  override def optimize(trainingData: Seq[(Vector[Any], Any)], numIterations: Int = 1, builder: Map[String, Any] => Learner): (Map[String, Any], Double) = {
     var best: Map[String, Any] = Map()
     var loss = Double.MaxValue
     /* Get the size of each dimension for index arithmetic */
@@ -36,7 +34,7 @@ class GridHyperOptimizer(base: Learner) extends HyperOptimizer(base) {
       }
 
       /* Set up a learner with these parameters and compute the loss */
-      val testLearner = base.setHypers(testHypers)
+      val testLearner = builder(testHypers)
       val res = testLearner.train(trainingData)
       if (res.getLoss().isEmpty) {
         throw new IllegalArgumentException("Trying to optimize hyper-paramters for a learner without getLoss")

--- a/src/main/scala/io/citrine/lolo/hypers/HyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/HyperOptimizer.scala
@@ -7,10 +7,8 @@ import io.citrine.lolo.Learner
   *
   * They take a range of hypers as a Map[(String, Seq[Any])] and output the best map and loss
   * Created by maxhutch on 12/8/16.
-  *
-  * @param base learner to optimize parameters for
   */
-abstract class HyperOptimizer(base: Learner) {
+abstract class HyperOptimizer() {
 
   /**
     * Add a 1D hyper range to the space searched by this optimizer
@@ -34,5 +32,5 @@ abstract class HyperOptimizer(base: Learner) {
     * @param numIterations to take before terminating
     * @return the best hyper map found in give iterations and the corresponding loss
     */
-  def optimize(trainingData: Seq[(Vector[Any], Any)], numIterations: Int = 8): (Map[String, Any], Double)
+  def optimize(trainingData: Seq[(Vector[Any], Any)], numIterations: Int = 8, builder: Map[String, Any] => Learner): (Map[String, Any], Double)
 }

--- a/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
@@ -10,10 +10,8 @@ import scala.util.Random
   * This optimizer can be evaluated multiple times and will persist the best results across those
   * calls.
   * Created by maxhutch on 12/7/16.
-  *
-  * @param base learner to optimize parameters for
   */
-class RandomHyperOptimizer(base: Learner) extends HyperOptimizer(base) {
+class RandomHyperOptimizer() extends HyperOptimizer {
 
   /** Keep track of the best hypers outside of the optimize call so it persists across calls */
   var best: Map[String, Any] = Map()
@@ -27,13 +25,13 @@ class RandomHyperOptimizer(base: Learner) extends HyperOptimizer(base) {
     * @param numIterations number of draws to take
     * @return the best hyper map found in give iterations and the corresponding loss
     */
-  override def optimize(trainingData: Seq[(Vector[Any], Any)], numIterations: Int): (Map[String, Any], Double) = {
+  override def optimize(trainingData: Seq[(Vector[Any], Any)], numIterations: Int, builder: Map[String, Any] => Learner): (Map[String, Any], Double) = {
     /* Just draw numIteration times */
     (0 until numIterations).foreach { i =>
       val testHypers = hyperGrids.map { case (n, v) =>
         n -> Random.shuffle(v).head
       }
-      val testLearner = base.setHypers(testHypers)
+      val testLearner = builder(testHypers)
       val res = testLearner.train(trainingData)
       if (res.getLoss().isEmpty) {
         throw new IllegalArgumentException("Trying to optimize hyper-paramters for a learner without getLoss")

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -24,16 +24,6 @@ case class RandomForest(
                          subsetStrategy: Any = "auto"
                        ) extends Learner {
 
-  override def getHypers(): Map[String, Any] = {
-    Map(
-      "numTrees" -> numTrees,
-      "useJackknife" -> useJackknife,
-      "biasLearner" -> biasLearner,
-      "leafLearner" -> leafLearner,
-      "subsetStrategy" -> subsetStrategy
-    )
-  }
-
   /**
     * Train a random forest model
     *

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -17,12 +17,12 @@ import io.citrine.lolo.{Learner, TrainingResult}
   *                       (auto => 1/3 for regression, sqrt for classification)
   */
 case class RandomForest(
-                    numTrees: Int = -1,
-                    useJackknife: Boolean = true,
-                    biasLearner: Option[Learner] = None,
-                    leafLearner: Option[Learner] = None,
-                    subsetStrategy: Any = "auto"
-                  ) extends Learner {
+                         numTrees: Int = -1,
+                         useJackknife: Boolean = true,
+                         biasLearner: Option[Learner] = None,
+                         leafLearner: Option[Learner] = None,
+                         subsetStrategy: Any = "auto"
+                       ) extends Learner {
 
   override def getHypers(): Map[String, Any] = {
     Map(
@@ -61,10 +61,10 @@ case class RandomForest(
           case x: Double =>
             (trainingData.head._1.size * x).toInt
         }
-        val DTLearner = new RegressionTreeLearner(
+        val DTLearner = RegressionTreeLearner(
           leafLearner = leafLearner,
           numFeatures = numFeatures)
-        val bagger = new Bagger(DTLearner,
+        val bagger = Bagger(DTLearner,
           numBags = numTrees,
           useJackknife = useJackknife,
           biasLearner = biasLearner
@@ -85,8 +85,8 @@ case class RandomForest(
           case x: Double =>
             (trainingData.head._1.size * x).toInt
         }
-        val DTLearner = new ClassificationTreeLearner(numFeatures = numFeatures)
-        val bagger = new Bagger(DTLearner,
+        val DTLearner = ClassificationTreeLearner(numFeatures = numFeatures)
+        val bagger = Bagger(DTLearner,
           numBags = numTrees
         )
         bagger.train(trainingData, weights)

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -25,12 +25,10 @@ case class GuessTheMeanLearner() extends Learner {
   }
 }
 
-@SerialVersionUID(999L)
 class GuessTheMeanTrainingResult[T](model: GuessTheMeanModel[T]) extends TrainingResult {
   override def getModel(): Model[GuessTheMeanResult[T]] = model
 }
 
-@SerialVersionUID(1000L)
 class GuessTheMeanModel[T](mean: T) extends Model[GuessTheMeanResult[T]] {
 
   def transform(inputs: Seq[Vector[Any]]): GuessTheMeanResult[T] = {

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -5,7 +5,14 @@ import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 /**
   * Created by maxhutch on 11/15/16.
   */
-class GuessTheMeanLearner extends Learner {
+case class GuessTheMeanLearner() extends Learner {
+
+  /**
+    * Get the hyperparameter map
+    *
+    * @return map of hyperparameters
+    */
+  override def getHypers(): Map[String, Any] = Map()
 
   /**
     * Train a model

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -8,13 +8,6 @@ import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 case class GuessTheMeanLearner() extends Learner {
 
   /**
-    * Get the hyperparameter map
-    *
-    * @return map of hyperparameters
-    */
-  override def getHypers(): Map[String, Any] = Map()
-
-  /**
     * Train a model
     *
     * @param trainingData to train on
@@ -34,13 +27,6 @@ case class GuessTheMeanLearner() extends Learner {
 
 @SerialVersionUID(999L)
 class GuessTheMeanTrainingResult[T](model: GuessTheMeanModel[T]) extends TrainingResult {
-  /**
-    * Get the hyperparameters used to train this model
-    *
-    * @return hypers set for model
-    */
-  override def getHypers(): Map[String, Any] = Map.empty[String, Any]
-
   override def getModel(): Model[GuessTheMeanResult[T]] = model
 }
 

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -103,7 +103,6 @@ case class LinearRegressionLearner(
   *
   * @param model contained
   */
-@SerialVersionUID(998L)
 class LinearRegressionTrainingResult(model: LinearRegressionModel) extends TrainingResult {
 
   override def getModel(): LinearRegressionModel = model
@@ -127,7 +126,6 @@ class LinearRegressionTrainingResult(model: LinearRegressionModel) extends Train
   * @param intercept intercept
   * @param indices   optional indices from which to extract real features
   */
-@SerialVersionUID(1000L)
 class LinearRegressionModel(
                              beta: DenseVector[Double],
                              intercept: Double,

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.linear
 
-import breeze.linalg.{DenseMatrix, DenseVector, diag, inv, norm, pinv, sum, trace}
+import breeze.linalg.{DenseMatrix, DenseVector, diag, pinv, sum}
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 
 /**
@@ -38,7 +38,7 @@ case class LinearRegressionLearner(
       .filterNot(_._1.asInstanceOf[Double].isNaN)
       .map(_._2)
       .filterNot(i => trainingData.exists(_._1(i).asInstanceOf[Double].isNaN))
-      .filterNot{i =>
+      .filterNot { i =>
         val unregularized = !regParam.exists(_.asInstanceOf[Double] > 0.0)
         lazy val constant = trainingData.forall(_._1(i) == trainingData.head._1(i))
         unregularized && constant // remove constant features if there's no regularization
@@ -79,7 +79,7 @@ case class LinearRegressionLearner(
         Mi * At * b
       } catch {
         case x: Throwable =>
-          val mean = if (weightsMatrix.isDefined) sum(b)/weights.get.sum else sum(b) / b.length
+          val mean = if (weightsMatrix.isDefined) sum(b) / weights.get.sum else sum(b) / b.length
           val res = DenseVector.zeros[Double](k)
           res(-1) = mean
           res
@@ -154,7 +154,7 @@ class LinearRegressionModel(
     * @return a predictionresult which includes, at least, the expected outputs
     */
   override def transform(inputs: Seq[Vector[Any]]): LinearRegressionResult = {
-    val filteredInputs = indices.map{case (ind, size) => inputs.map(inp => ind.map(inp(_)))}.getOrElse(inputs).flatten.asInstanceOf[Seq[Double]]
+    val filteredInputs = indices.map { case (ind, size) => inputs.map(inp => ind.map(inp(_))) }.getOrElse(inputs).flatten.asInstanceOf[Seq[Double]]
     val inputMatrix = new DenseMatrix(filteredInputs.size / inputs.size, inputs.size,
       filteredInputs.toArray
     )
@@ -165,6 +165,7 @@ class LinearRegressionModel(
   }
 
   /**
+    *
     * Get the beta from the linear model \beta^T X = y
     * @return beta as a vector of double
     */

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -70,7 +70,7 @@ case class LinearRegressionLearner(
 
     val beta = if (regParam.exists(_ > 0) || n >= k) {
       /* Construct the regularized problem and solve it */
-      val regVector = Math.pow(regParam.get, 2) * DenseVector.ones[Double](k)
+      val regVector = Math.pow(regParam.getOrElse(0.0), 2) * DenseVector.ones[Double](k)
       if (fitIntercept) regVector(-1) = 0.0
       val M = At * A + diag(regVector)
       try {

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -16,13 +16,6 @@ case class LinearRegressionLearner(
                                   ) extends Learner {
 
   /**
-    * Get the hyperparameter map
-    *
-    * @return map of hyperparameters
-    */
-  override def getHypers(): Map[String, Any] = Map("regParam" -> 0.0, "fitIntercept" -> fitIntercept)
-
-  /**
     * Train a linear model via direct inversion.
     *
     * @param trainingData to train on
@@ -101,7 +94,7 @@ case class LinearRegressionLearner(
       new LinearRegressionModel(beta, 0.0, indices = indicesToModel)
     }
 
-    new LinearRegressionTrainingResult(model, getHypers())
+    new LinearRegressionTrainingResult(model)
   }
 }
 
@@ -110,14 +103,8 @@ case class LinearRegressionLearner(
   *
   * @param model contained
   */
-@SerialVersionUID(999L)
-class LinearRegressionTrainingResult(model: LinearRegressionModel, hypers: Map[String, Any]) extends TrainingResult {
-  /**
-    * Get the hyperparameters used to train this model
-    *
-    * @return hypers set for model
-    */
-  override def getHypers(): Map[String, Any] = hypers
+@SerialVersionUID(998L)
+class LinearRegressionTrainingResult(model: LinearRegressionModel) extends TrainingResult {
 
   override def getModel(): LinearRegressionModel = model
 

--- a/src/main/scala/io/citrine/lolo/stats/correlations/DistanceCorrelation.scala
+++ b/src/main/scala/io/citrine/lolo/stats/correlations/DistanceCorrelation.scala
@@ -12,27 +12,29 @@ object DistanceCorrelation {
 
   /**
     * Double centered differnce matrix
-    * @param x sequence to take differences of
+    *
+    * @param x        sequence to take differences of
     * @param distance function
     * @tparam T of the sequence
     * @return a double centered distance matrix
     */
   def doubleCenter[T](x: Seq[T], distance: (T, T) => Double): DenseMatrix[Double] = {
-    val pairDistances: DenseMatrix[Double] = DenseMatrix.tabulate(x.size, x.size){ case (i,j) =>
+    val pairDistances: DenseMatrix[Double] = DenseMatrix.tabulate(x.size, x.size) { case (i, j) =>
       distance(x(i), x(j))
     }
     val grandMean = sum(pairDistances) / (x.size * x.size)
     val colSum: DenseVector[Double] = sum(pairDistances(*, ::))
     val colMean: DenseVector[Double] = colSum :* (1.0 / x.size)
-    DenseMatrix.tabulate(x.size, x.size){ case (i, j) =>
-      pairDistances(i,j) - colMean(i) - colMean(j) + grandMean
+    DenseMatrix.tabulate(x.size, x.size) { case (i, j) =>
+      pairDistances(i, j) - colMean(i) - colMean(j) + grandMean
     }
   }
 
   /**
     * Sample distance covariance
-    * @param x first sequence
-    * @param y second sequence
+    *
+    * @param x        first sequence
+    * @param y        second sequence
     * @param distance distance function
     * @tparam T of the sequences
     * @return the sample distance covariance
@@ -45,8 +47,9 @@ object DistanceCorrelation {
 
   /**
     * Distance correlation function, based on distance covariance
-    * @param x first sequence
-    * @param y second sequence
+    *
+    * @param x        first sequence
+    * @param y        second sequence
     * @param distance function
     * @tparam T of the sequences
     * @return the distance correlation (dCorr)

--- a/src/main/scala/io/citrine/lolo/stats/functions/Friedman.scala
+++ b/src/main/scala/io/citrine/lolo/stats/functions/Friedman.scala
@@ -17,7 +17,7 @@ object Friedman {
     */
   def friedmanSilverman(x: Seq[Double]): Double = {
     val x_pad = x.padTo(5, 0.0)
-    0.1 * Math.exp(4.0 * x_pad(0)) + 4.0 / (1 + Math.exp(- 20.0 * (x_pad(1) - 0.5))) + 3.0 * x_pad(2) + 2.0 * x_pad(3) + x_pad(4)
+    0.1 * Math.exp(4.0 * x_pad(0)) + 4.0 / (1 + Math.exp(-20.0 * (x_pad(1) - 0.5))) + 3.0 * x_pad(2) + 2.0 * x_pad(3) + x_pad(4)
   }
 
   /**
@@ -26,6 +26,7 @@ object Friedman {
     * From:
     * Friedman, Jerome H., Eric Grosse, and Werner Stuetzle. "Multidimensional additive spline approximation."
     * SIAM Journal on Scientific and Statistical Computing 4, no. 2 (1983): 291-301.
+    *
     * @param x input vector of length 5 or more
     * @return test function(x)
     */

--- a/src/main/scala/io/citrine/lolo/stats/metrics/ClassificationMetrics.scala
+++ b/src/main/scala/io/citrine/lolo/stats/metrics/ClassificationMetrics.scala
@@ -14,23 +14,23 @@ object ClassificationMetrics {
     * @return the weighted average f1 score
     */
   def f1scores(predictedVsActual: Seq[(Vector[Any], Any, Any)]): Double = {
-      val labels = predictedVsActual.map(_._3).distinct
-      val index = labels.zipWithIndex.toMap
-      val numLabels = labels.size
-      val confusionMatrix = DenseMatrix.zeros[Int](numLabels, numLabels)
-      predictedVsActual.foreach(p => confusionMatrix(index(p._2), index(p._3)) += 1)
-      val f1scores = labels.indices.map { i =>
-        val actualPositive: Double = sum(confusionMatrix(::, i))
-        val predictedPositive: Double = sum(confusionMatrix(i, ::))
-        val precision = if (predictedPositive > 0) confusionMatrix(i, i) / predictedPositive else 1.0
-        val recall = if (actualPositive > 0) confusionMatrix(i, i) / actualPositive else 1.0
-        if (precision > 0.0 && recall > 0.0) {
-          2.0 * precision * recall / (precision + recall) * actualPositive
-        } else {
-          0.0
-        }
+    val labels = predictedVsActual.map(_._3).distinct
+    val index = labels.zipWithIndex.toMap
+    val numLabels = labels.size
+    val confusionMatrix = DenseMatrix.zeros[Int](numLabels, numLabels)
+    predictedVsActual.foreach(p => confusionMatrix(index(p._2), index(p._3)) += 1)
+    val f1scores = labels.indices.map { i =>
+      val actualPositive: Double = sum(confusionMatrix(::, i))
+      val predictedPositive: Double = sum(confusionMatrix(i, ::))
+      val precision = if (predictedPositive > 0) confusionMatrix(i, i) / predictedPositive else 1.0
+      val recall = if (actualPositive > 0) confusionMatrix(i, i) / actualPositive else 1.0
+      if (precision > 0.0 && recall > 0.0) {
+        2.0 * precision * recall / (precision + recall) * actualPositive
+      } else {
+        0.0
       }
-      f1scores.sum / predictedVsActual.size
+    }
+    f1scores.sum / predictedVsActual.size
   }
 
   def f1scores(predicted: Seq[Any], actual: Seq[Any]): Double = {

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -12,14 +12,7 @@ import io.citrine.lolo._
   */
 class Standardizer(baseLearner: Learner) extends Learner {
 
-  override def setHypers(moreHypers: Map[String, Any]): this.type = {
-    baseLearner.setHypers(moreHypers)
-    super.setHypers(moreHypers)
-  }
-
-  override def getHypers(): Map[String, Any] = {
-    baseLearner.getHypers() ++ hypers
-  }
+  override def getHypers(): Map[String, Any] = baseLearner.getHypers()
 
   /**
     * Create affine transformations for continuous features and labels; pass data through to learner
@@ -46,13 +39,8 @@ class Standardizer(baseLearner: Learner) extends Learner {
 
 class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLearner {
 
-  override def setHypers(moreHypers: Map[String, Any]): this.type = {
-    baseLearner.setHypers(moreHypers)
-    super.setHypers(moreHypers)
-  }
-
   override def getHypers(): Map[String, Any] = {
-    baseLearner.getHypers() ++ hypers
+    baseLearner.getHypers()
   }
 
   /**

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -12,8 +12,6 @@ import io.citrine.lolo._
   */
 case class Standardizer(baseLearner: Learner) extends Learner {
 
-  override def getHypers(): Map[String, Any] = baseLearner.getHypers()
-
   /**
     * Create affine transformations for continuous features and labels; pass data through to learner
     *
@@ -33,15 +31,11 @@ case class Standardizer(baseLearner: Learner) extends Learner {
     val standardTrainingData = Standardizer.applyStandardization(inputs, inputTrans).zip(Standardizer.applyStandardization(labels, outputTrans))
     val baseTrainingResult = baseLearner.train(standardTrainingData, weights)
 
-    new StandardizerTrainingResult(baseTrainingResult, Seq(outputTrans) ++ inputTrans, getHypers())
+    new StandardizerTrainingResult(baseTrainingResult, Seq(outputTrans) ++ inputTrans)
   }
 }
 
 class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLearner {
-
-  override def getHypers(): Map[String, Any] = {
-    baseLearner.getHypers()
-  }
 
   /**
     * Train a model
@@ -68,7 +62,7 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
     val baseTrainingResult = baseLearner.train(standardInputs, standardLabels, weights)
 
     baseTrainingResult.zip(outputTrans).map { case (base, trans) =>
-      new StandardizerTrainingResult(base, Seq(trans) ++ inputTrans, getHypers())
+      new StandardizerTrainingResult(base, Seq(trans) ++ inputTrans)
     }
   }
 }
@@ -78,12 +72,10 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
   *
   * @param baseTrainingResult
   * @param trans
-  * @param hypers
   */
 class StandardizerTrainingResult(
                                   baseTrainingResult: TrainingResult,
-                                  trans: Seq[Option[(Double, Double)]],
-                                  hypers: Map[String, Any]
+                                  trans: Seq[Option[(Double, Double)]]
                                 ) extends TrainingResult {
   /**
     * Get the model contained in the training result
@@ -91,13 +83,6 @@ class StandardizerTrainingResult(
     * @return the model
     */
   override def getModel(): Model[PredictionResult[Any]] = new StandardizerModel(baseTrainingResult.getModel(), trans)
-
-  /**
-    * Get the hyperparameters used to train this model
-    *
-    * @return hypers set for model
-    */
-  override def getHypers(): Map[String, Any] = hypers
 
   override def getFeatureImportance(): Option[Vector[Double]] = baseTrainingResult.getFeatureImportance()
 }

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -10,7 +10,7 @@ import io.citrine.lolo._
   *
   * Created by maxhutch on 2/19/17.
   */
-class Standardizer(baseLearner: Learner) extends Learner {
+case class Standardizer(baseLearner: Learner) extends Learner {
 
   override def getHypers(): Map[String, Any] = baseLearner.getHypers()
 
@@ -53,7 +53,7 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
     */
   override def train(inputs: Seq[Vector[Any]], labels: Seq[Seq[Any]], weights: Option[Seq[Double]]): Seq[TrainingResult] = {
     val inputTrans = Standardizer.getMultiStandardization(inputs)
-    val outputTrans: Seq[Option[(Double, Double)]] = labels.map{ labelSeq =>
+    val outputTrans: Seq[Option[(Double, Double)]] = labels.map { labelSeq =>
       if (labelSeq.head != null && labelSeq.head.isInstanceOf[Double]) {
         Some(Standardizer.getStandardization(labelSeq.asInstanceOf[Seq[Double]].filterNot(_.isNaN())))
       } else {
@@ -61,13 +61,13 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
       }
     }
     val standardInputs = Standardizer.applyStandardization(inputs, inputTrans)
-    val standardLabels = labels.zip(outputTrans).map{ case (labelSeq, trans) =>
-        Standardizer.applyStandardization(labelSeq, trans)
+    val standardLabels = labels.zip(outputTrans).map { case (labelSeq, trans) =>
+      Standardizer.applyStandardization(labelSeq, trans)
     }
 
     val baseTrainingResult = baseLearner.train(standardInputs, standardLabels, weights)
 
-    baseTrainingResult.zip(outputTrans).map{case (base, trans) =>
+    baseTrainingResult.zip(outputTrans).map { case (base, trans) =>
       new StandardizerTrainingResult(base, Seq(trans) ++ inputTrans, getHypers())
     }
   }

--- a/src/main/scala/io/citrine/lolo/trees/Nodes.scala
+++ b/src/main/scala/io/citrine/lolo/trees/Nodes.scala
@@ -45,7 +45,6 @@ trait ModelNode[T <: PredictionResult[Any]] extends Serializable {
   * @param right branch node
   * @tparam T type of the output
   */
-@SerialVersionUID(999L)
 class InternalModelNode[T <: PredictionResult[Any]](
                                                      split: Split,
                                                      left: ModelNode[T],

--- a/src/main/scala/io/citrine/lolo/trees/Nodes.scala
+++ b/src/main/scala/io/citrine/lolo/trees/Nodes.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.trees
 
-import io.citrine.lolo.{Learner, Model, PredictionResult}
 import io.citrine.lolo.trees.splits.Split
+import io.citrine.lolo.{Learner, Model, PredictionResult}
 
 import scala.collection.mutable
 
@@ -72,10 +72,10 @@ class InternalModelNode[T <: PredictionResult[Any]](
   * @param trainingData to train on
   */
 class TrainingLeaf[T](
-                              trainingData: Seq[(Vector[AnyVal], T, Double)],
-                              leafLearner: Learner,
-                              depth: Int
-                            ) extends TrainingNode(
+                       trainingData: Seq[(Vector[AnyVal], T, Double)],
+                       leafLearner: Learner,
+                       depth: Int
+                     ) extends TrainingNode(
   trainingData = trainingData,
   remainingDepth = 0
 ) {

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingNode.scala
@@ -1,8 +1,8 @@
 package io.citrine.lolo.trees.classification
 
-import io.citrine.lolo.{Learner, PredictionResult}
-import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingLeaf, TrainingNode}
 import io.citrine.lolo.trees.splits.{ClassificationSplitter, NoSplit, Split}
+import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingLeaf, TrainingNode}
+import io.citrine.lolo.{Learner, PredictionResult}
 
 /**
   * Created by maxhutch on 1/12/17.

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -21,10 +21,6 @@ case class ClassificationTreeLearner(
 
   @transient private lazy val myLeafLearner: Learner = leafLearner.getOrElse(new GuessTheMeanLearner)
 
-  override def getHypers(): Map[String, Any] = {
-    myLeafLearner.getHypers() ++ Map("maxDepth" -> maxDepth, "minLeafInstances" -> 1, "numFeatures" -> numFeatures)
-  }
-
   /**
     * Train classification tree
     *
@@ -82,7 +78,7 @@ case class ClassificationTreeLearner(
     }
 
     /* Wrap them up in a regression tree */
-    new ClassificationTrainingResult(rootTrainingNode, inputEncoders, outputEncoder, getHypers())
+    new ClassificationTrainingResult(rootTrainingNode, inputEncoders, outputEncoder)
   }
 }
 
@@ -90,8 +86,7 @@ case class ClassificationTreeLearner(
 class ClassificationTrainingResult(
                                     rootTrainingNode: TrainingNode[AnyVal, Char],
                                     inputEncoders: Seq[Option[CategoricalEncoder[Any]]],
-                                    outputEncoder: CategoricalEncoder[Any],
-                                    hypers: Map[String, Any]
+                                    outputEncoder: CategoricalEncoder[Any]
                                   ) extends TrainingResult {
   /* Grab a prediction node.  The partitioning happens here */
   lazy val model = new ClassificationTree(rootTrainingNode.getNode(), inputEncoders, outputEncoder)
@@ -105,13 +100,6 @@ class ClassificationTrainingResult(
       importance.map(_ => 1.0 / importance.size)
     }
   }
-
-  /**
-    * Get the hyperparameters used to train this model
-    *
-    * @return hypers set for model
-    */
-  override def getHypers(): Map[String, Any] = hypers
 
   override def getModel(): ClassificationTree = model
 

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -12,14 +12,14 @@ import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
   *
   * @param numFeatures subset of features to select splits from
   */
-class ClassificationTreeLearner(
-                                 val numFeatures: Int = -1,
-                                 maxDepth: Int = 30,
-                                 minLeafInstances: Int = 1,
-                                 leafLearner: Option[Learner] = None
-                               ) extends Learner {
+case class ClassificationTreeLearner(
+                                      numFeatures: Int = -1,
+                                      maxDepth: Int = 30,
+                                      minLeafInstances: Int = 1,
+                                      leafLearner: Option[Learner] = None
+                                    ) extends Learner {
 
-  val myLeafLearner: Learner = leafLearner.getOrElse(new GuessTheMeanLearner)
+  @transient private lazy val myLeafLearner: Learner = leafLearner.getOrElse(new GuessTheMeanLearner)
 
   override def getHypers(): Map[String, Any] = {
     myLeafLearner.getHypers() ++ Map("maxDepth" -> maxDepth, "minLeafInstances" -> 1, "numFeatures" -> numFeatures)

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -82,7 +82,6 @@ case class ClassificationTreeLearner(
   }
 }
 
-@SerialVersionUID(999L)
 class ClassificationTrainingResult(
                                     rootTrainingNode: TrainingNode[AnyVal, Char],
                                     inputEncoders: Seq[Option[CategoricalEncoder[Any]]],
@@ -114,7 +113,6 @@ class ClassificationTrainingResult(
 /**
   * Classification tree
   */
-@SerialVersionUID(999L)
 class ClassificationTree(
                           rootModelNode: ModelNode[PredictionResult[Char]],
                           inputEncoders: Seq[Option[CategoricalEncoder[Any]]],

--- a/src/main/scala/io/citrine/lolo/trees/impurity/ImpurityCalculator.scala
+++ b/src/main/scala/io/citrine/lolo/trees/impurity/ImpurityCalculator.scala
@@ -2,13 +2,15 @@ package io.citrine.lolo.trees.impurity
 
 /**
   * Interface for an impurity calculator, which computes an impurity metric to drive a splitter
+  *
   * @tparam T
   */
 trait ImpurityCalculator[T] {
 
   /**
     * Add a value to the left partition
-    * @param value to add
+    *
+    * @param value  to add
     * @param weight of the value
     * @return the impurity after adding
     */
@@ -16,7 +18,8 @@ trait ImpurityCalculator[T] {
 
   /**
     * Remove a value from the left partition
-    * @param value to remove
+    *
+    * @param value  to remove
     * @param weight of the value
     * @return the impurity after removing
     */
@@ -29,6 +32,7 @@ trait ImpurityCalculator[T] {
 
   /**
     * Get the impurity at the current state of the calculator
+    *
     * @return impurity
     */
   def getImpurity: Double

--- a/src/main/scala/io/citrine/lolo/trees/impurity/MultiImpurityCalculator.scala
+++ b/src/main/scala/io/citrine/lolo/trees/impurity/MultiImpurityCalculator.scala
@@ -11,13 +11,14 @@ class MultiImpurityCalculator(
 
   /**
     * Add the value to each calculator
-    * @param value to add
+    *
+    * @param value  to add
     * @param weight of the value
     * @return the impurity after adding
     */
   def add(value: Array[AnyVal], weight: Double): Double = {
-    value.zip(calculators).map{case (v, calc) =>
-      if (v.isInstanceOf[Double]){
+    value.zip(calculators).map { case (v, calc) =>
+      if (v.isInstanceOf[Double]) {
         calc.asInstanceOf[ImpurityCalculator[Double]].add(v.asInstanceOf[Double], weight)
       } else if (v.isInstanceOf[Char]) {
         calc.asInstanceOf[ImpurityCalculator[Char]].add(v.asInstanceOf[Char], weight)
@@ -29,13 +30,14 @@ class MultiImpurityCalculator(
 
   /**
     * Remove the value from each calculator
-    * @param value to remove
+    *
+    * @param value  to remove
     * @param weight of the value
     * @return the impurity after removing
     */
   def remove(value: Array[AnyVal], weight: Double): Double = {
-    value.zip(calculators).map{case (v, calc) =>
-      if (v.isInstanceOf[Double]){
+    value.zip(calculators).map { case (v, calc) =>
+      if (v.isInstanceOf[Double]) {
         calc.asInstanceOf[ImpurityCalculator[Double]].remove(v.asInstanceOf[Double], weight)
       } else if (v.isInstanceOf[Char]) {
         calc.asInstanceOf[ImpurityCalculator[Char]].remove(v.asInstanceOf[Char], weight)
@@ -54,6 +56,7 @@ class MultiImpurityCalculator(
 
   /**
     * Get the impurity as the sum of the impurities
+    *
     * @return impurity
     */
   def getImpurity: Double = {
@@ -67,12 +70,13 @@ class MultiImpurityCalculator(
 object MultiImpurityCalculator {
   /**
     * Build the calculators for each index and then wrap them in the MultiImpurityCalculator
-    * @param labels that have Array values
+    *
+    * @param labels  that have Array values
     * @param weights which are assumed to be constant over the labels at each row
     * @return MultiImpurityCalculator that sum the impurity of each label index
     */
   def build(labels: Seq[Array[AnyVal]], weights: Seq[Double]): MultiImpurityCalculator = {
-    val calculators: Seq[ImpurityCalculator[AnyVal]] = labels.transpose.map{labelSeq =>
+    val calculators: Seq[ImpurityCalculator[AnyVal]] = labels.transpose.map { labelSeq =>
       if (labelSeq.head.isInstanceOf[Double]) {
         VarianceCalculator.build(labelSeq.asInstanceOf[Seq[Double]], weights)
           .asInstanceOf[ImpurityCalculator[AnyVal]]

--- a/src/main/scala/io/citrine/lolo/trees/impurity/VarianceCalculator.scala
+++ b/src/main/scala/io/citrine/lolo/trees/impurity/VarianceCalculator.scala
@@ -3,9 +3,10 @@ package io.citrine.lolo.trees.impurity
 /**
   * Calculat the weighted variance, which is \sum w_i * (x_i - \bar{x})^2, where \bar{x} is the weighted mean of x
   *
-  * @param totalSum weighted sum of the labels
+  *
+  * @param totalSum       weighted sum of the labels
   * @param totalSquareSum weighted sum of the squares of the labels
-  * @param totalWeight sum of the weights
+  * @param totalWeight    sum of the weights
   */
 class VarianceCalculator(
                           totalSum: Double,
@@ -60,7 +61,8 @@ class VarianceCalculator(
 object VarianceCalculator {
   /**
     * Build a variance calculator for labels and weights
-    * @param labels to build calculator for
+    *
+    * @param labels  to build calculator for
     * @param weights to build calculator for
     * @return VarianceCalculator for these labels and weights
     */
@@ -68,7 +70,7 @@ object VarianceCalculator {
     // be sure to filter out "missing" labels, which are NaN
     val config: (Double, Double, Double) = labels.zip(weights).filterNot(_._1.isNaN()).map { case (l, w) =>
       (w * l, w * l * l, w)
-    }.fold((0.0, 0.0, 0.0)){(p1: (Double, Double, Double), p2: (Double, Double, Double)) =>
+    }.fold((0.0, 0.0, 0.0)) { (p1: (Double, Double, Double), p2: (Double, Double, Double)) =>
       (p1._1 + p2._1, p1._2 + p2._2, p1._3 + p2._3)
     }
     new VarianceCalculator(config._1, config._2, config._3)

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
@@ -57,7 +57,7 @@ class MultiTaskTrainingNode(inputs: Seq[(Vector[AnyVal], Array[AnyVal], Double)]
       leftChild.get.getNode(index)
     } else if (rightChild.isDefined && right.nonEmpty) {
       rightChild.get.getNode(index)
-    } else{
+    } else {
       // If there are no children or the children don't have valid data for this label, emit a leaf (with GTM)
       if (label.isInstanceOf[Double]) {
         new TrainingLeaf[Double](reducedData.asInstanceOf[Seq[(Vector[AnyVal], Double, Double)]], new GuessTheMeanLearner(), 1).getNode()

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -10,7 +10,7 @@ import io.citrine.lolo.{Model, MultiTaskLearner, PredictionResult, TrainingResul
   * Multi-task tree learner, which produces multiple decision trees with the same split structure
   *
   */
-class MultiTaskTreeLearner extends MultiTaskLearner {
+case class MultiTaskTreeLearner() extends MultiTaskLearner {
 
   override def getHypers(): Map[String, Any] = Map()
 

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -12,6 +12,8 @@ import io.citrine.lolo.{Model, MultiTaskLearner, PredictionResult, TrainingResul
   */
 class MultiTaskTreeLearner extends MultiTaskLearner {
 
+  override def getHypers(): Map[String, Any] = Map()
+
   /**
     * Train a model
     *
@@ -73,7 +75,7 @@ class MultiTaskTreeLearner extends MultiTaskLearner {
     }
 
     // Wrap the models in dead-simple training results and return
-    models.map(new MultiTaskTreeTrainingResult(_, hypers))
+    models.map(new MultiTaskTreeTrainingResult(_, getHypers()))
   }
 }
 

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -12,8 +12,6 @@ import io.citrine.lolo.{Model, MultiTaskLearner, PredictionResult, TrainingResul
   */
 case class MultiTaskTreeLearner() extends MultiTaskLearner {
 
-  override def getHypers(): Map[String, Any] = Map()
-
   /**
     * Train a model
     *
@@ -75,22 +73,15 @@ case class MultiTaskTreeLearner() extends MultiTaskLearner {
     }
 
     // Wrap the models in dead-simple training results and return
-    models.map(new MultiTaskTreeTrainingResult(_, getHypers()))
+    models.map(new MultiTaskTreeTrainingResult(_))
   }
 }
 
-class MultiTaskTreeTrainingResult(model: Model[PredictionResult[Any]], hypers: Map[String, Any]) extends TrainingResult {
+class MultiTaskTreeTrainingResult(model: Model[PredictionResult[Any]]) extends TrainingResult {
   /**
     * Get the model contained in the training result
     *
     * @return the model
     */
   override def getModel(): Model[PredictionResult[Any]] = model
-
-  /**
-    * Get the hyperparameters used to train this model
-    *
-    * @return hypers set for model
-    */
-  override def getHypers(): Map[String, Any] = hypers
 }

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
@@ -26,13 +26,14 @@ class RegressionTrainingLeaf(
 
   /**
     * Pull the leaf model's feature importance and rescale it by the remaining impurity
+    *
     * @return feature importance as a vector
     */
   def getFeatureImportance(): scala.collection.mutable.ArraySeq[Double] = {
     importance match {
       case Some(x) =>
         // Compute the weighted sum of the label, the square label, and the weights
-        val expectations: (Double, Double, Double) = trainingData.map{ case (v, l, w) =>
+        val expectations: (Double, Double, Double) = trainingData.map { case (v, l, w) =>
           (l * w, l * l * w, w)
         }.reduce((u: (Double, Double, Double), v: (Double, Double, Double)) => (u._1 + v._1, u._2 + v._2, u._3 + v._3))
         // Use those sums to compute the variance as E[x^2] - E[x]^2

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.trees.regression
 
 import io.citrine.lolo.trees.splits.{NoSplit, RegressionSplitter, Split}
-import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingLeaf, TrainingNode}
+import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingNode}
 import io.citrine.lolo.{Learner, PredictionResult}
 
 /**
@@ -47,6 +47,7 @@ class RegressionTrainingNode(
     *
     * This routine sums the importance from the children and adds the local
     * improvement to the feature used in this split
+    *
     * @return feature importance as a vector
     */
   override def getFeatureImportance(): scala.collection.mutable.ArraySeq[Double] = {

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -23,11 +23,7 @@ case class RegressionTreeLearner(
                                   leafLearner: Option[Learner] = None
                                 ) extends Learner {
   /** Learner to use for training the leaves */
-  val myLeafLearner = leafLearner.getOrElse(new GuessTheMeanLearner())
-
-  override def getHypers(): Map[String, Any] = {
-    myLeafLearner.getHypers() ++ Map("minLeafInstances" -> minLeafInstances, "maxDepth" -> maxDepth, "numFeatures" -> numFeatures)
-  }
+  @transient private lazy val myLeafLearner = leafLearner.getOrElse(GuessTheMeanLearner())
 
   /**
     * Train the tree by recursively partitioning (splitting) the training data on a single feature
@@ -85,7 +81,7 @@ case class RegressionTreeLearner(
     }
 
     /* Wrap them up in a regression tree */
-    new RegressionTreeTrainingResult(rootTrainingNode, encoders, getHypers())
+    new RegressionTreeTrainingResult(rootTrainingNode, encoders)
   }
 
 }
@@ -93,8 +89,7 @@ case class RegressionTreeLearner(
 @SerialVersionUID(999L)
 class RegressionTreeTrainingResult(
                                     rootTrainingNode: TrainingNode[AnyVal, Double],
-                                    encoders: Seq[Option[CategoricalEncoder[Any]]],
-                                    hypers: Map[String, Any]
+                                    encoders: Seq[Option[CategoricalEncoder[Any]]]
                                   ) extends TrainingResult {
   lazy val model = new RegressionTree(rootTrainingNode.getNode(), encoders)
   lazy val importance = rootTrainingNode.getFeatureImportance()
@@ -107,8 +102,6 @@ class RegressionTreeTrainingResult(
   }
 
   override def getModel(): RegressionTree = model
-
-  override def getHypers(): Map[String, Any] = hypers
 
   /**
     * Return the pre-computed influences

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -3,7 +3,7 @@ package io.citrine.lolo.trees.regression
 import io.citrine.lolo.encoders.CategoricalEncoder
 import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.trees.splits.{NoSplit, RegressionSplitter}
-import io.citrine.lolo.trees.{ModelNode, TrainingLeaf, TrainingNode, TreeMeta}
+import io.citrine.lolo.trees.{ModelNode, TrainingNode, TreeMeta}
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 
 
@@ -17,11 +17,11 @@ import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
   * @param leafLearner learner to train the leaves with
   */
 case class RegressionTreeLearner(
-                             numFeatures: Int = -1,
-                             maxDepth: Int = 30,
-                             minLeafInstances: Int = 1,
-                             leafLearner: Option[Learner] = None
-                           ) extends Learner {
+                                  numFeatures: Int = -1,
+                                  maxDepth: Int = 30,
+                                  minLeafInstances: Int = 1,
+                                  leafLearner: Option[Learner] = None
+                                ) extends Learner {
   /** Learner to use for training the leaves */
   val myLeafLearner = leafLearner.getOrElse(new GuessTheMeanLearner())
 

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -86,7 +86,6 @@ case class RegressionTreeLearner(
 
 }
 
-@SerialVersionUID(999L)
 class RegressionTreeTrainingResult(
                                     rootTrainingNode: TrainingNode[AnyVal, Double],
                                     encoders: Seq[Option[CategoricalEncoder[Any]]]
@@ -117,7 +116,6 @@ class RegressionTreeTrainingResult(
   * @param root     of the tree
   * @param encoders for categorical variables
   */
-@SerialVersionUID(999L)
 class RegressionTree(
                       root: ModelNode[PredictionResult[Double]],
                       encoders: Seq[Option[CategoricalEncoder[Any]]]

--- a/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
@@ -2,7 +2,6 @@ package io.citrine.lolo.trees.splits
 
 import io.citrine.lolo.trees.impurity.GiniCalculator
 
-import scala.collection.mutable
 import scala.util.Random
 
 /**
@@ -84,7 +83,7 @@ object ClassificationSplitter {
          1) there is only one branch and
          2) it is usually false
        */
-      if (totalPurity < bestPurity && j + 1 >= minCount && Math.abs((thinData(j + 1)._1 - thinData(j)._1)/thinData(j)._1) > 1.0e-9) {
+      if (totalPurity < bestPurity && j + 1 >= minCount && Math.abs((thinData(j + 1)._1 - thinData(j)._1) / thinData(j)._1) > 1.0e-9) {
         bestPurity = totalPurity
         /* Try pivots at the midpoints between consecutive member values */
         bestPivot = (thinData(j + 1)._1 + thinData(j)._1) / 2.0 // thinData(j)._1 //

--- a/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
@@ -123,7 +123,7 @@ object MultiTaskSplitter {
     var leftNum = 0
     calculator.reset()
     val pivots = (0 until orderedNames.size).flatMap { j =>
-      thinData.filter(r => orderedNames(j) == r._1).map{r =>
+      thinData.filter(r => orderedNames(j) == r._1).map { r =>
         calculator.add(r._2, r._3)
         leftNum = leftNum + 1
       }

--- a/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
@@ -66,8 +66,8 @@ object RegressionSplitter {
   /**
     * Find the best split on a continuous variable
     *
-    * @param data        to split
-    * @param index       of the feature to split on
+    * @param data  to split
+    * @param index of the feature to split on
     * @return the best split of this feature
     */
   def getBestRealSplit(data: Seq[(Vector[AnyVal], Double, Double)], calculator: VarianceCalculator, index: Int, minCount: Int): (RealSplit, Double) = {
@@ -101,8 +101,8 @@ object RegressionSplitter {
   /**
     * Get find the best categorical splitter.
     *
-    * @param data        to split
-    * @param index       of the feature to split on
+    * @param data  to split
+    * @param index of the feature to split on
     * @return the best split of this feature
     */
   def getBestCategoricalSplit(

--- a/src/test/scala/io/citrine/lolo/PerformanceTest.scala
+++ b/src/test/scala/io/citrine/lolo/PerformanceTest.scala
@@ -5,7 +5,6 @@ import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import io.citrine.theta.Stopwatch
-import org.junit.Test
 
 /**
   * Performance tests
@@ -20,11 +19,12 @@ class PerformanceTest {
 
   /**
     * Time training and application of models
+    *
     * @param trainingData which is used both to train and then later apply the models to
-    * @param n number of training rows to take
-    * @param k number of features to consider per split
-    * @param b number of trees in the forest
-    * @param quiet whether to print messages to the screen
+    * @param n            number of training rows to take
+    * @param k            number of features to consider per split
+    * @param b            number of trees in the forest
+    * @param quiet        whether to print messages to the screen
     * @return the training and application time, in seconds
     */
   def timedTest(trainingData: Seq[(Vector[Any], Any)], n: Int, k: Int, b: Int, quiet: Boolean = true): (Double, Double) = {
@@ -37,10 +37,14 @@ class PerformanceTest {
     }
     val baggedLearner = new Bagger(DTLearner, numBags = b)
 
-    val timeTraining = Stopwatch.time({baggedLearner.train(data).getModel()}, benchmark = "None", minRun = 4, targetError = 0.1, maxRun = 32)
+    val timeTraining = Stopwatch.time({
+      baggedLearner.train(data).getModel()
+    }, benchmark = "None", minRun = 4, targetError = 0.1, maxRun = 32)
     val model = baggedLearner.train(data).getModel()
 
-    val timePredicting = Stopwatch.time({model.transform(inputs).getUncertainty()}, benchmark = "None", minRun = 4, targetError = 0.1, maxRun = 32)
+    val timePredicting = Stopwatch.time({
+      model.transform(inputs).getUncertainty()
+    }, benchmark = "None", minRun = 4, targetError = 0.1, maxRun = 32)
 
     if (!quiet) println(f"${timeTraining}%10.4f, ${timePredicting}%10.4f, ${n}%6d, ${k}%6d, ${b}%6d")
     (timeTraining, timePredicting)
@@ -58,12 +62,12 @@ class PerformanceTest {
     val (kTrain, kApply) = (bTrain.zip(bApply).take(1) ++ Ks.tail.map(k => timedTest(trainingData, Ns.head, k, Bs.head, quiet))).unzip
     val (nTrain, nApply) = (bTrain.zip(bApply).take(1) ++ Ns.tail.map(n => timedTest(trainingData, n, Ks.head, Bs.head, quiet))).unzip
 
-    val bTrainScale = (1 until bTrain.size).map(i => bTrain(i)/bTrain(i-1))
-    val nTrainScale = (1 until nTrain.size).map(i => nTrain(i)/nTrain(i-1))
-    val kTrainScale = (1 until kTrain.size).map(i => kTrain(i)/kTrain(i-1))
-    val bApplyScale = (1 until bApply.size).map(i => bApply(i)/bApply(i-1))
-    val nApplyScale = (1 until nApply.size).map(i => nApply(i)/nApply(i-1))
-    val kApplyScale = (1 until kApply.size).map(i => kApply(i)/kApply(i-1))
+    val bTrainScale = (1 until bTrain.size).map(i => bTrain(i) / bTrain(i - 1))
+    val nTrainScale = (1 until nTrain.size).map(i => nTrain(i) / nTrain(i - 1))
+    val kTrainScale = (1 until kTrain.size).map(i => kTrain(i) / kTrain(i - 1))
+    val bApplyScale = (1 until bApply.size).map(i => bApply(i) / bApply(i - 1))
+    val nApplyScale = (1 until nApply.size).map(i => nApply(i) / nApply(i - 1))
+    val kApplyScale = (1 until kApply.size).map(i => kApply(i) / kApply(i - 1))
 
     assert(bTrainScale.forall(s => s < Math.sqrt(8.0) && s > Math.sqrt(2.0)), bTrainScale)
     assert(kTrainScale.forall(s => s < Math.sqrt(8.0) && s > Math.sqrt(0.5)), kTrainScale)

--- a/src/test/scala/io/citrine/lolo/TestUtils.scala
+++ b/src/test/scala/io/citrine/lolo/TestUtils.scala
@@ -38,7 +38,7 @@ object TestUtils {
                             seed: Long = 0L
                           ): Vector[(Vector[Double], Double)] = {
     val rnd = new Random(seed)
-    Vector.fill(rows){
+    Vector.fill(rows) {
       val input = Vector.fill(cols)(xscale * rnd.nextDouble() + xoff)
       (input, function(input) + noise * rnd.nextGaussian())
     }
@@ -49,10 +49,10 @@ object TestUtils {
                       responseBins: Option[Int] = None
                      ): Seq[(Vector[Any], Any)] = {
     var outputData: Seq[(Vector[Any], Any)] = continuousData
-    inputBins.foreach{ case (index, nBins) =>
-        outputData = outputData.map{ case (input, response) =>
-          (input.updated(index, Math.round(input(index).asInstanceOf[Double] * nBins).toString), response)
-        }
+    inputBins.foreach { case (index, nBins) =>
+      outputData = outputData.map { case (input, response) =>
+        (input.updated(index, Math.round(input(index).asInstanceOf[Double] * nBins).toString), response)
+      }
     }
     responseBins.foreach { nBins =>
       val max = continuousData.map(_._2).max

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -26,8 +26,8 @@ class BaggerTest {
       TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
       inputBins = Seq((0, 8))
     )
-    val DTLearner = new RegressionTreeLearner(numFeatures = 3)
-    val baggedLearner = new Bagger(DTLearner, numBags = trainingData.size)
+    val DTLearner = RegressionTreeLearner(numFeatures = 3)
+    val baggedLearner = Bagger(DTLearner, numBags = trainingData.size)
     val RFMeta = baggedLearner.train(trainingData)
     val RF = RFMeta.getModel()
 
@@ -56,8 +56,8 @@ class BaggerTest {
       TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
       inputBins = Seq((0, 8)), responseBins = Some(8)
     )
-    val DTLearner = new ClassificationTreeLearner()
-    val baggedLearner = new Bagger(DTLearner, numBags = trainingData.size / 2)
+    val DTLearner = ClassificationTreeLearner()
+    val baggedLearner = Bagger(DTLearner, numBags = trainingData.size / 2)
     val RFMeta = baggedLearner.train(trainingData)
     val RF = RFMeta.getModel()
 
@@ -95,13 +95,13 @@ class BaggerTest {
     val nFeatures = 5
     val bagsPerRow = 4 // picked to be large enough that bias correction is small but model isn't too expensive
     val trainingData = TestUtils.generateTrainingData(128, nFeatures, xscale = width, seed = Random.nextLong())
-    val DTLearner = new RegressionTreeLearner(numFeatures = nFeatures)
-    val bias = new RegressionTreeLearner(maxDepth = 4)
-    val baggedLearner = new Bagger(DTLearner, numBags = bagsPerRow * trainingData.size, biasLearner = Some(bias))
+    val DTLearner = RegressionTreeLearner(numFeatures = nFeatures)
+    val bias = RegressionTreeLearner(maxDepth = 4)
+    val baggedLearner = Bagger(DTLearner, numBags = bagsPerRow * trainingData.size, biasLearner = Some(bias))
     val RFMeta = baggedLearner.train(trainingData)
     val RF = RFMeta.getModel()
 
-    val interiorTestSet = TestUtils.generateTrainingData(128, nFeatures, xscale = width/2.0, xoff = width/4.0, seed = Random.nextLong())
+    val interiorTestSet = TestUtils.generateTrainingData(128, nFeatures, xscale = width / 2.0, xoff = width / 4.0, seed = Random.nextLong())
     val fullTestSet = TestUtils.generateTrainingData(128, nFeatures, xscale = width, seed = Random.nextLong())
 
     val interiorStandardRMSE = BaggerTest.getStandardRMSE(interiorTestSet, RF)
@@ -126,8 +126,8 @@ class BaggerTest {
   def testScores(): Unit = {
     val csv = TestUtils.readCsv("double_example.csv")
     val trainingData = csv.map(vec => (vec.init, vec.last.asInstanceOf[Double]))
-    val DTLearner = new RegressionTreeLearner()
-    val baggedLearner = new Bagger(DTLearner, numBags = trainingData.size * 16) // use lots of trees to reduce noise
+    val DTLearner = RegressionTreeLearner()
+    val baggedLearner = Bagger(DTLearner, numBags = trainingData.size * 16) // use lots of trees to reduce noise
     val RF = baggedLearner.train(trainingData).getModel()
 
     /* Call transform on the training data */
@@ -146,8 +146,8 @@ class BaggerTest {
   @Test
   def testInterrupt(): Unit = {
     val trainingData = TestUtils.generateTrainingData(2048, 12, noise = 0.1, function = Friedman.friedmanSilverman)
-    val DTLearner = new RegressionTreeLearner(numFeatures = 3)
-    val baggedLearner = new Bagger(DTLearner, numBags = trainingData.size)
+    val DTLearner = RegressionTreeLearner(numFeatures = 3)
+    val baggedLearner = Bagger(DTLearner, numBags = trainingData.size)
 
     // Create a future to run train
     val tmpPool = Executors.newFixedThreadPool(1)
@@ -209,7 +209,7 @@ object BaggerTest {
         predictions.getUncertainty().get.asInstanceOf[Seq[Double]]
       )
     )
-    val standardError = pva.map{ case (a: Double, (p: Double, u: Double)) =>
+    val standardError = pva.map { case (a: Double, (p: Double, u: Double)) =>
       Math.abs(a - p) / u
     }
     Math.sqrt(standardError.map(Math.pow(_, 2.0)).sum / testSet.size)

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -40,8 +40,6 @@ class BaggerTest {
 
     assert(results.getGradient().isEmpty, "Returned a gradient when there shouldn't be one")
 
-    assert(RFMeta.getHypers().contains("maxDepth"))
-
     /* The first feature should be the most important */
     val importances = RFMeta.getFeatureImportance().get
     assert(importances(1) == importances.max)
@@ -74,8 +72,6 @@ class BaggerTest {
       maxProb > 0.5 && maxProb < 1.0 && Math.abs(classProbabilities.values.sum - 1.0) < 1.0e-6
     })
     assert(results.getGradient().isEmpty, "Returned a gradient when there shouldn't be one")
-
-    assert(RFMeta.getHypers().contains("maxDepth"))
 
     /* The first feature should be the most important */
     val importances = RFMeta.getFeatureImportance().get

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -67,11 +67,13 @@ class MultiTaskBaggerTest {
 
     val uncertainty = results.getUncertainty()
     assert(uncertainty.isDefined)
-    assert(trainingData.map(_._2).zip(uncertainty.get).forall { case (a, probs) =>
+    trainingData.map(_._2).zip(uncertainty.get).foreach { case (a, probs) =>
       val classProbabilities = probs.asInstanceOf[Map[Any, Double]]
       val maxProb = classProbabilities(a)
-      maxProb > 0.5 && maxProb < 1.0 && Math.abs(classProbabilities.values.sum - 1.0) < 1.0e-6
-    })
+      assert(maxProb >= 0.5)
+      assert(maxProb < 1.0)
+      assert(Math.abs(classProbabilities.values.sum - 1.0) < 1.0e-6)
+    }
     assert(results.getGradient().isEmpty, "Returned a gradient when there shouldn't be one")
   }
 

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -29,8 +29,8 @@ class MultiTaskBaggerTest {
     )
     val inputs = trainingData.map(_._1)
     val labels = trainingData.map(_._2)
-    val DTLearner = new MultiTaskTreeLearner()
-    val baggedLearner = new MultiTaskBagger(DTLearner, numBags = trainingData.size)
+    val DTLearner = MultiTaskTreeLearner()
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size)
     val RFMeta = baggedLearner.train(inputs, Seq(labels)).head
     val RF = RFMeta.getModel()
 
@@ -55,8 +55,8 @@ class MultiTaskBaggerTest {
     )
     val inputs = trainingData.map(_._1)
     val labels = trainingData.map(_._2)
-    val DTLearner = new MultiTaskTreeLearner()
-    val baggedLearner = new MultiTaskBagger(DTLearner, numBags = trainingData.size)
+    val DTLearner = MultiTaskTreeLearner()
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size)
     val RFMeta = baggedLearner.train(inputs, Seq(labels)).head
     val RF = RFMeta.getModel()
 
@@ -85,8 +85,8 @@ class MultiTaskBaggerTest {
     val inputs: Seq[Vector[Double]] = raw.map(_._1)
     val realLabel: Seq[Double] = raw.map(_._2)
     val catLabel: Seq[Boolean] = raw.map(_._2 > realLabel.max / 2.0)
-    val DTLearner = new MultiTaskTreeLearner()
-    val baggedLearner = new MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new RegressionTreeLearner(maxDepth = 2)))
+    val DTLearner = MultiTaskTreeLearner()
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new RegressionTreeLearner(maxDepth = 2)))
     val RFMeta = baggedLearner.train(inputs, Seq(realLabel, catLabel)).last
     val RF = RFMeta.getModel()
 
@@ -120,8 +120,8 @@ class MultiTaskBaggerTest {
       }
     )
 
-    val DTLearner = new MultiTaskTreeLearner()
-    val baggedLearner = new MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new GuessTheMeanLearner))
+    val DTLearner = MultiTaskTreeLearner()
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new GuessTheMeanLearner))
     val trainingResult = baggedLearner.train(inputs, Seq(sparseReal, sparseCat))
     val RFMeta = trainingResult.last
     val RF = RFMeta.getModel()
@@ -130,7 +130,7 @@ class MultiTaskBaggerTest {
     val realUncertainty = trainingResult.head.getModel().transform(inputs).getUncertainty().get
     assert(realUncertainty.forall(!_.asInstanceOf[Double].isNaN), s"Some uncertainty values were NaN")
 
-    val referenceModel = new Bagger(new ClassificationTreeLearner(), numBags = inputs.size)
+    val referenceModel = Bagger(ClassificationTreeLearner(), numBags = inputs.size)
       .train(inputs.zip(sparseCat).filterNot(_._2 == null))
     val reference = referenceModel
       .getModel()
@@ -142,7 +142,7 @@ class MultiTaskBaggerTest {
 
     // Make sure we can grab the loss without issue
     val singleLoss = referenceModel.getLoss().get
-    val multiLoss  = RFMeta.getLoss().get
+    val multiLoss = RFMeta.getLoss().get
     val regressionLoss = trainingResult.head.getLoss().get
     assert(!singleLoss.isNaN, "Single task classification loss was NaN")
     assert(!multiLoss.isNaN, "Sparse multitask classification loss was NaN")

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -10,8 +10,8 @@ import org.junit.Test
 @Test
 class RandomForestTest {
 
-    /**
-      * Test that the regression forest does the same thing as the regression bagger
+  /**
+    * Test that the regression forest does the same thing as the regression bagger
     */
   @Test
   def testRegressionForest(): Unit = {
@@ -20,7 +20,7 @@ class RandomForestTest {
       inputBins = Seq((0, 8))
     )
 
-    val RFMeta = new RandomForest()
+    val RFMeta = RandomForest()
       .train(trainingData)
     val RF = RFMeta.getModel()
 
@@ -53,12 +53,12 @@ class RandomForestTest {
 
     /* Inspect the results */
     val results = RF.transform(trainingData.map(_._1))
-    val means       = results.getExpected()
-    assert(trainingData.map(_._2).zip(means).forall{ case (a, p) => a == p})
+    val means = results.getExpected()
+    assert(trainingData.map(_._2).zip(means).forall { case (a, p) => a == p })
 
     val uncertainty = results.getUncertainty()
     assert(uncertainty.isDefined)
-    assert(trainingData.map(_._2).zip(uncertainty.get).forall{ case (a, probs) =>
+    assert(trainingData.map(_._2).zip(uncertainty.get).forall { case (a, probs) =>
       val classProbabilities = probs.asInstanceOf[Map[Any, Double]]
       val maxProb = classProbabilities(a)
       maxProb > 0.5 && maxProb < 1.0 && Math.abs(classProbabilities.values.sum - 1.0) < 1.0e-6

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -21,7 +21,6 @@ class RandomForestTest {
     )
 
     val RFMeta = new RandomForest()
-      .setHyper("numFeatures", 3)
       .train(trainingData)
     val RF = RFMeta.getModel()
 
@@ -48,8 +47,7 @@ class RandomForestTest {
       TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
       inputBins = Seq((0, 8)), responseBins = Some(8)
     )
-    val RFMeta = new RandomForest()
-      .setHyper("numTrees", trainingData.size * 2)
+    val RFMeta = new RandomForest(numTrees = trainingData.size * 2)
       .train(trainingData)
     val RF = RFMeta.getModel()
 

--- a/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
+++ b/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
@@ -30,7 +30,7 @@ class LinearRegressionTest {
       (data.t(::, i).toDenseVector.toArray.toVector, result(i))
     }
 
-    val lr = new LinearRegressionLearner(fitIntercept = false)
+    val lr = LinearRegressionLearner(fitIntercept = false)
     val lrm = lr.train(trainingData)
     val model = lrm.getModel()
     val output = model.transform(trainingData.map(_._1))
@@ -53,7 +53,7 @@ class LinearRegressionTest {
       (data.t(::, i).toDenseVector.toArray.toVector, result(i))
     }
 
-    val lr = new LinearRegressionLearner()
+    val lr = LinearRegressionLearner()
     val lrm = lr.train(trainingData)
     val model = lrm.getModel()
     val output = model.transform(trainingData.map(_._1))
@@ -138,7 +138,7 @@ class LinearRegressionTest {
 
     /* Make sure that feature importance matches the gradient */
     val betaScale = beta.map(Math.abs).sum
-    beta.zip(importance).foreach{case (b, i) =>
+    beta.zip(importance).foreach { case (b, i) =>
       val diff = Math.abs(Math.abs(b / betaScale) - i)
       assert(diff < Double.MinPositiveValue || diff / i < 1.0e-9,
         s"Beta and feature importance disagree: ${b / betaScale} vs ${i}")

--- a/src/test/scala/io/citrine/lolo/stats/correlations/DistanceCorrelationTest.scala
+++ b/src/test/scala/io/citrine/lolo/stats/correlations/DistanceCorrelationTest.scala
@@ -20,7 +20,7 @@ class DistanceCorrelationTest {
     val Y: Seq[Double] = Seq.tabulate(N)(i => Random.nextGaussian())
     val dcorr = DistanceCorrelation.distanceCorrelation(X, Y, dist)
 
-    assert(dcorr < 0.15, s"dCorr for independent vars is ${dcorr}" )
+    assert(dcorr < 0.15, s"dCorr for independent vars is ${dcorr}")
   }
 
 

--- a/src/test/scala/io/citrine/lolo/stats/metrics/ClassificationMetricsTest.scala
+++ b/src/test/scala/io/citrine/lolo/stats/metrics/ClassificationMetricsTest.scala
@@ -16,7 +16,7 @@ class ClassificationMetricsTest {
   def testSparse(): Unit = {
     val N = 512
     /* Make random predictions */
-    val pva = Seq.tabulate(N){i =>
+    val pva = Seq.tabulate(N) { i =>
       (Vector(0.0), Random.nextInt(N).toString, Random.nextInt(N).toString)
     }
     val loss = ClassificationMetrics.f1scores(pva)

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -138,7 +138,7 @@ class StandardizerTest {
     */
   @Test
   def testStandardRidge(): Unit = {
-    val learner = new LinearRegressionLearner().setHyper("regParam", 1.0)
+    val learner = new LinearRegressionLearner(regParam = Some(1.0))
     val model = learner.train(data).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -93,7 +93,6 @@ class StandardizerTest {
     }
   }
 
-
   /**
     * When the variance of a particular feature is 0
     *
@@ -128,10 +127,7 @@ class StandardizerTest {
     expected.zip(standardExpected).foreach { case (free: Double, standard: Double) =>
       assert(Math.abs(free - standard) < 1.0e-9, s"Failed test for expected. ${free} and ${standard} should be the same")
     }
-
-
   }
-
 
   /**
     * Ridge regression should depend on standardization

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -53,11 +53,11 @@ class StandardizerTest {
     */
   @Test
   def testStandardGTM(): Unit = {
-    val learner = new GuessTheMeanLearner
+    val learner = GuessTheMeanLearner()
     val model = learner.train(data).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
-    val standardLearner = new Standardizer(new GuessTheMeanLearner)
+    val standardLearner = Standardizer(GuessTheMeanLearner())
     val standardModel = standardLearner.train(data).getModel()
     val standardResult = standardModel.transform(data.map(_._1)).getExpected()
 
@@ -71,13 +71,13 @@ class StandardizerTest {
     */
   @Test
   def testStandardLinear(): Unit = {
-    val learner = new LinearRegressionLearner()
+    val learner = LinearRegressionLearner()
     val model = learner.train(data, Some(weights)).getModel()
     val result = model.transform(data.map(_._1))
     val expected = result.getExpected()
     val gradient = result.getGradient()
 
-    val standardLearner = new Standardizer(learner)
+    val standardLearner = Standardizer(learner)
     val standardModel = standardLearner.train(data, Some(weights)).getModel()
     val standardResult = standardModel.transform(data.map(_._1))
     val standardExpected = standardResult.getExpected()
@@ -101,13 +101,13 @@ class StandardizerTest {
     */
   @Test
   def testStandardWithConstantFeature(): Unit = {
-    val learner = new LinearRegressionLearner()
+    val learner = LinearRegressionLearner()
     val model = learner.train(dataWithConstant, Some(weights)).getModel()
     val result = model.transform(dataWithConstant.map(_._1))
     val expected = result.getExpected()
     val gradient = result.getGradient()
 
-    val standardLearner = new Standardizer(learner)
+    val standardLearner = Standardizer(learner)
     val standardModel = standardLearner.train(dataWithConstant, Some(weights)).getModel()
     val standardResult = standardModel.transform(dataWithConstant.map(_._1))
     val standardExpected = standardResult.getExpected()
@@ -138,7 +138,7 @@ class StandardizerTest {
     */
   @Test
   def testStandardRidge(): Unit = {
-    val learner = new LinearRegressionLearner(regParam = Some(1.0))
+    val learner = LinearRegressionLearner(regParam = Some(1.0))
     val model = learner.train(data).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
@@ -159,11 +159,11 @@ class StandardizerTest {
       responseBins = Some(2)
     )
 
-    val learner = new ClassificationTreeLearner()
+    val learner = ClassificationTreeLearner()
     val model = learner.train(trainingData).getModel()
     val result = model.transform(trainingData.map(_._1)).getExpected()
 
-    val standardLearner = new Standardizer(learner)
+    val standardLearner = Standardizer(learner)
     val standardModel = standardLearner.train(trainingData).getModel()
     val standardResult = standardModel.transform(trainingData.map(_._1)).getExpected()
     result.zip(standardResult).foreach { case (free: String, standard: String) =>
@@ -188,8 +188,8 @@ class StandardizerTest {
     val rescaledLabel = doubleLabel.map(_ * scale)
 
     // Train and evaluate standard models on original and rescaled labels
-    val standardizer = new MultiTaskStandardizer(new MultiTaskTreeLearner())
-    val baseRes     = standardizer.train(inputs, Seq(doubleLabel,   sparseCatLabel)).last.getModel().transform(inputs).getExpected()
+    val standardizer = new MultiTaskStandardizer(MultiTaskTreeLearner())
+    val baseRes = standardizer.train(inputs, Seq(doubleLabel, sparseCatLabel)).last.getModel().transform(inputs).getExpected()
     val standardRes = standardizer.train(inputs, Seq(rescaledLabel, sparseCatLabel)).last.getModel().transform(inputs).getExpected()
     // Train and evaluate unstandardized model on rescaled labels
 

--- a/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
@@ -41,7 +41,7 @@ class ClassificationTreeTest {
         function = Friedman.friedmanSilverman),
       responseBins = Some(2)
     )
-    val DTLearner = new ClassificationTreeLearner()
+    val DTLearner = ClassificationTreeLearner()
     val DTMeta = DTLearner.train(trainingData)
     val DT = DTMeta.getModel()
 
@@ -69,7 +69,7 @@ class ClassificationTreeTest {
       TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
       responseBins = Some(16)
     )
-    val DTLearner = new ClassificationTreeLearner()
+    val DTLearner = ClassificationTreeLearner()
     val N = 100
     val start = System.nanoTime()
     val DTMeta = DTLearner.train(trainingData)
@@ -107,7 +107,7 @@ class ClassificationTreeTest {
       TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
       inputBins = Seq((0, 8)), responseBins = Some(16)
     )
-    val DTLearner = new ClassificationTreeLearner()
+    val DTLearner = ClassificationTreeLearner()
     val N = 100
     val start = System.nanoTime()
     val DT = DTLearner.train(trainingData).getModel()

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -128,8 +128,8 @@ class RegressionTreeTest {
   def testLinearLeaves(): Unit = {
     val trainingData = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
 
-    val linearLearner = new LinearRegressionLearner().setHyper("regParam", 0.0)
-    val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner)).setHyper("minLeafInstances", 2)
+    val linearLearner = new LinearRegressionLearner(regParam = Some(0.0))
+    val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner), minLeafInstances = 2)
     val DTMeta = DTLearner.train(trainingData)
     val DT = DTMeta.getModel()
 
@@ -162,7 +162,7 @@ class RegressionTreeTest {
       inputBins = Seq((11, 8))
     ).asInstanceOf[Seq[(Vector[Any], Double)]]
 
-    val linearLearner = new LinearRegressionLearner().setHyper("regParam", 1.0)
+    val linearLearner = new LinearRegressionLearner(regParam = Some(1.0))
     val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 0)
     val DTMeta = DTLearner.train(trainingData)
     val DT = DTMeta.getModel()
@@ -191,7 +191,7 @@ class RegressionTreeTest {
   def testWeights(): Unit = {
     val trainingData = TestUtils.generateTrainingData(32, 12, noise = 100.0, function = Friedman.friedmanSilverman, seed = 3L)
 
-    val linearLearner = new LinearRegressionLearner().setHyper("regParam", 1.0)
+    val linearLearner = new LinearRegressionLearner(regParam = Some(1.0))
     val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 1)
     val DTMeta = DTLearner.train(trainingData, weights = Some(Seq.fill(trainingData.size){Random.nextInt(8)}))
     val DT = DTMeta.getModel()

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -26,7 +26,7 @@ class RegressionTreeTest {
       (input, 2.0)
     }
 
-    val DTLearner = new RegressionTreeLearner()
+    val DTLearner = RegressionTreeLearner()
     val DTMeta = DTLearner.train(X)
     val DT = DTMeta.getModel()
     assert(DTMeta.getFeatureImportance()
@@ -40,7 +40,7 @@ class RegressionTreeTest {
   def testSimpleTree(): Unit = {
     val csv = TestUtils.readCsv("double_example.csv")
     val trainingData = csv.map(vec => (vec.init, vec.last.asInstanceOf[Double]))
-    val DTLearner = new RegressionTreeLearner()
+    val DTLearner = RegressionTreeLearner()
     val DT = DTLearner.train(trainingData).getModel()
 
     /* We should be able to memorize the inputs */
@@ -57,8 +57,8 @@ class RegressionTreeTest {
     */
   @Test
   def longerTest(): Unit = {
-    val trainingData =TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
-    val DTLearner = new RegressionTreeLearner()
+    val trainingData = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+    val DTLearner = RegressionTreeLearner()
     val N = 100
     val start = System.nanoTime()
     val DTMeta = DTLearner.train(trainingData)
@@ -95,7 +95,7 @@ class RegressionTreeTest {
       inputBins = Seq((0, 8))
     ).asInstanceOf[Seq[(Vector[Any], Double)]]
 
-    val DTLearner = new RegressionTreeLearner()
+    val DTLearner = RegressionTreeLearner()
     val N = 100
     val start = System.nanoTime()
     val DTMeta = DTLearner.train(trainingData)
@@ -128,8 +128,8 @@ class RegressionTreeTest {
   def testLinearLeaves(): Unit = {
     val trainingData = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
 
-    val linearLearner = new LinearRegressionLearner(regParam = Some(0.0))
-    val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner), minLeafInstances = 2)
+    val linearLearner = LinearRegressionLearner(regParam = Some(0.0))
+    val DTLearner = RegressionTreeLearner(leafLearner = Some(linearLearner), minLeafInstances = 2)
     val DTMeta = DTLearner.train(trainingData)
     val DT = DTMeta.getModel()
 
@@ -162,8 +162,8 @@ class RegressionTreeTest {
       inputBins = Seq((11, 8))
     ).asInstanceOf[Seq[(Vector[Any], Double)]]
 
-    val linearLearner = new LinearRegressionLearner(regParam = Some(1.0))
-    val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 0)
+    val linearLearner = LinearRegressionLearner(regParam = Some(1.0))
+    val DTLearner = RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 0)
     val DTMeta = DTLearner.train(trainingData)
     val DT = DTMeta.getModel()
 
@@ -176,7 +176,7 @@ class RegressionTreeTest {
     /* They should all be non-zero */
     assert(importances.last == 0.0)
 
-    assert(linearImportance.zip(importances).map{case (x, y) => x-y}.forall(d => Math.abs(d) < 1.0e-9),
+    assert(linearImportance.zip(importances).map { case (x, y) => x - y }.forall(d => Math.abs(d) < 1.0e-9),
       s"Expected linear and maxDepth=0 importances to align"
     )
 
@@ -191,9 +191,11 @@ class RegressionTreeTest {
   def testWeights(): Unit = {
     val trainingData = TestUtils.generateTrainingData(32, 12, noise = 100.0, function = Friedman.friedmanSilverman, seed = 3L)
 
-    val linearLearner = new LinearRegressionLearner(regParam = Some(1.0))
-    val DTLearner = new RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 1)
-    val DTMeta = DTLearner.train(trainingData, weights = Some(Seq.fill(trainingData.size){Random.nextInt(8)}))
+    val linearLearner = LinearRegressionLearner(regParam = Some(1.0))
+    val DTLearner = RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 1)
+    val DTMeta = DTLearner.train(trainingData, weights = Some(Seq.fill(trainingData.size) {
+      Random.nextInt(8)
+    }))
     val DT = DTMeta.getModel()
 
     /* The first feature should be the most important */

--- a/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
@@ -45,7 +45,7 @@ object ClassificationSplitterTest {
   )
 
   val encoder = CategoricalEncoder.buildEncoder(testData.map(_._2))
-  val encodedData = testData.map{case (f, l) =>
+  val encodedData = testData.map { case (f, l) =>
     (f.asInstanceOf[Vector[AnyVal]], encoder.encode(l), 1.0)
   }
 
@@ -53,6 +53,7 @@ object ClassificationSplitterTest {
 
   /**
     * Run the tests
+    *
     * @param args foo
     */
   def main(args: Array[String]): Unit = {

--- a/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
@@ -60,7 +60,7 @@ class MultiTaskSplitterTest {
     )
     val labels = Vector(Array(1.238, null), Array(1.180, null))
     val weights = Vector(1.0, 1.0)
-    val data = inputs.indices.map{i =>
+    val data = inputs.indices.map { i =>
       (inputs(i), labels(i).asInstanceOf[Array[AnyVal]], weights(i))
     }
     val (pivot, impurity) = MultiTaskSplitter.getBestSplit(data, data.head._1.size, 1)

--- a/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
@@ -53,7 +53,7 @@ class SplitterTest {
   @Test
   def testLargeDuplicates(): Unit = {
     val base: Double = 3.0e9
-    val trainingData = Seq.fill(8){
+    val trainingData = Seq.fill(8) {
       (Vector(base + Random.nextDouble()), Random.nextDouble(), 1.0)
     }
 


### PR DESCRIPTION
This PR removes the mutable `hypers: Map[String, Any]` map from the Learner to facilitate an immutable pattern. The hyperparameter optimization methods are changed to take a builder function.  

Additionally, most learners have been migrated to case classes.  Hyperparameters can be accessed directly via the public members of the case classes and changed via the case class `copy` method. 

`SerialVersionUID` annotations have also been removed for simplicity.  They didn't solve the model serialization/compatibility issues, and were hard to keep track of.