### PR TITLE
Be less aggresive about rectifying importance scores

### DIFF
--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -173,10 +173,11 @@ class BaggerTest {
     val results = RF.transform(trainingData.map(_._1))
     val scores = results.getImportanceScores().get
     val corners = Seq(0, 7, 56, 63)
-    assert(
-      corners.forall(i => scores(i)(i) == scores(i).max),
-      "One of the training corners didn't have the highest score"
-    )
+    corners.foreach { i =>
+      assert(scores(i)(i) == scores(i).max,
+        s"The corner at $i didn't have the highest score: ${scores(i)(i)} vs ${scores(i).max}"
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
The variance is a sum of importance scores.  Each score is stochastic
and bias corrected, which is noisy and can result in scores that
are negative after the correction (which isn't possible).  We had
been rectifying each of those scores before summing them to get
the variance.

That wasn't a good idea: the whole point of the bias correction
is to shift the estimate down, but our rectifying logic was
in-introducing an upward bias.  Intead, we should rectify _after_
the sum, not before it.  If the result is still negative, then we'll
use the amplitude of the largest (or smallest) importance score
as an estimate of the variance scale.  However, in those cases, the user
should really be using more trees.