### PR TITLE
Bump to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Lolo supports:
  * bagged learners to produce ensemble models, e.g. random forests
  * linear and ridge regression
  * regression _leaf models_, e.g. ridge regression trained on the leaf data
+ * random rotation ensembles
  * bias-corrected jackknife-after-bootstrap and infinitesimal jackknife variance estimates
  * bias models trained on out-of-bag residuals
  * discrete influence scores, which characterize the response of a prediction each training instance
@@ -33,7 +34,7 @@ Lolo is on the central repository, and can be used by simply adding the followin
 <dependency>
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
 </dependency>
 ```
 Lolo provides higher level wrappers for common learner combinations.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>2.2.5</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/python/lolopy/version.py
+++ b/python/lolopy/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.0.5"
+__version__ = "1.1.0"


### PR DESCRIPTION
Deployed on Maven: https://search.maven.org/artifact/io.citrine/lolo/3.0.0/jar
Deployed on PyPi: https://pypi.org/project/lolopy/1.1.0/