### PR TITLE
Refactor to split BaggedResult impls by type

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -12,7 +12,7 @@ import org.slf4j.{Logger, LoggerFactory}
   * implications.
   */
 trait BaggedResult[+T] extends PredictionResult[T] {
-  protected val predictions: Seq[PredictionResult[T]]
+  def predictions: Seq[PredictionResult[T]]
 
   /**
     * Average the gradients from the models in the ensemble
@@ -135,8 +135,8 @@ case class BaggedSingleResult(
   }
 }
 
-class BaggedClassificationResult(
-                                  override protected val predictions: Seq[PredictionResult[Any]]
+case class BaggedClassificationResult(
+                                  predictions: Seq[PredictionResult[Any]]
                                 ) extends BaggedResult[Any] {
   lazy val expectedMatrix: Seq[Seq[Any]] = predictions.map(p => p.getExpected()).transpose
 
@@ -164,8 +164,8 @@ class BaggedClassificationResult(
   * @param NibIn       the sample matrix as (N_models x N_training)
   * @param bias        model to use for estimating bias
   */
-class BaggedMultiResult(
-                         override protected val predictions: Seq[PredictionResult[Double]],
+case class BaggedMultiResult(
+                         predictions: Seq[PredictionResult[Double]],
                          NibIn: Vector[Vector[Int]],
                          useJackknife: Boolean,
                          bias: Option[Seq[Double]] = None,

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -11,8 +11,8 @@ import org.slf4j.{Logger, LoggerFactory}
   * This allows the implementation to depend on the number of simultaneous predictions, which has performance
   * implications.
   */
-trait BaggedResult extends PredictionResult[Any] {
-  protected val predictions: Seq[PredictionResult[Any]]
+trait BaggedResult[+T] extends PredictionResult[T] {
+  protected val predictions: Seq[PredictionResult[T]]
 
   /**
     * Average the gradients from the models in the ensemble
@@ -40,25 +40,22 @@ trait BaggedResult extends PredictionResult[Any] {
   * @param predictions for each constituent model
   * @param NibIn       the sample matrix as (N_models x N_training)
   * @param bias        model to use for estimating bias
-  * @param repInput    representative input
   */
 case class BaggedSingleResult(
-                               predictions: Seq[PredictionResult[Any]],
+                               predictions: Seq[PredictionResult[Double]],
                                NibIn: Vector[Vector[Int]],
                                useJackknife: Boolean,
                                bias: Option[Double] = None,
-                               repInput: Vector[Any],
                                rescale: Double = 1.0
-                             ) extends BaggedResult {
-  assert(predictions.head.getExpected().head.isInstanceOf[Double])
-  private lazy val treePredictions: Array[Double] = predictions.map(_.getExpected().head.asInstanceOf[Double]).toArray
+                             ) extends BaggedResult[Double] {
+  private lazy val treePredictions: Array[Double] = predictions.map(_.getExpected().head).toArray
 
   /**
     * Return the ensemble average or maximum vote
     *
     * @return expected value of each prediction
     */
-  override def getExpected(): Seq[Any] = Seq(expected)
+  override def getExpected(): Seq[Double] = Seq(expected)
 
   private lazy val expected = treePredictions.sum / treePredictions.length
   private lazy val treeVariance: Double = treePredictions.map(x => Math.pow(x - expected, 2.0)).sum / treePredictions.length
@@ -138,6 +135,24 @@ case class BaggedSingleResult(
   }
 }
 
+class BaggedClassificationResult(
+                                  override protected val predictions: Seq[PredictionResult[Any]]
+                                ) extends BaggedResult[Any] {
+  lazy val expectedMatrix: Seq[Seq[Any]] = predictions.map(p => p.getExpected()).transpose
+
+  lazy val expected: Seq[Any] = expectedMatrix.map(ps => ps.groupBy(identity).maxBy(_._2.size)._1).seq
+  lazy val uncertainty: Seq[Map[Any, Double]] = expectedMatrix.map(ps => ps.groupBy(identity).mapValues(_.size.toDouble / ps.size))
+
+  /**
+   * Return the majority vote vote
+   *
+   * @return expected value of each prediction
+   */
+  override def getExpected(): Seq[Any] = expected
+
+  override def getUncertainty(): Option[Seq[Any]] = Some(uncertainty)
+}
+
 /**
   * Container with model-wise predictions and logic to compute variances and training row scores
   *
@@ -148,30 +163,28 @@ case class BaggedSingleResult(
   * @param predictions for each constituent model
   * @param NibIn       the sample matrix as (N_models x N_training)
   * @param bias        model to use for estimating bias
-  * @param repInput    representative input
   */
 class BaggedMultiResult(
-                         override protected val predictions: Seq[PredictionResult[Any]],
+                         override protected val predictions: Seq[PredictionResult[Double]],
                          NibIn: Vector[Vector[Int]],
                          useJackknife: Boolean,
                          bias: Option[Seq[Double]] = None,
-                         repInput: Vector[Any],
                          rescale: Double = 1.0
-                       ) extends BaggedResult {
+                       ) extends BaggedResult[Double]{
 
   /**
-    * Return the ensemble average or maximum vote
+    * Return the ensemble average
     *
     * @return expected value of each prediction
     */
-  override def getExpected(): Seq[Any] = expected
+  override def getExpected(): Seq[Double] = expected
 
   /**
     * Return jackknife-based variance estimates
     *
     * @return uncertainty of each prediction
     */
-  override def getUncertainty(): Option[Seq[Any]] = Some(uncertainty)
+  override def getUncertainty(): Option[Seq[Double]] = Some(uncertainty)
 
   /**
     * Return IJ scores
@@ -179,17 +192,13 @@ class BaggedMultiResult(
     * @return training row scores of each prediction
     */
   override def getInfluenceScores(actuals: Seq[Any]): Option[Seq[Seq[Double]]] = {
-    rep match {
-      case x: Double =>
-        Some(influences(
-          expected.asInstanceOf[Seq[Double]].toVector,
-          actuals.toVector.asInstanceOf[Vector[Double]],
-          expectedMatrix.asInstanceOf[Seq[Seq[Double]]],
-          NibJMat,
-          NibIJMat
-        ))
-      case x: Any => None
-    }
+    Some(influences(
+      expected.asInstanceOf[Seq[Double]].toVector,
+      actuals.toVector.asInstanceOf[Vector[Double]],
+      expectedMatrix.asInstanceOf[Seq[Seq[Double]]],
+      NibJMat,
+      NibIJMat
+    ))
   }
 
   override def getImportanceScores(): Option[Seq[Seq[Double]]] = Some(scores)
@@ -198,16 +207,10 @@ class BaggedMultiResult(
   lazy val Nib: Vector[Vector[Int]] = NibIn.transpose.map(_.map(_ - 1))
 
   /* Make a matrix of the tree-wise predictions */
-  lazy val expectedMatrix: Seq[Seq[Any]] = predictions.map(p => p.getExpected()).transpose
-
-  /* For checking the type of the prediction */
-  lazy val rep: Any = expectedMatrix.head.head
+  lazy val expectedMatrix: Seq[Seq[Double]] = predictions.map(p => p.getExpected()).transpose
 
   /* Extract the prediction by averaging for regression, taking the most popular response for classification */
-  lazy val expected = rep match {
-    case x: Double => expectedMatrix.map(ps => ps.asInstanceOf[Seq[Double]].sum / ps.size)
-    case x: Any => expectedMatrix.map(ps => ps.groupBy(identity).maxBy(_._2.size)._1).seq
-  }
+  lazy val expected: Seq[Double] = expectedMatrix.map(ps => ps.sum / ps.size)
 
   /* This matrix is used to compute the jackknife variance */
   lazy val NibJMat = new DenseMatrix[Double](Nib.head.size, Nib.size,
@@ -228,28 +231,21 @@ class BaggedMultiResult(
   )
 
   /* Compute the uncertainties one prediction at a time */
-  lazy val uncertainty = rep match {
-    case x: Double =>
-      val sigma2: Seq[Double] = if (useJackknife) {
-        variance(expected.asInstanceOf[Seq[Double]].toVector, expectedMatrix.asInstanceOf[Seq[Seq[Double]]], NibJMat, NibIJMat)
-      } else {
-        Seq.fill(expected.size)(0.0)
-      }
-      val rescale2 = rescale * rescale
-      sigma2.zip(bias.getOrElse(Seq.fill(expected.size)(0.0))).map { case (variance, b) => Math.sqrt(b * b + variance * rescale2) }
-    case x: Any =>
-      expectedMatrix.map(ps => ps.groupBy(identity).mapValues(_.size.toDouble / ps.size))
+  lazy val uncertainty: Seq[Double] = {
+    val sigma2: Seq[Double] = if (useJackknife) {
+      variance(expected.asInstanceOf[Seq[Double]].toVector, expectedMatrix, NibJMat, NibIJMat)
+    } else {
+      Seq.fill(expected.size)(0.0)
+    }
+    val rescale2 = rescale * rescale
+    sigma2.zip(bias.getOrElse(Seq.fill(expected.size)(0.0))).map { case (variance, b) => Math.sqrt(b * b + variance * rescale2) }
   }
 
   /* Compute the scores one prediction at a time */
-  lazy val scores: Seq[Vector[Double]] = rep match {
-    case x: Double =>
-      scores(expected.asInstanceOf[Seq[Double]].toVector, expectedMatrix.asInstanceOf[Seq[Seq[Double]]], NibJMat, NibIJMat)
+  lazy val scores: Seq[Vector[Double]] = scores(expected.toVector, expectedMatrix, NibJMat, NibIJMat)
         // make sure the variance is non-negative after the stochastic correction
         .map(BaggedResult.rectifyImportanceScores)
         .map(_.map(Math.sqrt))
-    case x: Any => Seq.fill(expected.size)(Vector.fill(Nib.size)(0.0))
-  }
 
   /**
     * Compute the variance of a prediction as the average of bias corrected IJ and J variance estimates

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -38,7 +38,7 @@ class BaggedResultTest {
     * @param trainingData The original training data for the model
     * @param model        The trained model
     */
-  private def testConsistency(trainingData: Seq[(Vector[Any], Any)], model: BaggedModel): Unit = {
+  private def testConsistency(trainingData: Seq[(Vector[Any], Any)], model: BaggedModel[Any]): Unit = {
     val testSubset = Random.shuffle(trainingData).take(16)
     val (singleValues, singleUncertainties) = testSubset.map { case (x, _) =>
       val res = model.transform(Seq(x))

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -216,10 +216,10 @@ class BaggerTest {
 
     // Create a future to run train
     val tmpPool = Executors.newFixedThreadPool(1)
-    val fut: Future[BaggedTrainingResult] = tmpPool.submit(
-      new Callable[BaggedTrainingResult] {
+    val fut: Future[BaggedTrainingResult[Any]] = tmpPool.submit(
+      new Callable[BaggedTrainingResult[Any]] {
         override def call() = {
-          val res = baggedLearner.train(trainingData)
+          val res: BaggedTrainingResult[Any] = baggedLearner.train(trainingData)
           assert(false, "Training was not terminated")
           res
         }
@@ -274,7 +274,7 @@ class BaggerTest {
       numFeatures = 2,
       splitter = RegressionSplitter(randomizePivotLocation = true)
     )
-    val trainedModel: BaggedModel = Bagger(DTLearner,
+    val trainedModel: BaggedModel[Any] = Bagger(DTLearner,
       numBags = 16, useJackknife = true, uncertaintyCalibration = true)
       .train(trainingData)
       .getModel()
@@ -336,7 +336,7 @@ object BaggerTest {
   }
 
 
-  def getStandardRMSE(testSet: Seq[(Vector[Any], Double)], model: BaggedModel): Double = {
+  def getStandardRMSE(testSet: Seq[(Vector[Any], Double)], model: BaggedModel[Any]): Double = {
     val predictions = model.transform(testSet.map(_._1))
     val pva = testSet.map(_._2).zip(
       predictions.getExpected().asInstanceOf[Seq[Double]].zip(


### PR DESCRIPTION
The MultiBaggedResult was riddled with if/else logic to handle both
regression and classification in the same class.  This was more confusing
than it was deduplicating, because we don't jackknife for classification.

This splits the classification result out explicitly, making it much
simpler and allowing the regression case to have the correct
T = Double generic class.