### PR TITLE
Adding a test that fails because all the weights are zero

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -1,3 +1,3 @@
 all:
-	cd ..; mvn -P lolopy clean package -DskipTests=true -Dmaven.javadoc.skip=True
+	cd ..; mvn -B -P lolopy clean package -DskipTests=true -Dmaven.javadoc.skip=True
 	pip install -e .

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -66,7 +66,7 @@ case class Bagger(
       // of non-zero training weights
       Iterator.continually {
         Vector.fill(trainingData.size)(dist.draw())
-      }.filter(_.count(_ > 0) >= Bagger.minimumNonzeroWeightSize).take(numBags).toVector
+      }.filter(_.count(_ > 0) >= Bagger.minimumNonzeroWeightSize).take(actualBags).toVector
     }.filter{nMat =>
       lazy val noAlwaysPresentTrainingData = nMat.transpose.forall{vec => vec.contains(0)}
       // Make sure that at least one learner is missing each training point

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -35,11 +35,10 @@ case class RegressionTreeLearner(
     * @return a RegressionTree
     */
   override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]] = None): RegressionTreeTrainingResult = {
+    require(trainingData.nonEmpty, s"The input training data was empty")
     if (!trainingData.head._2.isInstanceOf[Double]) {
       throw new IllegalArgumentException(s"Tried to train regression on non-double labels, e.g.: ${trainingData.head._2}")
     }
-    assert(trainingData.size > 4, s"We need to have at least 4 rows, only ${trainingData.size} given")
-
     val repInput = trainingData.head._1
 
     /* Create encoders for any categorical features */
@@ -58,6 +57,11 @@ case class RegressionTreeLearner(
     val finalTraining = encodedTraining.zip(weights.getOrElse(Seq.fill(trainingData.size)(1.0))).map { case ((f, l), w) =>
       (f, l.asInstanceOf[Double], w)
     }.filter(_._3 > 0).toVector
+
+    require(
+      finalTraining.size >= 4,
+      s"We need to have at least 4 rows with non-zero weights, only ${finalTraining.size} given"
+    )
 
     /* If the number of features isn't specified, use all of them */
     val numFeaturesActual = if (numFeatures > 0) {

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -92,6 +92,19 @@ class RandomForestTest {
     assert(lossWithRandomization < lossWithoutRandomization)
   }
 
+  /**
+    * Make sure that we can draw training weights consistently even when the training size is small
+    */
+  @Test
+  def testWeightsWithSmallData(): Unit = {
+    val trainingData = TestUtils.generateTrainingData(8, 1)
+    // the number of trees is the number of times we generate weights
+    // so this has the effect of creating lots of different sets of weights
+    val learner = RandomForest(numTrees = 16384)
+    // the test is that this training doesn't throw an exception
+    learner.train(trainingData).getModel()
+  }
+
 }
 
 object RandomForestTest {


### PR DESCRIPTION
If we have small training data but draw lots of different
weight vectors, then one of them is likely to have all zero weights.
That will cause an empty training set and trigger an exception downstream.

This reproduces the error seen in #186 (I think).