### PR TITLE
Enable lolopy profile on deploy

### DIFF
--- a/cd/before-deploy.sh
+++ b/cd/before-deploy.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
-    openssl aes-256-cbc -K $encrypted_9c3484b2e90f_key -iv $encrypted_9c3484b2e90f_iv -in cd/codesigning.asc.enc -out cd/codesigning.asc -d
-    gpg --fast-import cd/codesigning.asc
-fi

--- a/cd/deploy.sh
+++ b/cd/deploy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
-    mvn deploy -P sign,build-extras --settings cd/mvnsettings.xml
+    openssl aes-256-cbc -K $encrypted_9c3484b2e90f_key -iv $encrypted_9c3484b2e90f_iv -in cd/codesigning.asc.enc -out cd/codesigning.asc -d
+    gpg --fast-import cd/codesigning.asc
+    mvn deploy -P sign,build-extras,lolopy --settings cd/mvnsettings.xml
 fi


### PR DESCRIPTION
This will deploy the jar-with-dependencies next to the normal jar.
It also cleans up the deploy process to use some newer travis
config options.