### PR TITLE
Added uber jar profile to pom.xml with shade plugin conf.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
                         <version>2.4.3</version>
+                        <!-- http://maven.apache.org/plugins/maven-shade-plugin/examples/attached-artifact.html -->
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                        </configuration>
                         <executions>
                             <execution>
                                 <phase>package</phase>


### PR DESCRIPTION
The idea is to generate an uber (fat/shaded/..) jar during packaging and attach it to maven reactor goal so that it is uploaded to central.
Also, minor version bump due to changes.

Generating and deploying the artifacts would work out of the box when profile is activated. (i. e `mvn clean deploy -Plolopy`)