### PR TITLE
Remove bias for duplicate input rows with different categorical labels.

### DIFF
--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -20,7 +20,7 @@ case class GuessTheMeanLearner() extends Learner {
     val data = trainingData.map(_._2).zip(weights.getOrElse(Seq.fill(trainingData.size)(1.0)))
     val mean = data.head._1 match {
       case x: Double => data.asInstanceOf[Seq[(Double, Double)]].map(p => p._1 * p._2).sum / data.map(_._2).sum
-      case x: Any => Random.shuffle(data.groupBy(_._1).mapValues(_.map(_._2).sum)).maxBy(_._2)._1
+      case x: Any => Random.shuffle(data.groupBy(_._1).mapValues(_.map(_._2).sum).toSeq).maxBy(_._2)._1
     }
 
     new GuessTheMeanTrainingResult(new GuessTheMeanModel(mean))

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -2,6 +2,8 @@ package io.citrine.lolo.linear
 
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 
+import scala.util.Random
+
 /**
   * Created by maxhutch on 11/15/16.
   */
@@ -18,7 +20,7 @@ case class GuessTheMeanLearner() extends Learner {
     val data = trainingData.map(_._2).zip(weights.getOrElse(Seq.fill(trainingData.size)(1.0)))
     val mean = data.head._1 match {
       case x: Double => data.asInstanceOf[Seq[(Double, Double)]].map(p => p._1 * p._2).sum / data.map(_._2).sum
-      case x: Any => data.groupBy(_._1).mapValues(_.map(_._2).sum).maxBy(_._2)._1
+      case x: Any => Random.shuffle(data.groupBy(_._1).mapValues(_.map(_._2).sum)).maxBy(_._2)._1
     }
 
     new GuessTheMeanTrainingResult(new GuessTheMeanModel(mean))

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -111,9 +111,12 @@ class RandomForestTest {
 
     // Posterior beta distribution with Jeffrey prior.
     val d = new Beta(winsSuffixed + 0.5, winsPrefixed + 0.5)
+    val l = d.inverseCdf(2e-6)
+    val r = d.inverseCdf(1-2e-6)
     val tol = 1e-2
-    assert(d.inverseCdf(2e-6) < 0.5 - tol, "Bias detected toward prefixed duplicate rows (rate " + d.mean + " should be close to 0.5)")
-    assert(d.inverseCdf(1-2e-6) > 0.5 + tol, "Bias detected toward suffixed duplicate rows (rate " + d.mean + " should be close to 0.5)")
+    // println(f"Rate=${d.mean}%.3f (1e-6 CI ${l}%.3f - ${r}%.3f)")
+    assert(l < 0.5 - tol, f"Bias detected toward prefixed duplicate rows: rate ${d.mean}%.3f (1e-6 CI ${l}%.3f - ${r}%.3f) should be close to 0.5")
+    assert(r > 0.5 + tol, f"Bias detected toward suffixed duplicate rows: rate ${d.mean}%.3f (1e-6 CI ${l}%.3f - ${r}%.3f) should be close to 0.5")
   }
 
   /**

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -107,13 +107,13 @@ class RandomForestTest {
       } else {
         (0,0)
       }
-    }.asInstanceOf[Seq[(Int,Int)]].reduce{(a:(Int,Int),b:(Int,Int))=>(a._1+b._1, a._2+b._2)}
+    }.asInstanceOf[Seq[(Int,Int)]].reduce{(a: (Int,Int),b: (Int,Int))=>(a._1 + b._1, a._2 + b._2)}
 
     // Posterior beta distribution with Jeffrey prior.
     val d = new Beta(wins1 + 0.5, wins2 + 0.5)
     val tol = 1e-2
-    assert(d.inverseCdf(2e-6) < 0.5 - tol, "Bias detected toward prefixed duplicate rows (rate "+ d.mean + " should be close to 0.5)")
-    assert(d.inverseCdf(1-2e-6) > 0.5 + tol, "Bias detected toward prefixed duplicate rows (rate "+ d.mean + " should be close to 0.5)")
+    assert(d.inverseCdf(2e-6) < 0.5 - tol, "Bias detected toward prefixed duplicate rows (rate " + d.mean + " should be close to 0.5)")
+    assert(d.inverseCdf(1-2e-6) > 0.5 + tol, "Bias detected toward prefixed duplicate rows (rate " + d.mean + " should be close to 0.5)")
   }
 
   /**

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo.learners
 
+import breeze.stats.distributions.Beta
 import io.citrine.lolo.TestUtils
 import io.citrine.lolo.stats.functions.Friedman
 import org.junit.Test
@@ -73,6 +74,49 @@ class RandomForestTest {
   }
 
   /**
+    * Ensure classification forest isn't biased toward one or the other ordering of class labels
+    * when there are duplicate inputs.
+    */
+  @Test
+  def testClassificationForestUnbiased(): Unit = {
+    val numTrials = 30
+    var (wins1, wins2): (Int,Int) = (0 until numTrials).map {case i: Int =>
+      val mainTrainingData = TestUtils.binTrainingData(
+        TestUtils.generateTrainingData(128, 5, noise = 0.1, function = Friedman.friedmanSilverman, seed = i),
+        responseBins = Some(2)
+      )
+      val dupeLabel = "DUPE"
+      val trainingData1 = mainTrainingData ++ Seq(
+        (mainTrainingData.head._1, dupeLabel)
+      )
+      val trainingData2 = Seq(
+        (mainTrainingData.head._1, dupeLabel)
+      ) ++ mainTrainingData
+
+      val RF1 = RandomForest(numTrees = trainingData1.size * 2).train(trainingData1)
+      val RF2 = RandomForest(numTrees = trainingData2.size * 2).train(trainingData2)
+      val predicted1 = RF1.getModel().transform(mainTrainingData.map(_._1))
+      val predicted2 = RF2.getModel().transform(mainTrainingData.map(_._1))
+      val extraLabelCount1 = predicted1.getExpected().count { case p: String => p == dupeLabel }
+      val extraLabelCount2 = predicted2.getExpected().count { case p: String => p == dupeLabel }
+
+      if (extraLabelCount1 > extraLabelCount2) {
+        (1,0)
+      } else if (extraLabelCount1 < extraLabelCount2) {
+        (0,1)
+      } else {
+        (0,0)
+      }
+    }.asInstanceOf[Seq[(Int,Int)]].reduce{(a:(Int,Int),b:(Int,Int))=>(a._1+b._1, a._2+b._2)}
+
+    // Posterior beta distribution with Jeffrey prior.
+    val d = new Beta(wins1 + 0.5, wins2 + 0.5)
+    val tol = 1e-2
+    assert(d.inverseCdf(2e-6) < 0.5 - tol, "Bias detected toward prefixed duplicate rows (rate "+ d.mean + " should be close to 0.5)")
+    assert(d.inverseCdf(1-2e-6) > 0.5 + tol, "Bias detected toward prefixed duplicate rows (rate "+ d.mean + " should be close to 0.5)")
+  }
+
+  /**
     * Randomized splits should do really well on linear signals when there are lots of trees.  Test that they
     * outperform mid-point splits
     */
@@ -118,5 +162,7 @@ object RandomForestTest {
   def main(argv: Array[String]): Unit = {
     new RandomForestTest()
       .testClassificationForest()
+    new RandomForestTest()
+      .testClassificationForestUnbiased()
   }
 }

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -109,12 +109,11 @@ class RandomForestTest {
       }
     }.asInstanceOf[Seq[(Int,Int)]].reduce{(a: (Int,Int),b: (Int,Int))=>(a._1 + b._1, a._2 + b._2)}
 
-    // Posterior beta distribution with Jeffrey prior.
+    // Posterior beta distribution with Jeffreys prior.
     val d = new Beta(winsSuffixed + 0.5, winsPrefixed + 0.5)
     val l = d.inverseCdf(2e-6)
     val r = d.inverseCdf(1-2e-6)
     val tol = 1e-2
-    // println(f"Rate=${d.mean}%.3f (1e-6 CI ${l}%.3f - ${r}%.3f)")
     assert(l < 0.5 - tol, f"Bias detected toward prefixed duplicate rows: rate ${d.mean}%.3f (1e-6 CI ${l}%.3f - ${r}%.3f) should be close to 0.5")
     assert(r > 0.5 + tol, f"Bias detected toward suffixed duplicate rows: rate ${d.mean}%.3f (1e-6 CI ${l}%.3f - ${r}%.3f) should be close to 0.5")
   }


### PR DESCRIPTION
Lolo classification forests using the default `GuessTheMeanLearner` do something that I find problematic when there are duplicated input rows in the training data. In particular, if `ClassificationTree` is trained on data in which the input `I` maps to both class labels `L1` and `L2` in equal proportion, only the label that appears first in the dataset passed to the leaf learner will affect that leaf's predictions. Although bagging should partially mitigate this effect, it will still bias predictions near `I` toward the categories that appear earlier in the training data whenever there are multiple data that have inputs `I` associated with different labels. This bug-report-as-test-case demonstrates this bias in the case of a classification forest.