### PR TITLE
Adding option to randomize pivot location in decision trees

### DIFF
--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -252,7 +252,7 @@ class RandomForestMixin(BaseLoloLearner):
 
     def __init__(self, num_trees=-1, use_jackknife=True, bias_learner=None,
                  leaf_learner=None, subset_strategy="auto", min_leaf_instances=1,
-                 max_depth=2**30, uncertainty_calibration=False):
+                 max_depth=2**30, uncertainty_calibration=False, randomize_pivot_location=False):
         """Initialize the RandomForest
 
         Args:
@@ -267,6 +267,7 @@ class RandomForestMixin(BaseLoloLearner):
             min_leaf_instances (int): Minimum number of features used at each leaf
             max_depth (int): Maximum depth to which to allow the decision trees to grow
             uncertainty_calibration (bool): whether to re-calibrate the predicted uncertainty based on out-of-bag residuals
+            randomize_pivot_location (bool): whether to draw pivots randomly or always select the midpoint
         """
         super(RandomForestMixin, self).__init__()
 
@@ -279,6 +280,7 @@ class RandomForestMixin(BaseLoloLearner):
         self.min_leaf_instances = min_leaf_instances
         self.max_depth = max_depth
         self.uncertainty_calibration = uncertainty_calibration
+        self.randomize_pivot_location = randomize_pivot_location
 
     def _make_learner(self):
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
@@ -293,7 +295,8 @@ class RandomForestMixin(BaseLoloLearner):
             self.subset_strategy,
             self.min_leaf_instances,
             self.max_depth,
-            self.uncertainty_calibration
+            self.uncertainty_calibration,
+            self.randomize_pivot_location
         )
         return learner
 

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -284,6 +284,7 @@ class RandomForestMixin(BaseLoloLearner):
 
     def _make_learner(self):
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
+        #  TODO: that ^^, please
         learner = self.gateway.jvm.io.citrine.lolo.learners.RandomForest(
             self.num_trees, self.use_jackknife,
             getattr(self.gateway.jvm.io.citrine.lolo.learners.RandomForest,
@@ -312,7 +313,8 @@ class RandomForestClassifier(BaseLoloClassifier, RandomForestMixin):
 class RegressionTreeLearner(BaseLoloRegressor):
     """Regression tree learner, based on the RandomTree algorithm."""
 
-    def __init__(self, num_features=-1, max_depth=30, min_leaf_instances=1, leaf_learner=None):
+    def __init__(self, num_features=-1, max_depth=30, min_leaf_instances=1, leaf_learner=None,
+                 randomize_pivot_location=False):
         """Initialize the learner
 
         Args:
@@ -320,19 +322,27 @@ class RegressionTreeLearner(BaseLoloRegressor):
             max_depth (int): Maximum depth of the regression tree
             min_leaf_instances (int): Minimum number instances per leaf
             leaf_learner (BaseLoloLearner): Learner to use on the leaves
+            randomize_pivot_location (bool): whether to draw pivots randomly or always select the midpoint
         """
         super(RegressionTreeLearner, self).__init__()
         self.num_features = num_features
         self.max_depth = max_depth
         self.min_leaf_instances = min_leaf_instances
         self.leaf_learner = leaf_learner
+        self.randomize_pivot_location = randomize_pivot_location
 
     def _make_learner(self):
+        if self.leaf_learner is None:
+            leaf_learner = getattr(
+                self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner,
+                "$lessinit$greater$default$4"
+            )()
+        else:
+            leaf_learner = self.gateway.jvm.scala.Some(self.leaf_learner._make_learner())
         return self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner(
             self.num_features, self.max_depth, self.min_leaf_instances,
-            getattr(self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner,
-                    "$lessinit$greater$default$4")() if self.leaf_learner is None
-            else self.gateway.jvm.scala.Some(self.leaf_learner._make_learner())
+            leaf_learner,
+            self.randomize_pivot_location
         )
 
 class LinearRegression(BaseLoloRegressor):

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -16,6 +16,9 @@ import io.citrine.lolo.{Learner, TrainingResult}
   * @param subsetStrategy for random feature selection at each split
   *                       (auto => 1/3 for regression, sqrt for classification)
   * @param minLeafInstances minimum number of instances per leave in each tree
+  * @param maxDepth       maximum depth of each tree in the forest (default: unlimited)
+  * @param uncertaintyCalibration whether to empirically recalibrate the predicted uncertainties (default: false)
+  * @param randomizePivotLocation whether generate splits randomly between the data points (default: false)
   */
 case class RandomForest(
                          numTrees: Int = -1,
@@ -25,7 +28,8 @@ case class RandomForest(
                          subsetStrategy: Any = "auto",
                          minLeafInstances: Int = 1,
                          maxDepth: Int = Integer.MAX_VALUE,
-                         uncertaintyCalibration: Boolean = false
+                         uncertaintyCalibration: Boolean = false,
+                         randomizePivotLocation: Boolean = false
                        ) extends Learner {
   /**
     * Train a random forest model
@@ -59,7 +63,8 @@ case class RandomForest(
           leafLearner = leafLearner,
           numFeatures = numFeatures,
           minLeafInstances = minLeafInstances,
-          maxDepth = maxDepth
+          maxDepth = maxDepth,
+          randomizePivotLocation = randomizePivotLocation
         )
         val bagger = Bagger(DTLearner,
           numBags = numTrees,
@@ -88,7 +93,8 @@ case class RandomForest(
           leafLearner = leafLearner,
           numFeatures = numFeatures,
           minLeafInstances = minLeafInstances,
-          maxDepth = maxDepth
+          maxDepth = maxDepth,
+          randomizePivotLocation = randomizePivotLocation
         )
         val bagger = Bagger(DTLearner,
           numBags = numTrees

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingNode.scala
@@ -15,7 +15,8 @@ class ClassificationTrainingNode(
                                   numFeatures: Int,
                                   minLeafInstances: Int,
                                   remainingDepth: Int,
-                                  maxDepth: Int
+                                  maxDepth: Int,
+                                  randomizePivotLocation: Boolean = false
                                 ) extends TrainingNode(trainingData, remainingDepth) {
 
   assert(trainingData.size > 1, "If we are going to split, we need at least 2 training rows")
@@ -24,9 +25,9 @@ class ClassificationTrainingNode(
   lazy val (leftTrain, rightTrain) = trainingData.partition(r => split.turnLeft(r._1))
   assert(leftTrain.size > 0 && rightTrain.size > 0, s"Split ${split} resulted in zero size: ${trainingData.map(_._1(split.getIndex()))}")
 
-  lazy val leftChild = ClassificationTrainingNode.buildChild(leftTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures)
+  lazy val leftChild = ClassificationTrainingNode.buildChild(leftTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures, randomizePivotLocation)
 
-  lazy val rightChild = ClassificationTrainingNode.buildChild(rightTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures)
+  lazy val rightChild = ClassificationTrainingNode.buildChild(rightTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures, randomizePivotLocation)
 
 
   /**
@@ -67,12 +68,13 @@ object ClassificationTrainingNode {
                   minLeafInstances: Int,
                   remainingDepth: Int,
                   maxDepth: Int,
-                  numFeatures: Int
+                  numFeatures: Int,
+                  randomizePivotLocation: Boolean = false
                 ): TrainingNode[AnyVal, Char] = {
     if (trainingData.size >= 2 * minLeafInstances && remainingDepth > 0 && trainingData.exists(_._2 != trainingData.head._2)) {
-      val (leftSplit, leftDelta) = ClassificationSplitter.getBestSplit(trainingData, numFeatures, minLeafInstances)
+      val (leftSplit, leftDelta) = ClassificationSplitter.getBestSplit(trainingData, numFeatures, minLeafInstances, randomizePivotLocation)
       if (!leftSplit.isInstanceOf[NoSplit]) {
-        new ClassificationTrainingNode(trainingData, leafLearner, leftSplit, leftDelta, numFeatures, minLeafInstances, remainingDepth - 1, maxDepth)
+        new ClassificationTrainingNode(trainingData, leafLearner, leftSplit, leftDelta, numFeatures, minLeafInstances, remainingDepth - 1, maxDepth, randomizePivotLocation)
       } else {
         new TrainingLeaf(trainingData, leafLearner, maxDepth - remainingDepth)
       }

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -16,7 +16,8 @@ case class ClassificationTreeLearner(
                                       numFeatures: Int = -1,
                                       maxDepth: Int = 30,
                                       minLeafInstances: Int = 1,
-                                      leafLearner: Option[Learner] = None
+                                      leafLearner: Option[Learner] = None,
+                                      randomizePivotLocation: Boolean = false
                                     ) extends Learner {
 
   @transient private lazy val myLeafLearner: Learner = leafLearner.getOrElse(new GuessTheMeanLearner)
@@ -61,7 +62,7 @@ case class ClassificationTreeLearner(
     }
 
     /* The tree is built of training nodes */
-    val (split, delta) = ClassificationSplitter.getBestSplit(finalTraining, numFeaturesActual, minLeafInstances)
+    val (split, delta) = ClassificationSplitter.getBestSplit(finalTraining, numFeaturesActual, minLeafInstances, randomizePivotLocation)
     val rootTrainingNode = if (split.isInstanceOf[NoSplit] || maxDepth == 0) {
       new TrainingLeaf(finalTraining, myLeafLearner, 0)
     } else {
@@ -73,7 +74,8 @@ case class ClassificationTreeLearner(
         numFeaturesActual,
         remainingDepth = maxDepth - 1,
         maxDepth = maxDepth,
-        minLeafInstances = minLeafInstances
+        minLeafInstances = minLeafInstances,
+        randomizePivotLocation = randomizePivotLocation
       )
     }
 

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
@@ -10,17 +10,20 @@ import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingLeaf}
   *
   * @param inputs data on which to select splits and form models
   */
-class MultiTaskTrainingNode(inputs: Seq[(Vector[AnyVal], Array[AnyVal], Double)]) {
+class MultiTaskTrainingNode(
+                             inputs: Seq[(Vector[AnyVal], Array[AnyVal], Double)],
+                             randomizePivotLocation: Boolean = false
+                           ) {
 
   // Compute a split
-  val (split, _) = MultiTaskSplitter.getBestSplit(inputs, inputs.head._1.size, 1)
+  val (split, _) = MultiTaskSplitter.getBestSplit(inputs, inputs.head._1.size, 1, randomizePivotLocation)
 
   // Try to construct left and right children
   val (leftChild: Option[MultiTaskTrainingNode], rightChild: Option[MultiTaskTrainingNode]) = split match {
     case _: NoSplit => (None, None)
     case _: Any =>
       val (leftData, rightData) = inputs.partition(row => split.turnLeft(row._1))
-      (Some(new MultiTaskTrainingNode(leftData)), Some(new MultiTaskTrainingNode(rightData)))
+      (Some(new MultiTaskTrainingNode(leftData, randomizePivotLocation)), Some(new MultiTaskTrainingNode(rightData, randomizePivotLocation)))
   }
 
   // Construct the model node for the `index`th label

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -10,7 +10,9 @@ import io.citrine.lolo.{Model, MultiTaskLearner, PredictionResult, TrainingResul
   * Multi-task tree learner, which produces multiple decision trees with the same split structure
   *
   */
-case class MultiTaskTreeLearner() extends MultiTaskLearner {
+case class MultiTaskTreeLearner(
+                                 randomizePivotLocation: Boolean = false
+                               ) extends MultiTaskLearner {
 
   /**
     * Train a model
@@ -51,7 +53,7 @@ case class MultiTaskTreeLearner() extends MultiTaskLearner {
     }.filter(_._3 > 0.0)
 
     // Construct the training tree
-    val root = new MultiTaskTrainingNode(collectedData)
+    val root = new MultiTaskTrainingNode(collectedData, randomizePivotLocation)
 
     // Construct the model trees
     val nodes = labels.indices.map(root.getNode)

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
@@ -15,7 +15,8 @@ class RegressionTrainingNode(
                               numFeatures: Int,
                               minLeafInstances: Int,
                               remainingDepth: Int,
-                              maxDepth: Int
+                              maxDepth: Int,
+                              randomizePivotLocation: Boolean = false
                             )
   extends TrainingNode(
     trainingData = trainingData,
@@ -29,9 +30,9 @@ class RegressionTrainingNode(
   lazy val (leftTrain, rightTrain) = trainingData.partition(r => split.turnLeft(r._1))
   assert(leftTrain.nonEmpty && rightTrain.nonEmpty, s"Split ${split} resulted in zero size: ${trainingData.map(_._1(split.getIndex()))}")
 
-  lazy val leftChild = RegressionTrainingNode.buildChild(leftTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures)
+  lazy val leftChild = RegressionTrainingNode.buildChild(leftTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures, randomizePivotLocation)
 
-  lazy val rightChild = RegressionTrainingNode.buildChild(rightTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures)
+  lazy val rightChild = RegressionTrainingNode.buildChild(rightTrain, leafLearner, minLeafInstances, remainingDepth, maxDepth, numFeatures, randomizePivotLocation)
 
   /**
     * Get the lightweight prediction node for the output tree
@@ -82,12 +83,13 @@ object RegressionTrainingNode {
                   minLeafInstances: Int,
                   remainingDepth: Int,
                   maxDepth: Int,
-                  numFeatures: Int
+                  numFeatures: Int,
+                  randomizePivotLocation: Boolean = false
                 ): TrainingNode[AnyVal, Double] = {
     if (trainingData.size >= 2 * minLeafInstances && remainingDepth > 0 && trainingData.exists(_._2 != trainingData.head._2)) {
-      val (leftSplit, leftDelta) = RegressionSplitter.getBestSplit(trainingData, numFeatures, minLeafInstances)
+      val (leftSplit, leftDelta) = RegressionSplitter.getBestSplit(trainingData, numFeatures, minLeafInstances, randomizePivotLocation)
       if (!leftSplit.isInstanceOf[NoSplit]) {
-        new RegressionTrainingNode(trainingData, leafLearner, leftSplit, leftDelta, numFeatures, minLeafInstances, remainingDepth - 1, maxDepth)
+        new RegressionTrainingNode(trainingData, leafLearner, leftSplit, leftDelta, numFeatures, minLeafInstances, remainingDepth - 1, maxDepth, randomizePivotLocation)
       } else {
         new RegressionTrainingLeaf(trainingData, leafLearner, maxDepth - remainingDepth)
       }

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -21,7 +21,8 @@ case class RegressionTreeLearner(
                                   numFeatures: Int = -1,
                                   maxDepth: Int = 30,
                                   minLeafInstances: Int = 1,
-                                  leafLearner: Option[Learner] = None
+                                  leafLearner: Option[Learner] = None,
+                                  randomizePivotLocation: Boolean = false
                                 ) extends Learner {
   /** Learner to use for training the leaves */
   @transient private lazy val myLeafLearner = leafLearner.getOrElse(GuessTheMeanLearner())
@@ -66,7 +67,7 @@ case class RegressionTreeLearner(
     }
 
     /* The tree is built of training nodes */
-    val (split, delta) = RegressionSplitter.getBestSplit(finalTraining, numFeaturesActual, minLeafInstances)
+    val (split, delta) = RegressionSplitter.getBestSplit(finalTraining, numFeaturesActual, minLeafInstances, randomizePivotLocation)
     val rootTrainingNode: TrainingNode[AnyVal, Double] = if (split.isInstanceOf[NoSplit] || maxDepth == 0) {
       new RegressionTrainingLeaf(finalTraining, myLeafLearner, 0)
     } else {
@@ -78,7 +79,9 @@ case class RegressionTreeLearner(
         numFeaturesActual,
         minLeafInstances = minLeafInstances,
         remainingDepth = maxDepth - 1,
-        maxDepth)
+        maxDepth,
+        randomizePivotLocation
+      )
     }
 
     /* Wrap them up in a regression tree */

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -65,6 +65,33 @@ class RandomForestTest {
     })
   }
 
+  /**
+    * Randomized splits should do really well on linear signals when there are lots of trees.  Test that they
+    * outperform mid-point splits
+    */
+  @Test
+  def testRandomizedSplitLocations(): Unit = {
+    // Generate a linear signal in one dimension: 2 * x
+    val trainingData: Seq[(Vector[Double], Double)] = TestUtils.generateTrainingData(32, 1, function = {x =>
+      x.head * 2.0
+    })
+
+    // Create a consistent set of parameters
+    val baseForest = RandomForest(numTrees = 16384, useJackknife = false)
+
+    // Turn off split randomization and compute the loss (out-of-bag error)
+    val lossWithoutRandomization: Double = baseForest.copy(randomizePivotLocation = false)
+      .train(trainingData)
+      .getLoss().get
+
+    // Turn on split randomization and compute the loss (out-of-bag error)
+    val lossWithRandomization: Double = baseForest.copy(randomizePivotLocation = true)
+      .train(trainingData)
+      .getLoss().get
+
+    assert(lossWithRandomization < lossWithoutRandomization)
+  }
+
 }
 
 object RandomForestTest {

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -53,6 +53,26 @@ class RegressionTreeTest {
   }
 
   /**
+    * Test a simple tree with only real inputs
+    * Even with randomization, the training data should be memorized
+    */
+  @Test
+  def testrandomizePivotLocation(): Unit = {
+    val csv = TestUtils.readCsv("double_example.csv")
+    val trainingData = csv.map(vec => (vec.init, vec.last.asInstanceOf[Double]))
+    val DTLearner = RegressionTreeLearner(randomizePivotLocation = true)
+    val DT = DTLearner.train(trainingData).getModel()
+
+    /* We should be able to memorize the inputs */
+    val output = DT.transform(trainingData.map(_._1))
+    trainingData.zip(output.getExpected()).foreach { case ((x, a), p) =>
+      assert(Math.abs(a - p) < 1.0e-9)
+    }
+    assert(output.getGradient().isEmpty)
+    output.getDepth().foreach(d => assert(d > 3 && d < 9, s"Depth is ${d}"))
+  }
+
+  /**
     * Test a larger case and time it as a benchmark guideline
     */
   @Test

--- a/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
@@ -40,6 +40,8 @@ object CalibrationStudy {
       generateSweepAtFixedTrainingSize(calibrated = true)
     }
 
+    generatePvaAndHistogram(Friedman.friedmanSilverman, "fs", nTrain = 250, nTree = 64, range = 10, nFeature = 5)
+
   }
 
   def generateSweepAtFixedRatio(
@@ -172,12 +174,12 @@ object CalibrationStudy {
       .map{case (x, y) => (x.drop(ignoreDims), y)}
     val learner = Bagger(
       RegressionTreeLearner(
-        numFeatures = nFeature / 3
+        numFeatures = nFeature
       ),
       numBags = nTree,
       useJackknife = true,
-      uncertaintyCalibration = false,
-      biasLearner = Some(RegressionTreeLearner(maxDepth = (Math.log(nTrain) / Math.log(2) / 2).toInt))
+      uncertaintyCalibration = true,
+      biasLearner = None // Some(RegressionTreeLearner(maxDepth = (Math.log(nTrain) / Math.log(2) / 2).toInt))
     )
 
     val fullStream = StatisticalValidation.generativeValidation[Double](


### PR DESCRIPTION
The pivot is generally chosen to be the midpoint between the two nearest data points
in the split (i.e. the rightmost point in the left partition and the leftmost point in
the right partition).  If randomizePivotLocation is set, then the pivot location is
drawn uniformaly from the line between those two points.  This can improve
modeling performance and uncertainty quantification in ensemble models, e.g.
random forests.