### PR TITLE
Add a failing case between single and multi predict

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -228,6 +228,8 @@ class BaggedMultiResult(
       } else {
         Seq.fill(expected.size)(0.0)
       }
+      println("bias: ", bias)
+      println("variance: ", sigma2)
       sigma2.zip(bias.getOrElse(Seq.fill(expected.size)(0.0))).map(p => Math.sqrt(p._2 * p._2 + p._1)).map(_ * rescale)
     case x: Any =>
       expectedMatrix.map(ps => ps.groupBy(identity).mapValues(_.size.toDouble / ps.size))

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -20,6 +20,7 @@ trait BaggedResult extends PredictionResult[Any] {
     * @return the gradient of each prediction as a vector of doubles
     */
   override def getGradient(): Option[Seq[Vector[Double]]] = gradient
+
   private lazy val gradient = if (predictions.head.getGradient().isEmpty) {
     /* If the underlying model has no gradient, return None */
     None
@@ -42,13 +43,13 @@ trait BaggedResult extends PredictionResult[Any] {
   * @param repInput    representative input
   */
 case class BaggedSingleResult(
-                    predictions: Seq[PredictionResult[Any]],
-                    NibIn: Vector[Vector[Int]],
-                    useJackknife: Boolean,
-                    bias: Option[Double] = None,
-                    repInput: Vector[Any],
-                    rescale: Double = 1.0
-                  ) extends BaggedResult {
+                               predictions: Seq[PredictionResult[Any]],
+                               NibIn: Vector[Vector[Int]],
+                               useJackknife: Boolean,
+                               bias: Option[Double] = None,
+                               repInput: Vector[Any],
+                               rescale: Double = 1.0
+                             ) extends BaggedResult {
   assert(predictions.head.getExpected().head.isInstanceOf[Double])
   private lazy val treePredictions = predictions.map(_.getExpected().head.asInstanceOf[Double]).toArray
 
@@ -58,6 +59,7 @@ case class BaggedSingleResult(
     * @return expected value of each prediction
     */
   override def getExpected(): Seq[Any] = Seq(expected)
+
   private lazy val expected = treePredictions.sum / treePredictions.size
 
   /**
@@ -66,6 +68,7 @@ case class BaggedSingleResult(
     * @return uncertainty of each prediction
     */
   override def getUncertainty(): Option[Seq[Any]] = Some(Seq(scalarUncertainty))
+
   private lazy val scalarUncertainty = if (useJackknife) {
     Math.sqrt(singleScores.sum * Math.pow(rescale, 2.0) + Math.pow(bias.getOrElse(0.0), 2.0))
   } else {
@@ -80,6 +83,7 @@ case class BaggedSingleResult(
     * @return training row scores of each prediction
     */
   override def getImportanceScores(): Option[Seq[Seq[Double]]] = Some(Seq(singleScores))
+
   private lazy val singleScores: Vector[Double] = {
     // Compute the variance of the ensemble of predicted values and divide by the size of the ensemble an extra time
     val varT = 1.0 / (treePredictions.size * treePredictions.size) * treePredictions.map(y => Math.pow(y - expected, 2.0)).sum
@@ -131,7 +135,7 @@ case class BaggedSingleResult(
     // The uncertainty must be positive, so anything smaller than zero is noise.  Make sure that no estimated
     // uncertainty is below that noise level
     val floor = Math.max(0, -minimumContribution)
-    trainingContributions.map{x => Math.max(x, floor)}
+    trainingContributions.map { x => Math.max(x, floor) }
   }
 }
 
@@ -148,13 +152,13 @@ case class BaggedSingleResult(
   * @param repInput    representative input
   */
 class BaggedMultiResult(
-                    override protected val predictions: Seq[PredictionResult[Any]],
-                    NibIn: Vector[Vector[Int]],
-                    useJackknife: Boolean,
-                    bias: Option[Seq[Double]] = None,
-                    repInput: Vector[Any],
-                    rescale: Double = 1.0
-                  ) extends BaggedResult {
+                         override protected val predictions: Seq[PredictionResult[Any]],
+                         NibIn: Vector[Vector[Int]],
+                         useJackknife: Boolean,
+                         bias: Option[Seq[Double]] = None,
+                         repInput: Vector[Any],
+                         rescale: Double = 1.0
+                       ) extends BaggedResult {
 
   /**
     * Return the ensemble average or maximum vote
@@ -220,7 +224,7 @@ class BaggedMultiResult(
     Nib.flatMap { v =>
       val itot = 1.0 / v.size
       val vtot = v.sum.toDouble / (v.size * v.size)
-      v.map(n => (n * itot - vtot))
+      v.map(n => n * itot - vtot)
     }.toArray
   )
 
@@ -232,7 +236,8 @@ class BaggedMultiResult(
       } else {
         Seq.fill(expected.size)(0.0)
       }
-      sigma2.zip(bias.getOrElse(Seq.fill(expected.size)(0.0))).map(p => Math.sqrt(p._2 * p._2 + p._1)).map(_ * rescale)
+      val rescale2 = rescale * rescale
+      sigma2.zip(bias.getOrElse(Seq.fill(expected.size)(0.0))).map { case (variance, b) => Math.sqrt(b * b + variance * rescale2) }
     case x: Any =>
       expectedMatrix.map(ps => ps.groupBy(identity).mapValues(_.size.toDouble / ps.size))
   }
@@ -259,7 +264,7 @@ class BaggedMultiResult(
                 NibJ: DenseMatrix[Double],
                 NibIJ: DenseMatrix[Double]
               ): Seq[Double] = {
-    scores(meanPrediction, modelPredictions, NibJ, NibIJ).map{_.sum}
+    scores(meanPrediction, modelPredictions, NibJ, NibIJ).map(_.sum)
   }
 
   /**
@@ -295,7 +300,7 @@ class BaggedMultiResult(
     /* Avoid division in the loop */
     val inverseSize = 1.0 / modelPredictions.head.size
 
-    (0 until modelPredictions.size).map { i =>
+    modelPredictions.indices.map { i =>
       Async.canStop()
       /* Compute the first order bias correction for the variance estimators */
       val correction = Math.pow(inverseSize * norm(predMat(::, i) - meanPrediction(i)), 2)
@@ -337,7 +342,7 @@ class BaggedMultiResult(
     /* Avoid division in the loop */
     val inverseSize = 1.0 / modelPredictions.head.size
 
-    (0 until modelPredictions.size).map { i =>
+    modelPredictions.indices.map { i =>
       /* Compute the first order bias correction for the variance estimators */
       val correction = inverseSize * norm(predMat(::, i) - meanPrediction(i))
 

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -105,7 +105,7 @@ case class Bagger(
     }
 
     /* Wrap the models in a BaggedModel object */
-    val ratio = if (uncertaintyCalibration && trainingData.head._2.isInstanceOf[Double]) {
+    val ratio = if (uncertaintyCalibration && trainingData.head._2.isInstanceOf[Double] && useJackknife) {
       Async.canStop()
       oobErrors.map{case (_, error, uncertainty) => Math.abs(error / uncertainty)}.sorted.drop((oobErrors.size * 0.68).toInt).head
     } else {
@@ -120,7 +120,7 @@ case class Bagger(
       val biasTraining = oobErrors.map { case (f, e, u) =>
         // Math.E is only statistically correct.  It should be actualBags / Nib.transpose(i).count(_ == 0)
         // Or, better yet, filter the bags that don't include the training example
-        val bias = Math.max(Math.abs(e) - u, 0)
+        val bias = Math.max(Math.abs(e) - u * ratio, 0)
         (f, bias)
       }
       Async.canStop()

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -30,7 +30,6 @@ class BaggedResultTest {
       Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = true, useJackknife = false),
       Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = false)
     ).foreach { bagger =>
-      println(s"testing ${bagger}")
       testConsistency(trainingData, bagger.train(trainingData).getModel())
     }
   }

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.bags
 
 import io.citrine.lolo.TestUtils
+import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import org.junit.Test
@@ -17,13 +18,19 @@ class BaggedResultTest {
       inputBins = Seq((0, 8))
     )
 
-    val DTLearner = RegressionTreeLearner(numFeatures = 3)
+    val DTLearner = RegressionTreeLearner(numFeatures = 12)
 
     Array(
-      Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = false),
-      Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = true, useJackknife = false),
       Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = true),
+      Bagger(DTLearner, numBags = 64, biasLearner = Some(new RegressionTreeLearner(
+        maxDepth = 5,
+        leafLearner = Some(new GuessTheMeanLearner()))
+      ), uncertaintyCalibration = true, useJackknife = false),
+
+      Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = true, useJackknife = false),
+      Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = false)
     ).foreach { bagger =>
+      println(s"testing ${bagger}")
       testConsistency(trainingData, bagger.train(trainingData).getModel())
     }
   }

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -19,15 +19,12 @@ class BaggedResultTest {
     )
 
     val DTLearner = RegressionTreeLearner(numFeatures = 12)
+    val biasLearner = RegressionTreeLearner(maxDepth = 5, leafLearner = Some(GuessTheMeanLearner()))
 
     Array(
       Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = true),
-      Bagger(DTLearner, numBags = 64, biasLearner = Some(new RegressionTreeLearner(
-        maxDepth = 5,
-        leafLearner = Some(new GuessTheMeanLearner()))
-      ), uncertaintyCalibration = true, useJackknife = false),
-
-      Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = true, useJackknife = false),
+      Bagger(DTLearner, numBags = 64, biasLearner = Some(biasLearner), uncertaintyCalibration = true, useJackknife = false),
+      Bagger(DTLearner, numBags = 64, biasLearner = Some(biasLearner), uncertaintyCalibration = true, useJackknife = true),
       Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = false)
     ).foreach { bagger =>
       testConsistency(trainingData, bagger.train(trainingData).getModel())


### PR DESCRIPTION
There appears to be some inconsistency between single and multi-predict when jack-knife = false.