### PR TITLE
Support random rotations of features

### DIFF
--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -24,7 +24,7 @@ trait PredictionResult[+T] {
   /**
     * Get the training row scores for each prediction
     *
-    * @return training row scores of each prediction
+    * @return sequence (over predictions) of sequence (over training rows) of importances
     */
   def getImportanceScores(): Option[Seq[Seq[Double]]] = None
 

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -93,7 +93,7 @@ class RotatedFeatureTrainingResult(
   * @param baseModel model to which to delegate prediction on rotated features
   * @param rotatedFeatures indices of features to rotate
   * @param trans matrix to apply to features
-  * @tparam T
+  * @tparam T label type
   */
 class RotatedFeatureModel[T](
                              baseModel: Model[PredictionResult[T]],
@@ -179,15 +179,11 @@ object FeatureRotator {
     * @return list of feature indices that are doubles
     */
   def getDoubleFeatures(rep: Vector[Any]): IndexedSeq[Int] = {
-    rep.indices.collect( i =>
-      rep(i) match {
-        case _: Double => i
-      }
-    )
+    rep.indices.filter(i => rep(i).isInstanceOf[Double])
   }
 
   /**
-   * Apply rotation to a vectors.
+   * Apply rotation to a vector.
    *
    * @param input vector to rotate
    * @param featuresToRotate vector of feature indices included in rotation

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -1,0 +1,225 @@
+package io.citrine.lolo.transformers
+
+import io.citrine.lolo._
+import breeze.linalg.{DenseMatrix, DenseVector, diag, qr}
+import breeze.linalg.qr.QR
+import breeze.numerics.signum
+import breeze.stats.distributions.Gaussian
+
+/**
+  * Rotate the training data before passing along to a base learner
+  *
+  * This may be useful for improving randomization in random forests,
+  * especially when using random feature selection without bagging.
+  *
+  * Created by gregor-robinson on 2020-01-02.
+  */
+case class FeatureRotator(baseLearner: Learner) extends Learner {
+
+  /**
+    * Create linear transformations for continuous features and labels & pass data through to learner
+    *
+    * @param trainingData to train on
+    * @param weights      for the training rows, if applicable
+    * @return training result containing a model
+    */
+  override def train(
+                     trainingData: Seq[(Vector[Any], Any)],
+                     weights: Option[Seq[Double]]
+                    ): RotatedFeatureTrainingResult = {
+    val featuresToRotate = FeatureRotator.getDoubleFeatures(trainingData.head._1)
+    val trans = FeatureRotator.getRandomRotation(featuresToRotate.length)
+
+    val (inputs, labels) = trainingData.unzip
+    val rotatedTrainingData = FeatureRotator.applyRotation(inputs, featuresToRotate, trans).zip(labels)
+    val baseTrainingResult = baseLearner.train(rotatedTrainingData, weights)
+
+    new RotatedFeatureTrainingResult(baseTrainingResult, featuresToRotate, trans)
+  }
+}
+
+class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiTaskLearner {
+
+  /**
+    * Create linear transformations for continuous features and labels & pass data through to learner
+    *
+    * @param inputs  to train on
+    * @param labels  sequence of sequences of labels
+    * @param weights for the training rows, if applicable
+    * @return a sequence of training results, one for each label
+    */
+  override def train(
+                     inputs: Seq[Vector[Any]],
+                     labels: Seq[Seq[Any]],
+                     weights: Option[Seq[Double]]
+                    ): Seq[RotatedFeatureTrainingResult] = {
+    val featuresToRotate = FeatureRotator.getDoubleFeatures(inputs.head)
+    val trans = FeatureRotator.getRandomRotation(inputs.head.length)
+    val rotatedFeatures = FeatureRotator.applyRotation(inputs, featuresToRotate, trans)
+    val baseTrainingResult = baseLearner.train(rotatedFeatures, labels, weights)
+
+    baseTrainingResult.map { case (base) =>
+      new RotatedFeatureTrainingResult(base, featuresToRotate, trans)
+    }
+  }
+}
+
+/**
+  * Training result bundling the base learner's training result with the list of rotated features and the transformation
+  *
+  * @param baseTrainingResult training result to which to delegate prediction on rotated features
+  * @param rotatedFeatures indices of features to rotate
+  * @param trans matrix to apply to features
+  */
+class RotatedFeatureTrainingResult(
+                                   baseTrainingResult: TrainingResult,
+                                   rotatedFeatures: IndexedSeq[Int],
+                                   trans: DenseMatrix[Double]
+                                  ) extends TrainingResult {
+
+  /**
+    * Get the model contained in the training result
+    *
+    * @return the model
+    */
+  override def getModel(): Model[PredictionResult[Any]] = {
+    new RotatedFeatureModel(baseTrainingResult.getModel(), rotatedFeatures, trans)
+  }
+}
+
+/**
+  * Model bundling the base learner's model with the list of rotated features and the transformation
+  *
+  * @param baseModel model to which to delegate prediction on rotated features
+  * @param rotatedFeatures indices of features to rotate
+  * @param trans matrix to apply to features
+  * @tparam T
+  */
+class RotatedFeatureModel[T](
+                             baseModel: Model[PredictionResult[T]],
+                             rotatedFeatures: IndexedSeq[Int],
+                             trans: DenseMatrix[Double]
+                            ) extends Model[PredictionResult[T]] {
+
+  /**
+    * Transform the inputs and then apply the base model
+    *
+    * @param inputs to apply the model to
+    * @return a RotatedFeaturePredictionResult which includes, at least, the expected outputs
+    */
+  override def transform(inputs: Seq[Vector[Any]]): RotatedFeaturePrediction[T] = {
+    val rotatedInputs = FeatureRotator.applyRotation(inputs, rotatedFeatures,  trans)
+    new RotatedFeaturePrediction(baseModel.transform(rotatedInputs), rotatedFeatures, trans)
+  }
+}
+
+/**
+  * Prediction bundling the base learner's prediction with the list of rotated features and the transformation
+  *
+  * @param baseResult
+  * @param rotatedFeatures
+  * @param trans
+  * @tparam T
+  */
+class RotatedFeaturePrediction[T](
+                                  baseResult: PredictionResult[T],
+                                  rotatedFeatures: IndexedSeq[Int],
+                                  trans: DenseMatrix[Double]
+                                 ) extends PredictionResult[T] {
+  /**
+    * Get the expected values for this prediction by delegating to baseResult
+    *
+    * @return expected value of each prediction
+    */
+  override def getExpected(): Seq[T] = baseResult.getExpected().asInstanceOf[Seq[T]]
+
+  /**
+    * Get the uncertainty of the prediction by delegating to baseResult
+    *
+    * @return uncertainty of each prediction
+    */
+  override def getUncertainty(): Option[Seq[Any]] = baseResult.getUncertainty()
+
+  /**
+    * Get the gradient or sensitivity of each prediction
+    *
+    * @return a vector of doubles for each prediction
+    */
+  override def getGradient(): Option[Seq[Vector[Double]]] = {
+    var baseGradient = baseResult.getGradient()
+    // TODO: how should this handle None gradients?
+    baseGradient.map { g =>
+      FeatureRotator.applyRotation(g, rotatedFeatures, trans.t).asInstanceOf[Seq[Vector[Double]]]
+    }
+  }
+
+}
+
+/**
+  * Utilities to compute and apply rotations.
+  */
+object FeatureRotator {
+
+  /**
+    * Draw a random unitary matrix from the uniform (Haar) measure.
+    *
+    * @param dimension for which to get a rotator
+    * @return unitary matrix
+    */
+  def getRandomRotation(dimension: Int): DenseMatrix[Double] = {
+    val X = DenseMatrix.rand(dimension, dimension, Gaussian(0, 1))
+    val QR(_Q, _R) = qr(X)
+    diag(signum(diag(_R))) * _Q.toDenseMatrix
+  }
+
+  /**
+    * Get list of feature indices that make sense to rotate.
+    *
+    * @param rep representative vector of features
+    * @return list of feature indices that are doubles
+    */
+  def getDoubleFeatures(rep: Vector[Any]): IndexedSeq[Int] = {
+    rep.indices.collect( i =>
+      rep(i) match {
+        case x if x.isInstanceOf[Double] => i
+      }
+    )
+  }
+
+  /**
+   * Apply rotation to a vectors.
+   *
+   * @param input vector to rotate
+   * @param featuresToRotate vector of feature indices included in rotation
+   * @param trans linear transformation matrix to apply
+   * @return rotated vectors
+   */
+  def applyOneRotation(
+                    input: Vector[Any],
+                    featuresToRotate: IndexedSeq[Int],
+                    trans: DenseMatrix[Double]
+                   ): Vector[Any] = {
+    val out = input.toArray
+    val rotated: DenseVector[Double] = trans * DenseVector(featuresToRotate.map(i => input(i)).asInstanceOf[Seq[Double]].toArray)
+    featuresToRotate.indices.foreach{ i =>
+      out(featuresToRotate(i)) = rotated(i)
+    }
+    out.toVector
+  }
+
+  /**
+    * Apply rotation to a sequence of vectors.
+    *
+    * @param input sequence of vectors to rotate
+    * @param featuresToRotate vector of feature indices included in rotation
+    * @param trans linear transformation matrix to apply
+    * @return sequence of rotated vectors
+    */
+  def applyRotation(
+                    input: Seq[Vector[Any]],
+                    featuresToRotate: IndexedSeq[Int],
+                    trans: DenseMatrix[Double]
+                   ): Seq[Vector[Any]] = {
+    input.map { x => applyOneRotation(x, featuresToRotate, trans) }
+  }
+}

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -38,7 +38,7 @@ case class FeatureRotator(baseLearner: Learner) extends Learner {
   }
 }
 
-class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiTaskLearner {
+case class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiTaskLearner {
 
   /**
     * Create linear transformations for continuous features and labels & pass data through to learner
@@ -71,7 +71,7 @@ class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiTaskLe
   * @param rotatedFeatures indices of features to rotate
   * @param trans matrix to apply to features
   */
-class RotatedFeatureTrainingResult(
+case class RotatedFeatureTrainingResult(
                                    baseTrainingResult: TrainingResult,
                                    rotatedFeatures: IndexedSeq[Int],
                                    trans: DenseMatrix[Double]
@@ -85,6 +85,10 @@ class RotatedFeatureTrainingResult(
   override def getModel(): Model[PredictionResult[Any]] = {
     new RotatedFeatureModel(baseTrainingResult.getModel(), rotatedFeatures, trans)
   }
+
+  override def getLoss(): Option[Double] = baseTrainingResult.getLoss()
+
+  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Any, Any)]] = baseTrainingResult.getPredictedVsActual()
 }
 
 /**
@@ -95,7 +99,7 @@ class RotatedFeatureTrainingResult(
   * @param trans matrix to apply to features
   * @tparam T label type
   */
-class RotatedFeatureModel[T](
+case class RotatedFeatureModel[T](
                              baseModel: Model[PredictionResult[T]],
                              rotatedFeatures: IndexedSeq[Int],
                              trans: DenseMatrix[Double]
@@ -119,9 +123,9 @@ class RotatedFeatureModel[T](
   * @param baseResult
   * @param rotatedFeatures
   * @param trans
-  * @tparam T
+  * @tparam T label type
   */
-class RotatedFeaturePrediction[T](
+case class RotatedFeaturePrediction[T](
                                   baseResult: PredictionResult[T],
                                   rotatedFeatures: IndexedSeq[Int],
                                   trans: DenseMatrix[Double]

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -94,9 +94,9 @@ class FeatureRotatorTest {
 
     rotatedTrainingResult.getPredictedVsActual().foreach { x =>
       x.zip(data).foreach { case (a,b) =>
-        assert(a._1 == b._1)
-        assert(a._2 == b._2)
-        assert(a._3 == b._2)
+        assert(a._1 == b._1, "getPredictedVsActual must return the correct training inputs.")
+        assert(a._2 == b._2, "getPredictedVsActual must return the correct predicted value.")
+        assert(a._3 == b._2, "getPredictedVsActual must return the correct actual value.")
       }
     }
   }

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -85,15 +85,20 @@ class FeatureRotatorTest {
     */
   @Test
   def testPassthroughFunctions(): Unit = {
-    val rotatedTrainingResult = FeatureRotator(GuessTheMeanLearner()).train(data)
+    val rotatedTrainingResult = FeatureRotator(RegressionTreeLearner()).train(data)
+
     assert(
       rotatedTrainingResult.getLoss() == rotatedTrainingResult.baseTrainingResult.getLoss(),
       "Function getLoss() should pass through to base learner."
     )
-    assert(
-      rotatedTrainingResult.getPredictedVsActual() == rotatedTrainingResult.baseTrainingResult.getPredictedVsActual(),
-      "Function getPredictedVsActual() should pass through to base learner."
-    )
+
+    rotatedTrainingResult.getPredictedVsActual().foreach { x =>
+      x.zip(data).foreach { case (a,b) =>
+        assert(a._1 == b._1)
+        assert(a._2 == b._2)
+        assert(a._3 == b._2)
+      }
+    }
   }
 
   /**

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -1,0 +1,118 @@
+package io.citrine.lolo.transformers
+
+import breeze.linalg.{DenseMatrix, DenseVector, det}
+import io.citrine.lolo.TestUtils
+import io.citrine.lolo.linear.{GuessTheMeanLearner, LinearRegressionLearner}
+import io.citrine.lolo.stats.functions.Friedman
+import io.citrine.lolo.stats.metrics.ClassificationMetrics
+import io.citrine.lolo.trees.classification.ClassificationTreeLearner
+import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
+import org.junit.Test
+
+import scala.util.Random
+
+/**
+  * Created by gregor-robinson on 2020-01-06.
+  */
+@Test
+class FeatureRotatorTest {
+
+  val data: Vector[(Vector[Double], Double)] = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+  val weights: Vector[Double] = Vector.fill(data.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
+
+  // Creating another dataset which has 1 feature that has 0 variance.
+  val dataWithConstant: Vector[(Vector[Double], Double)] = data.map(d => (0.0 +: d._1, d._2))
+
+  @Test
+  def testRandomRotation(): Unit = {
+    val inputs = data.map(_._1)
+    for (i <- 1 to 10) {
+      val U = FeatureRotator.getRandomRotation(inputs.head.length)
+      assert(U.rows == inputs.head.length)
+      assert(U.cols == inputs.head.length)
+
+      // Check that the determinant is one.
+      val d = det(U)
+
+      // Check that the matrix is unitary.
+      (U.t * U - DenseMatrix.eye[Double](inputs.head.length)).toArray.foreach{ x =>
+        assert(Math.abs(x) < 1e-9)
+      }
+
+      val featuresToRotate = inputs.head.indices.asInstanceOf[IndexedSeq[Int]]
+      val rotatedInputs = FeatureRotator.applyRotation(inputs, featuresToRotate, U)
+    }
+  }
+
+  /**
+    * Guess the mean should be invariant under rotation.
+    */
+  @Test
+  def testStandardGTM(): Unit = {
+    val learner = GuessTheMeanLearner()
+    val model = learner.train(data).getModel()
+    val result = model.transform(data.map(_._1)).getExpected()
+
+    val rotatedLearner = FeatureRotator(GuessTheMeanLearner())
+    val rotatedModel = rotatedLearner.train(data).getModel()
+    val rotatedResult = rotatedModel.transform(data.map(_._1)).getExpected()
+
+    result.zip(rotatedResult).foreach { case (free: Double, rotated: Double) =>
+      assert(Math.abs(free - rotated) < 1.0e-9, s"${free} and ${rotated} should be the same")
+    }
+  }
+
+  /**
+    * Linear regression should be invariant under standardization
+    */
+  @Test
+  def testStandardLinear(): Unit = {
+    val learner = LinearRegressionLearner()
+    val model = learner.train(data, Some(weights)).getModel()
+    val result = model.transform(data.map(_._1))
+    val expected = result.getExpected()
+    val gradient = result.getGradient()
+
+    val rotatedLearner = FeatureRotator(learner)
+    val rotatedModel = rotatedLearner.train(data, Some(weights)).getModel()
+    val rotatedResult = rotatedModel.transform(data.map(_._1))
+    val rotatedExpected = rotatedResult.getExpected()
+    val rotatedGradient = rotatedResult.getGradient()
+
+    expected.zip(rotatedExpected).foreach { case (free: Double, rotated: Double) =>
+      assert(Math.abs(free - rotated) < 1.0e-9, s"${free} and ${rotated} should be the same")
+    }
+
+    // TODO: test gradient.
+    //gradient.get.zip(rotatedGradient.get).foreach { case (free, rotated) =>
+    //  val diff = free.zip(rotated).map { case (f, s) => Math.abs(f - s) }.max
+    //  assert(diff < 1.0e-9, "Gradients should be the same")
+    //}
+  }
+
+  /**
+    * Ridge regression should not depend on standardization
+    */
+  @Test
+  def testStandardRidge(): Unit = {
+    val learner = LinearRegressionLearner(regParam = Some(1.0))
+    val model = learner.train(data).getModel()
+    val result = model.transform(data.map(_._1)).getExpected()
+
+    val rotatedLearner = new FeatureRotator(learner)
+    val rotatedModel = rotatedLearner.train(data).getModel()
+    val rotatedResult = rotatedModel.transform(data.map(_._1)).getExpected()
+
+    result.zip(rotatedResult).foreach { case (free: Double, rotated: Double) =>
+      assert(Math.abs(free - rotated) < 1.0e-9, s"${free} and ${rotated} should be the same")
+    }
+  }
+
+  /*
+   * TODO: test with RegressionTreeLearner
+   * TODO: test ClassificationTreeLearner
+   * TODO: test MultiTaskTreeLearner
+   * TODO: test skips non-double input features
+   * TODO: investigate performance relative to un-rotated random forest
+   */
+}

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -7,6 +7,7 @@ import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
+import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import org.junit.Test
 
 import scala.util.Random
@@ -17,30 +18,65 @@ import scala.util.Random
 @Test
 class FeatureRotatorTest {
 
-  val data: Vector[(Vector[Double], Double)] = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+  val data: Seq[(Vector[Any], Any)] = TestUtils.binTrainingData(
+    TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
+    inputBins = Seq((0, 8))
+  )
   val weights: Vector[Double] = Vector.fill(data.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
-
-  // Creating another dataset which has 1 feature that has 0 variance.
-  val dataWithConstant: Vector[(Vector[Double], Double)] = data.map(d => (0.0 +: d._1, d._2))
 
   @Test
   def testRandomRotation(): Unit = {
     val inputs = data.map(_._1)
+    val numRealInputs = inputs.head.length -1
     for (i <- 1 to 10) {
-      val U = FeatureRotator.getRandomRotation(inputs.head.length)
-      assert(U.rows == inputs.head.length)
-      assert(U.cols == inputs.head.length)
-
-      // Check that the determinant is one.
-      val d = det(U)
+      val U = FeatureRotator.getRandomRotation(numRealInputs)
+      assert(U.rows == numRealInputs)
+      assert(U.cols == numRealInputs)
 
       // Check that the matrix is unitary.
-      (U.t * U - DenseMatrix.eye[Double](inputs.head.length)).toArray.foreach{ x =>
+      (U.t * U - DenseMatrix.eye[Double](numRealInputs)).toArray.foreach{ x =>
         assert(Math.abs(x) < 1e-9)
       }
 
-      val featuresToRotate = inputs.head.indices.asInstanceOf[IndexedSeq[Int]]
-      val rotatedInputs = FeatureRotator.applyRotation(inputs, featuresToRotate, U)
+      // Check that the determinant is one.
+      val d = det(U)
+      assert(Math.abs(d - 1.0) < 1e-9, s"Determinant of U should be 1 but is ${d}")
+    }
+  }
+
+  @Test
+  def testApplyRotation(): Unit = {
+    val inputs = data.map(_._1)
+    val numRealInputs = inputs.head.length -1
+    val featuresToRotate = (1 to numRealInputs).asInstanceOf[IndexedSeq[Int]]
+
+    // Create rotation matrix that exchanges first, second, and last real inputs
+    val U = DenseMatrix.eye[Double](dim = numRealInputs)
+    U(0,0) = 0.0
+    U(1,1) = 0.0
+    U(numRealInputs-1,numRealInputs-1) = 0.0
+    U(0,1) = 1.0
+    U(1,numRealInputs-1) = 1.0
+    U(numRealInputs-1,0) = 1.0
+
+    val rotatedInputs = FeatureRotator.applyRotation(inputs, featuresToRotate, U)
+    inputs.indices.foreach { i =>
+      assert(inputs(i)(0) == rotatedInputs(i)(0), "Failed to leave categorical invariant.")
+      assert(Math.abs(inputs(i)(1).asInstanceOf[Double] - rotatedInputs(i)(numRealInputs).asInstanceOf[Double]) < 1e-9, "Failed to exchange coordinates.")
+      assert(Math.abs(inputs(i)(2).asInstanceOf[Double] - rotatedInputs(i)(1).asInstanceOf[Double]) < 1e-9, "Failed to exchange coordinates.")
+      assert(Math.abs(inputs(i)(numRealInputs).asInstanceOf[Double] - rotatedInputs(i)(2).asInstanceOf[Double]) < 1e-9, "Failed to exchange coordinates.")
+      (3 to numRealInputs - 1).foreach { j =>
+        assert(Math.abs(inputs(i)(j).asInstanceOf[Double] - rotatedInputs(i)(j).asInstanceOf[Double]) < 1e-9, "Unexpected modification of un-rotated coordinate.")
+      }
+    }
+
+    // Check that we can undo rotation by applying the transpose
+    val unrotatedInputs = FeatureRotator.applyRotation(rotatedInputs, featuresToRotate, U.t)
+    inputs.indices.foreach { i =>
+      assert(inputs(i)(0) == unrotatedInputs(i)(0), "Failed to leave categorical invariant.")
+      (1 to numRealInputs - 1).foreach { j =>
+        assert(Math.abs(inputs(i)(j).asInstanceOf[Double] - unrotatedInputs(i)(j).asInstanceOf[Double]) < 1e-9, "Unexpected modification of coordinate after applying transpose.")
+      }
     }
   }
 
@@ -48,7 +84,7 @@ class FeatureRotatorTest {
     * Guess the mean should be invariant under rotation.
     */
   @Test
-  def testStandardGTM(): Unit = {
+  def testRotatedGTM(): Unit = {
     val learner = GuessTheMeanLearner()
     val model = learner.train(data).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
@@ -63,10 +99,10 @@ class FeatureRotatorTest {
   }
 
   /**
-    * Linear regression should be invariant under standardization
+    * Linear regression should be invariant under rotation
     */
   @Test
-  def testStandardLinear(): Unit = {
+  def testRotatedLinear(): Unit = {
     val learner = LinearRegressionLearner()
     val model = learner.train(data, Some(weights)).getModel()
     val result = model.transform(data.map(_._1))
@@ -83,18 +119,17 @@ class FeatureRotatorTest {
       assert(Math.abs(free - rotated) < 1.0e-9, s"${free} and ${rotated} should be the same")
     }
 
-    // TODO: test gradient.
-    //gradient.get.zip(rotatedGradient.get).foreach { case (free, rotated) =>
-    //  val diff = free.zip(rotated).map { case (f, s) => Math.abs(f - s) }.max
-    //  assert(diff < 1.0e-9, "Gradients should be the same")
-    //}
+    gradient.get.zip(rotatedGradient.get).foreach { case (free, rotated) =>
+      val diff = free.zip(rotated).map { case (f, s) => Math.abs(f - s) }.max
+      assert(diff < 1.0e-9, "Gradients should be the same")
+    }
   }
 
   /**
-    * Ridge regression should not depend on standardization
+    * Ridge regression should not depend on rotation
     */
   @Test
-  def testStandardRidge(): Unit = {
+  def testRotatedRidge(): Unit = {
     val learner = LinearRegressionLearner(regParam = Some(1.0))
     val model = learner.train(data).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
@@ -108,11 +143,85 @@ class FeatureRotatorTest {
     }
   }
 
+  /**
+   * Regression trees should not depend on rotation
+   */
+  @Test
+  def testRotatedRegressionTree(): Unit = {
+    val learner = RegressionTreeLearner()
+    val model = learner.train(data).getModel()
+    val result = model.transform(data.map(_._1)).getExpected()
+
+    val rotatedLearner = new FeatureRotator(learner)
+    val rotatedModel = rotatedLearner.train(data).getModel()
+    val rotatedResult = rotatedModel.transform(data.map(_._1)).getExpected()
+
+    result.zip(rotatedResult).foreach { case (free: Double, rotated: Double) =>
+      assert(Math.abs(free - rotated) < 1.0e-9, s"${free} and ${rotated} should be the same")
+    }
+  }
+
+  /**
+   * Classification trees should not depend on rotation
+   */
+  @Test
+  def testRotatedClassificationTree(): Unit = {
+    val classificationData = TestUtils.binTrainingData(
+      TestUtils.generateTrainingData(2048, 12, noise = 0.1,
+        function = Friedman.friedmanSilverman),
+      responseBins = Some(2)
+    )
+
+    val learner = ClassificationTreeLearner()
+    val model = learner.train(classificationData).getModel()
+    val result = model.transform(classificationData.map(_._1)).getExpected()
+
+    val rotatedLearner = new FeatureRotator(learner)
+    val rotatedModel = rotatedLearner.train(classificationData).getModel()
+    val rotatedResult = rotatedModel.transform(classificationData.map(_._1)).getExpected()
+
+    result.zip(rotatedResult).foreach { case (free: Any, rotated: Any) =>
+      assert(free == rotated, s"${free} and ${rotated} should be the same")
+    }
+  }
+
+  /**
+   * Test that multitask rotation has the proper performance and invariants
+   */
+  @Test
+  def testMultiTaskRotator(): Unit = {
+    val data: Vector[(Vector[Double], Double)] = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+
+    // Generate multi-task training data
+    val (inputs, doubleLabel) = data.unzip
+    val catLabel = inputs.map(x => Friedman.friedmanGrosseSilverman(x) > 15.0)
+
+    // Sparsify the categorical labels
+    val sparseCatLabel = catLabel.map(x => if (Random.nextBoolean()) x else null)
+
+    // Train and evaluate rotated models on original and rotated features
+    val baseLearner = new MultiTaskTreeLearner()
+    val rotator = new MultiTaskFeatureRotator(MultiTaskTreeLearner())
+
+    // Check double labels are the same
+    val baseDoubleRes = baseLearner.train(inputs, Seq(doubleLabel, sparseCatLabel)).head.getModel().transform(inputs).getExpected()
+    val rotatedDoubleRes = rotator.train(inputs, Seq(doubleLabel, sparseCatLabel)).head.getModel().transform(inputs).getExpected()
+    baseDoubleRes.zip(rotatedDoubleRes).foreach { case (br: Double, rr: Double) =>
+      assert(Math.abs(br - rr) < 1e-9, "Predicted double label not the same in rotated learner.")
+    }
+
+    // Check categorical labels are the same
+    val baseTrainingRes = baseLearner.train(inputs, Seq(doubleLabel, sparseCatLabel))
+    val baseCatRes = baseLearner.train(inputs, Seq(doubleLabel, sparseCatLabel)).last.getModel().transform(inputs).getExpected()
+    val rotatedCatRes = rotator.train(inputs, Seq(doubleLabel, sparseCatLabel)).last.getModel().transform(inputs).getExpected()
+
+    val baseF1 = ClassificationMetrics.f1scores(baseCatRes, catLabel)
+    val rotatedF1 = ClassificationMetrics.f1scores(rotatedCatRes, catLabel)
+    // rotatedF1 appears to come in be substantially lower than baseF1; this is just a rough sanity check / smoketest.
+    assert(Math.abs(baseF1 - rotatedF1) < 0.15)
+  }
+
   /*
-   * TODO: test with RegressionTreeLearner
-   * TODO: test ClassificationTreeLearner
-   * TODO: test MultiTaskTreeLearner
-   * TODO: test skips non-double input features
    * TODO: investigate performance relative to un-rotated random forest
    */
 }


### PR DESCRIPTION
This PR introduces a transformer that rotates input feature space before passing the transformed data to a base learner, with a specific aim of applying random rotations. There is reason to believe that random rotations of feature space can improve the performance of various kinds of learners --- such as by increasing entropy across an ensemble, or by decreasing the incidence of unimportant feature subsets for methods that use ensembles over random feature subsets. One promising application, random rotation ensembles introduced by Blaser & Fryzlewicz, trains each base learner in an ensemble method on a different random rotation of feature space; predictions are performed using the same rotations that were applied to the training data. Blaser & Fryzlewicz (2016) found large improvement in RMSE using this approach on Fisher's iris dataset.

Note: there are a few tests indicated by TODOs that I still want to write before merging this, but I would appreciate eyes on the implementation for feedback. Some questions for the team: What's an appropriate way to handle None in `getGradient`? Are there any other cases you want to see in the unit tests?