### PR TITLE
Uncertainty recalibration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.3</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -109,7 +109,11 @@ case class Bagger(
     for the training points. If a point has 0 uncertainty, the ratio is 1 if error is also 0, otherwise infinity */
     val ratio = if (uncertaintyCalibration && trainingData.head._2.isInstanceOf[Double] && useJackknife) {
       Async.canStop()
-      oobErrors.map{case (_, error, uncertainty) => Math.abs(error / uncertainty)}.sorted.drop((oobErrors.size * 0.68).toInt).head
+      oobErrors.map {
+        case (_, 0.0, 0.0) => 1.0
+        case (_, _, 0.0) => Double.PositiveInfinity
+        case (_, error, uncertainty) => Math.abs(error / uncertainty)
+      }.sorted.drop((oobErrors.size * 0.68).toInt).head
     } else {
       1.0
     }

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -116,6 +116,7 @@ case class Bagger(
     } else {
       1.0
     }
+    assert(!ratio.isNaN && !ratio.isInfinity, "Uncertainty calibration ratio is not real")
 
     /* Wrap the models in a BaggedModel object */
     if (biasLearner.isEmpty || oobErrors.isEmpty) {

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -107,12 +107,9 @@ case class Bagger(
 
     /* Calculate the uncertainty calibration ratio, which is the 68th percentile of error/uncertainty
     for the training points. If a point has 0 uncertainty, the ratio is 1 if error is also 0, otherwise infinity */
-    val ratio = if (uncertaintyCalibration && trainingData.head._2.isInstanceOf[Double]) {
+    val ratio = if (uncertaintyCalibration && trainingData.head._2.isInstanceOf[Double] && useJackknife) {
       Async.canStop()
-      oobErrors.map{case (_, error, uncertainty) => uncertainty match {
-        case 0 => if (error == 0) 1 else Double.PositiveInfinity
-        case _ => Math.abs(error / uncertainty)}
-      }.sorted.drop((oobErrors.size * 0.68).toInt).head
+      oobErrors.map{case (_, error, uncertainty) => Math.abs(error / uncertainty)}.sorted.drop((oobErrors.size * 0.68).toInt).head
     } else {
       1.0
     }


### PR DESCRIPTION
The calculation of the recalibration ratio takes into account points with zero uncertainty, and makes sure the resulting ratio is a real number.