### PR TITLE
Uncertainty decomposition in Regression Interface

### DIFF
--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -181,18 +181,6 @@ class TestRF(TestCase):
         rf.fit(X[:16, :], y[:16])
         self.assertLess(r2_score(y, rf.predict(X)), 1.0)  # Should not fit the whole dataset perfectly
 
-        # Make sure the bias learner does something
-        rf = RandomForestRegressor(use_jackknife=False)
-        rf.fit(X, y)
-        y_pred, y_std = rf.predict(X, return_std=True)
-        total_std = sum(y_std)
-
-        rf = RandomForestRegressor(use_jackknife=False,
-                                   bias_learner=LinearRegression())
-        y_pred, y_std = rf.fit(X, y).predict(X, return_std=True)
-        total_std_bias = sum(y_std)
-        self.assertGreater(total_std_bias - total_std, 0)   # Should increase the bias
-
 
 if __name__ == "__main__":
     main()

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -67,11 +67,6 @@ class TestRF(TestCase):
         rf.clear_model()
         self.assertIsNone(rf.model_)
 
-        # Test removing Jackknife, which should produce equal uncertainties for all entries
-        rf.use_jackknife = False
-        rf.fit(X, y)
-        y_pred, y_std = rf.predict(X, return_std=True)
-        self.assertAlmostEqual(np.std(y_std), 0)
 
     def test_classifier(self):
         rf = RandomForestClassifier()
@@ -190,12 +185,13 @@ class TestRF(TestCase):
         rf = RandomForestRegressor(use_jackknife=False)
         rf.fit(X, y)
         y_pred, y_std = rf.predict(X, return_std=True)
-        self.assertAlmostEqual(0, max(y_std) - min(y_std))  # Should have same sigma for all predictions
+        total_std = sum(y_std)
 
-        rf = RandomForestRegressor(num_trees=16, use_jackknife=False, min_leaf_instances=8,
+        rf = RandomForestRegressor(use_jackknife=False,
                                    bias_learner=LinearRegression())
         y_pred, y_std = rf.fit(X, y).predict(X, return_std=True)
-        self.assertGreater(max(y_std) - min(y_std), 0)   # Should have different sigma for some predictions
+        total_std_bias = sum(y_std)
+        self.assertGreater(total_std_bias - total_std, 0)   # Should increase the bias
 
 
 if __name__ == "__main__":

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -16,7 +16,10 @@ trait PredictionResult[+T] {
   /**
     * Get the uncertainty of the prediction
     *
-    * For example, in regression this is sqrt(bias^2 + variance)
+    * For regression, this should be a standard deviation for the output distribution.
+    * If includeNoise, then it is a prediction interval; if not, then this is a confidence interval
+    *
+    * @param includeNoise whether the uncertainty should account for irreducible noise (i.e. a prediction interval)
     * @return uncertainty of each prediction
     */
   def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = None
@@ -44,12 +47,59 @@ trait PredictionResult[+T] {
   def getGradient(): Option[Seq[Vector[Double]]] = None
 }
 
+/**
+ * Additional regression-specific interface
+ */
 trait RegressionResult extends PredictionResult[Double] {
+  /**
+   * Get the 1-\sigma Prediction Interval for each prediction, if possible
+   *
+   * https://en.wikipedia.org/wiki/Prediction_interval
+   * The prediction interval is typically the sum of the (square) bias, variance, and irreducible error
+   */
   def getPredictionInterval(): Option[Seq[Double]] = None
+
+  /**
+   * Get the 1-\sigma Confidence Interval for each prediction, if possible
+   * https://en.wikipedia.org/wiki/Confidence_interval
+   */
   def getConfidenceInterval(): Option[Seq[Double]] = None
+
+  /**
+   * Get the estimated magnitude of the bias of each prediction, if possible
+   *
+   * See https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
+   */
   def getBias(): Option[Seq[Double]] = None
-  def getVariance(): Option[Seq[Double]] = None
+
+  /**
+   * Get the estimated magnitude of the sqrt of the variance of each prediction, if possible
+   *
+   * The sqrt is so that the bias, variance, and irreducible error have the same scale.
+   * See https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
+   */
+  def getRootVariance(): Option[Seq[Double]] = None
+
+  /**
+   * Get the estimated magnitude of the irreducible noise of each prediction, if possible
+   *
+   * See https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
+   */
   def getIrreducibleError(): Option[Seq[Double]] = None
+
+  /**
+   * Get the "uncertainty", which is the prediction interval if includeNoise and the confidence interval otherwise
+   *
+   * @param includeNoise whether the uncertainty should account for irreducible noise (i.e. a prediction interval)
+   * @return uncertainty of each prediction
+   */
+  override def getUncertainty(includeNoise: Boolean): Option[Seq[Any]] = {
+    if (includeNoise) {
+      getPredictionInterval()
+    } else {
+      getConfidenceInterval()
+    }
+  }
 }
 
 case class MultiResult[T](values: Seq[T]) extends PredictionResult[T] {

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -48,6 +48,16 @@ trait PredictionResult[+T] {
 
 /**
  * Additional regression-specific interface
+ * 
+ * This interface is experimental and SHOULD BE REVIEWED before being merged into `master`. 
+ * n particular, an explanation of how the different methods relate to each other, 
+ * how predictive uncertainty is decomposed, and what the assumptions are 
+ * should be added, as these are currently not entirely clear.
+ * 
+ * For example, does the interface assume that the predictions are the mean of a predictive distribution 
+ * (as opposed to, for example, the median, or the value with highest probability)? 
+ * Does it assume the predictive distribution to be normal? 
+ * Such assumptions are fine, but should be explicitly stated.
  */
 trait RegressionResult extends PredictionResult[Double] {
   /**

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -44,6 +44,14 @@ trait PredictionResult[+T] {
   def getGradient(): Option[Seq[Vector[Double]]] = None
 }
 
+trait RegressionResult extends PredictionResult[Double] {
+  def getPredictionInterval(): Option[Seq[Double]] = None
+  def getConfidenceInterval(): Option[Seq[Double]] = None
+  def getBias(): Option[Seq[Double]] = None
+  def getVariance(): Option[Seq[Double]] = None
+  def getIrreducibleError(): Option[Seq[Double]] = None
+}
+
 case class MultiResult[T](values: Seq[T]) extends PredictionResult[T] {
   /**
     * Get the expected values for this prediction

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -56,7 +56,7 @@ trait RegressionResult extends PredictionResult[Double] {
    *
    * Observations of the predicted variable are expected to have a stddev that matches this value.
    * This statistic is related to the https://en.wikipedia.org/wiki/Prediction_interval
-   * It does not include estimated bias, if applicable
+   * It does not include estimated bias, even if the regression result contains a bias estimate.
    */
   def getStdDevObs(): Option[Seq[Double]] = None
 
@@ -65,17 +65,17 @@ trait RegressionResult extends PredictionResult[Double] {
    *
    * This statistic is related to the https://en.wikipedia.org/wiki/Prediction_interval
    * This statistic includes the contribution of the estimated bias.  E.g., for a normal distribution of predicted
-   * means, the total error is sqrt(bias**2 + variance)
+   * means, the total error is sqrt(bias**2 + variance).
    */
   def getTotalErrorObs(): Option[Seq[Double]] = None
 
   /**
     * Get a quantile from the distribution of predicted observations, if possible
     *
-    * Observations of the predicted variable are expected to have a distribution with this quantile.
+    * Observations of the predicted variable are inferred to have a distribution with this quantile.
     * This statistic is related to the https://en.wikipedia.org/wiki/Prediction_interval
-   *  getObsQuantile(0.5) is a central statistic for the estimated bias, if the bias is estimated but not
-   *  corrected.
+    * getObsQuantile(0.5) is a central statistic for the estimated bias, if the bias is estimated but not
+    * corrected.
     *
     * @param quantile to get, taken between 0.0 and 1.0 (i.e. not a percentile)
     */
@@ -84,7 +84,8 @@ trait RegressionResult extends PredictionResult[Double] {
   /**
    * Get the expected error of the predicted mean observations, if possible
    *
-   * The mean of a large sample of repeated observations are expected to have a stddev that matches this value.
+   * The mean of a large sample of repeated observations are expected to have a root mean squared error of the mean
+   * that matches this value.
    * This statistic is related to the https://en.wikipedia.org/wiki/Confidence_interval
    * This statistic includes the contribution of the estimated bias.  E.g., for a normal distribution of predicted
    * means, the total error is sqrt(bias**2 + variance)
@@ -103,7 +104,7 @@ trait RegressionResult extends PredictionResult[Double] {
   /**
    * Get the standard deviation of the distribution of predicted mean observations, if possible
    *
-   * The variation is the variation due to the finite size of the training data, which can be thought of as being
+   * The variation is due to the finite size of the training data, which can be thought of as being
    * sampled from some training data distribution.
    * This statistic is related to the variance in the bias-variance trade-off
    * https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
@@ -121,7 +122,7 @@ trait RegressionResult extends PredictionResult[Double] {
   /**
    * Get the estimated magnitude of the bias of each prediction, if possible
    *
-   * The bias is signed and can be added to the prediction to improve accuracy.
+   * The bias is signed and can be subtracted from the prediction to improve accuracy.
    * See https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
    */
   def getBias(): Option[Seq[Double]] = None

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -48,15 +48,15 @@ trait PredictionResult[+T] {
 
 /**
  * Additional regression-specific interface
- * 
- * This interface is experimental and SHOULD BE REVIEWED before being merged into `master`. 
- * n particular, an explanation of how the different methods relate to each other, 
- * how predictive uncertainty is decomposed, and what the assumptions are 
+ *
+ * This interface is experimental and SHOULD BE REVIEWED before being merged into `master`.
+ * n particular, an explanation of how the different methods relate to each other,
+ * how predictive uncertainty is decomposed, and what the assumptions are
  * should be added, as these are currently not entirely clear.
- * 
- * For example, does the interface assume that the predictions are the mean of a predictive distribution 
- * (as opposed to, for example, the median, or the value with highest probability)? 
- * Does it assume the predictive distribution to be normal? 
+ *
+ * For example, does the interface assume that the predictions are the mean of a predictive distribution
+ * (as opposed to, for example, the median, or the value with highest probability)?
+ * Does it assume the predictive distribution to be normal?
  * Such assumptions are fine, but should be explicitly stated.
  */
 trait RegressionResult extends PredictionResult[Double] {

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -19,7 +19,7 @@ trait PredictionResult[+T] {
     * For example, in regression this is sqrt(bias^2 + variance)
     * @return uncertainty of each prediction
     */
-  def getUncertainty(): Option[Seq[Any]] = None
+  def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = None
 
   /**
     * Get the training row scores for each prediction

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -93,7 +93,7 @@ trait RegressionResult extends PredictionResult[Double] {
    * @param includeNoise whether the uncertainty should account for irreducible noise (i.e. a prediction interval)
    * @return uncertainty of each prediction
    */
-  override def getUncertainty(includeNoise: Boolean): Option[Seq[Any]] = {
+  override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
     if (includeNoise) {
       getPredictionInterval()
     } else {

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -129,7 +129,7 @@ trait RegressionResult extends PredictionResult[Double] {
   def getQuantileMean(quantile: Double): Option[Seq[Double]] = None
 
   /**
-   * **EXPERIMENTAL** Get the estimated magnitude of the bias of each prediction, if possible
+   * **EXPERIMENTAL** Get the estimated bias of each prediction, if possible
    *
    * The bias is signed and can be subtracted from the prediction to improve accuracy.
    * See https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -120,10 +120,13 @@ trait RegressionResult extends PredictionResult[Double] {
   def getQuantileMean(quantile: Double): Option[Seq[Double]] = None
 
   /**
-   * Get the estimated magnitude of the bias of each prediction, if possible
+   * **EXPERIMENTAL** Get the estimated magnitude of the bias of each prediction, if possible
    *
    * The bias is signed and can be subtracted from the prediction to improve accuracy.
    * See https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
+   *
+   * It is unclear if this method will be a stable member of the interface.  It should be reviewed
+   * before the next formal release.
    */
   def getBias(): Option[Seq[Double]] = None
 

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -50,7 +50,7 @@ trait PredictionResult[+T] {
  * Additional regression-specific interface
  *
  * This interface is experimental and SHOULD BE REVIEWED before being merged into `master`.
- * n particular, an explanation of how the different methods relate to each other,
+ * In particular, an explanation of how the different methods relate to each other,
  * how predictive uncertainty is decomposed, and what the assumptions are
  * should be added, as these are currently not entirely clear.
  *

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -14,15 +14,14 @@ trait PredictionResult[+T] {
   def getExpected(): Seq[T]
 
   /**
-    * Get the uncertainty of the prediction
-    *
-    * For regression, this should be a standard deviation for the output distribution.
-    * If includeNoise, then it is a prediction interval; if not, then this is a confidence interval
-    *
-    * @param includeNoise whether the uncertainty should account for irreducible noise (i.e. a prediction interval)
-    * @return uncertainty of each prediction
-    */
-  def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = None
+   * Get the "uncertainty" of the prediction
+   *
+   * For regression, this should be the TotalError if non-observational and the StdDevObs if observational
+   *
+   * @param observational whether the uncertainty should account for observational uncertainty
+   * @return uncertainty of each prediction
+   */
+  def getUncertainty(observational: Boolean = true): Option[Seq[Any]] = None
 
   /**
     * Get the training row scores for each prediction
@@ -129,7 +128,6 @@ trait RegressionResult extends PredictionResult[Double] {
    * before the next formal release.
    */
   def getBias(): Option[Seq[Double]] = None
-
 
   /**
    * Get the "uncertainty", which is the TotalError if non-observational and the StdDevObs if observational

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -61,14 +61,7 @@ case class BaggedSingleResult(
 
   override def getPredictionInterval(): Option[Seq[Double]] = Some(Seq(treeVariance))
 
-  override def getVariance(): Option[Seq[Double]] = Some(Seq(scalarUncertainty))
-
-  /**
-    * Return jackknife-based variance estimates
-    *
-    * @return uncertainty of each prediction
-    */
-  override def getUncertainty(): Option[Seq[Any]] = getPredictionInterval()
+  override def getRootVariance(): Option[Seq[Double]] = Some(Seq(scalarUncertainty))
 
   private lazy val scalarUncertainty: Double = {
     // make sure the variance is non-negative after the stochastic correction
@@ -149,7 +142,7 @@ case class BaggedClassificationResult(
    */
   override def getExpected(): Seq[Any] = expected
 
-  override def getUncertainty(): Option[Seq[Any]] = Some(uncertainty)
+  override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(uncertainty)
 }
 
 /**
@@ -177,20 +170,13 @@ case class BaggedMultiResult(
     */
   override def getExpected(): Seq[Double] = expected
 
-  /**
-    * Return jackknife-based variance estimates
-    *
-    * @return uncertainty of each prediction
-    */
-  override def getUncertainty(): Option[Seq[Double]] = getPredictionInterval()
-
   override def getPredictionInterval(): Option[Seq[Double]] = Some{
     expectedMatrix.asInstanceOf[Seq[Seq[Double]]].zip(expected.asInstanceOf[Seq[Double]]).map{case (b, y) =>
       b.map{x => Math.pow(x - y, 2.0)}.sum / b.size
     }
   }
 
-  override def getVariance(): Option[Seq[Double]] = Some(uncertainty)
+  override def getRootVariance(): Option[Seq[Double]] = Some(uncertainty)
 
   /**
     * Return IJ scores

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -61,7 +61,14 @@ case class BaggedSingleResult(
 
   override def getStdDevObs(): Option[Seq[Double]] = Some(Seq(treeVariance))
 
-  override def getStdDev(): Option[Seq[Double]] = Some(Seq(scalarUncertainty))
+  override def getStdDevMean(): Option[Seq[Double]] = Some(Seq(scalarUncertainty))
+
+  /**
+   * For the sake of parity, we were using this method
+   */
+  override def getUncertainty(observational: Boolean): Option[Seq[Any]] = {
+    getStdDevMean()
+  }
 
   private lazy val scalarUncertainty: Double = {
     // make sure the variance is non-negative after the stochastic correction
@@ -176,7 +183,14 @@ case class BaggedMultiResult(
     }
   }
 
-  override def getStdDev(): Option[Seq[Double]] = Some(uncertainty)
+  override def getStdDevMean(): Option[Seq[Double]] = Some(uncertainty)
+
+  /**
+   * For the sake of parity, we were using this method
+   */
+  override def getUncertainty(observational: Boolean): Option[Seq[Any]] = {
+    getStdDevMean()
+  }
 
   /**
     * Return IJ scores

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -59,9 +59,9 @@ case class BaggedSingleResult(
   private lazy val expected = treePredictions.sum / treePredictions.length
   private lazy val treeVariance: Double = treePredictions.map(x => Math.pow(x - expected, 2.0)).sum / treePredictions.length
 
-  override def getPredictionInterval(): Option[Seq[Double]] = Some(Seq(treeVariance))
+  override def getStdDevObs(): Option[Seq[Double]] = Some(Seq(treeVariance))
 
-  override def getRootVariance(): Option[Seq[Double]] = Some(Seq(scalarUncertainty))
+  override def getStdDev(): Option[Seq[Double]] = Some(Seq(scalarUncertainty))
 
   private lazy val scalarUncertainty: Double = {
     // make sure the variance is non-negative after the stochastic correction
@@ -170,13 +170,13 @@ case class BaggedMultiResult(
     */
   override def getExpected(): Seq[Double] = expected
 
-  override def getPredictionInterval(): Option[Seq[Double]] = Some{
+  override def getStdDevObs(): Option[Seq[Double]] = Some{
     expectedMatrix.asInstanceOf[Seq[Seq[Double]]].zip(expected.asInstanceOf[Seq[Double]]).map{case (b, y) =>
       b.map{x => Math.pow(x - y, 2.0)}.sum / b.size
     }
   }
 
-  override def getRootVariance(): Option[Seq[Double]] = Some(uncertainty)
+  override def getStdDev(): Option[Seq[Double]] = Some(uncertainty)
 
   /**
     * Return IJ scores

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -241,9 +241,9 @@ class BaggedModel[+T: ClassTag](
 
     val res = if (inputs.size == 1 && isRegression) {
       // In the special case of a single prediction on a real value, emit an optimized BaggedSingleResult
-      BaggedSingleResult(ensemblePredictions.map(_.asInstanceOf[PredictionResult[Double]]), Nib, useJackknife, bias.map(_.head), rescale)
+      BaggedSingleResult(ensemblePredictions.map(_.asInstanceOf[PredictionResult[Double]]), Nib, bias.map(_.head), rescale)
     } else if (isRegression) {
-      new BaggedMultiResult(ensemblePredictions.map(_.asInstanceOf[PredictionResult[Double]]), Nib, useJackknife, bias, rescale)
+      new BaggedMultiResult(ensemblePredictions.map(_.asInstanceOf[PredictionResult[Double]]), Nib, bias, rescale)
     } else {
       new BaggedClassificationResult(ensemblePredictions)
     }

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -144,11 +144,11 @@ case class RotatedFeaturePrediction[T](
   override def getExpected(): Seq[T] = baseResult.getExpected().asInstanceOf[Seq[T]]
 
   /**
-    * Get the uncertainty of the prediction by delegating to baseResult
-    *
-    * @return uncertainty of each prediction
-    */
-  override def getUncertainty(): Option[Seq[Any]] = baseResult.getUncertainty()
+   * Get the uncertainty of the prediction by delegating to baseResult
+   *
+   * @return uncertainty of each prediction
+   */
+  override def getUncertainty(observational: Boolean): Option[Seq[Any]] = baseResult.getUncertainty(observational)
 
   /**
     * Get the gradient or sensitivity of each prediction

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -137,8 +137,8 @@ class StandardizerPrediction[T](baseResult: PredictionResult[T], trans: Seq[Opti
     *
     * @return uncertainty of each prediction
     */
-  override def getUncertainty(): Option[Seq[Any]] = {
-    baseResult.getUncertainty() match {
+  override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
+    baseResult.getUncertainty(includeNoise) match {
       case Some(x) if trans.head.isDefined => Some(x.map(_.asInstanceOf[Double] * rescale))
       case x: Any => x
     }

--- a/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
+++ b/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
@@ -189,7 +189,7 @@ object LoloPyDataLoader {
   def makeRegressionPredictionResult(expected: Seq[Double], uncertainty: Seq[Double]) : PredictionResult[Double] = {
     new PredictionResult[Double] {
       override def getExpected(): Seq[Double] = expected
-      override def getUncertainty(): Option[Seq[Any]] = Some(uncertainty)
+      override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(uncertainty)
     }
   }
 }

--- a/src/test/scala/io/citrine/lolo/util/LoloPyDataLoaderTest.scala
+++ b/src/test/scala/io/citrine/lolo/util/LoloPyDataLoaderTest.scala
@@ -44,7 +44,7 @@ class LoloPyDataLoaderTest {
         1.0 :: 2.0 :: 3.0 :: Nil
       }
 
-      override def getUncertainty(): Option[Seq[Any]] = {
+      override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
         Some(0.1 :: 0.2 :: 0.3 :: Nil)
       }
     }
@@ -72,7 +72,7 @@ class LoloPyDataLoaderTest {
         0 :: 1 :: 0 :: 1 :: Nil
       }
 
-      override def getUncertainty(): Option[Seq[Any]] = {
+      override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
         Some(Map(0 -> 1.0) :: Map(1 -> 0.5, 0 -> 0.2, 2 -> 0.3) :: Map(0 -> 1.0) :: Map(1 -> 1.0) :: Nil)
       }
 

--- a/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
@@ -51,7 +51,7 @@ class MeritTest {
       val predictionResult = new PredictionResult[Double] {
         override def getExpected(): Seq[Double] = pua.map(_._1)
 
-        override def getUncertainty(): Option[Seq[Any]] = Some(pua.map(_._2))
+        override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(pua.map(_._2))
       }
       (predictionResult, pua.map(_._3))
     }


### PR DESCRIPTION
This PR breaks out a specific `RegressionResult` interface and adds both the bias/variance/irreducible error decomposition and the prediction interval / confidence interval distinction.  Further, an `includeNoise` option is added to the existing `getUncertainty` method to distinguish between the prediction and confidence interval understandings of "uncertainty", e.g. "uncertainty in the expectation" vs "uncertainty of the outcome".  Finally, the interface is used for the bagger with ensemble variance serving as a prediction interval and the jackknife estimate as the variance.  The bias and confidence interval may be added pending further study.