### PR TITLE
UQ sanity check

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -58,13 +58,13 @@ case class BaggedSingleResult(
 
   private lazy val expected = treePredictions.sum / treePredictions.length
   private lazy val treeVariance: Double = {
-    assert(treePredictions.length > 1, "Bootstrap variance undefined for fewer than 2 bootstrap samples." + treePredictions.length)
-    treePredictions.map(x => Math.pow(x - expected, 2.0)).sum / treePredictions.length
+    assert(treePredictions.length > 1, "Bootstrap variance undefined for fewer than 2 bootstrap samples.")
+    treePredictions.map(x => Math.pow(x - expected, 2.0)).sum / (treePredictions.length - 1)
   }
 
-  override def getStdDevObs(): Option[Seq[Double]] = Some(Seq(scalarUncertainty))
+  override def getStdDevMean(): Option[Seq[Double]] = Some(Seq(stdDevMean))
 
-  override def getStdDevMean(): Option[Seq[Double]] = None
+  override def getStdDevObs(): Option[Seq[Double]] = Some(Seq(stdDevObs))
 
   /**
    * For the sake of parity, we were using this method
@@ -77,12 +77,11 @@ case class BaggedSingleResult(
     }
   }
 
-  private lazy val scalarUncertainty: Double = {
-    // make sure the variance is non-negative after the stochastic correction
-    val rectified = BaggedResult.rectifyEstimatedVariance(singleScores)
-    Math.sqrt(rectified * Math.pow(rescale, 2.0) + Math.pow(bias.getOrElse(0.0), 2.0))
-  } ensuring(_ >= 0.0)
+  private lazy val stdDevMean: Double = Math.sqrt(BaggedResult.rectifyEstimatedVariance(singleScores))
 
+  private lazy val stdDevObs: Double = {
+    rescale * Math.sqrt(treeVariance)
+  } ensuring(_ >= 0.0)
 
   /**
     * The importances are computed as an average of bias-corrected jackknife-after-bootstrap
@@ -93,8 +92,9 @@ case class BaggedSingleResult(
   override def getImportanceScores(): Option[Seq[Seq[Double]]] = Some(Seq(singleScores))
 
   private lazy val singleScores: Vector[Double] = {
-    // Compute the variance of the ensemble of predicted values and divide by the size of the ensemble an extra time
-    val varT = treeVariance / treePredictions.length
+    // Compute the Bessel-uncorrected variance of the ensemble of predicted values,
+    // and then divide by the size of the ensemble an extra time
+    val varT = treeVariance * (treePredictions.length - 1.0) / (treePredictions.length * treePredictions.length)
 
     // This will be more convenient later
     val nMat = NibIn.transpose
@@ -184,9 +184,9 @@ case class BaggedMultiResult(
     */
   override def getExpected(): Seq[Double] = expected
 
-  override def getStdDevObs(): Option[Seq[Double]] = Some(uncertainty)
+  override def getStdDevObs(): Option[Seq[Double]] = Some(varObs.map{v => Math.sqrt(v)})
 
-  override def getStdDevMean(): Option[Seq[Double]] = None
+  override def getStdDevMean(): Option[Seq[Double]] = Some(stdDevMean)
 
   /**
    * For the sake of parity, we were using this method
@@ -243,11 +243,13 @@ case class BaggedMultiResult(
     }.toArray
   )
 
-  /* Compute the uncertainties one prediction at a time */
-  lazy val uncertainty: Seq[Double] = {
-    val sigma2: Seq[Double] = variance(expected.asInstanceOf[Seq[Double]].toVector, expectedMatrix, NibJMat, NibIJMat)
-    val rescale2 = rescale * rescale
-    sigma2.zip(bias.getOrElse(Seq.fill(expected.size)(0.0))).map { case (variance, b) => Math.sqrt(b * b + variance * rescale2) }
+  /* This represents the variance of the estimate of the mean. */
+  lazy val stdDevMean: Seq[Double] = variance(expected.asInstanceOf[Seq[Double]].toVector, expectedMatrix, NibJMat, NibIJMat).map{Math.sqrt}
+
+  /* This estimates the variance of predictive distribution. */
+  lazy val varObs: Seq[Double] = expectedMatrix.asInstanceOf[Seq[Seq[Double]]].zip(expected.asInstanceOf[Seq[Double]]).map { case (b, y) =>
+    assert(Nib.size > 1, "Bootstrap variance undefined for fewer than 2 bootstrap samples.")
+    b.map { x => rescale * rescale * Math.pow(x - y, 2.0) }.sum / (b.size - 1)
   }
 
   /* Compute the scores one prediction at a time */

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -3,7 +3,7 @@ package io.citrine.lolo.bags
 import breeze.stats.distributions.Poisson
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.util.{Async, InterruptibleExecutionContext}
-import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
+import io.citrine.lolo.{Learner, Model, PredictionResult, RegressionResult, TrainingResult}
 
 import scala.collection.parallel.ExecutionContextTaskSupport
 import scala.collection.parallel.immutable.ParSeq
@@ -112,7 +112,10 @@ case class Bagger(
         }, useJackknife)
         val predicted = model.transform(Seq(trainingData(idx)._1))
         val error = predicted.getExpected().head - trainingData(idx)._2.asInstanceOf[Double]
-        val uncertainty = predicted.getUncertainty().get.head.asInstanceOf[Double]
+        val uncertainty = predicted match {
+          case x: RegressionResult => x.getStdDevObs.get.head
+          case _: Any => throw new UnsupportedOperationException("Computing oobErrors for classification is not supported.")
+        }
         Some(trainingData(idx)._1, error, uncertainty)
       }
     }

--- a/src/main/scala/io/citrine/lolo/bags/BaggerUtil.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggerUtil.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.bags
 
 import io.citrine.lolo.util.Async
-import io.citrine.lolo.{Model, PredictionResult}
+import io.citrine.lolo.{Model, PredictionResult, RegressionResult}
 
 import scala.collection.parallel.immutable.ParSeq
 
@@ -42,7 +42,10 @@ protected case class BaggerHelper(
       }, useJackknife)
       val predicted = model.transform(Seq(trainingData(idx)._1))
       val error = predicted.getExpected().head - trainingData(idx)._2.asInstanceOf[Double]
-      val uncertainty = predicted.getUncertainty().get.head.asInstanceOf[Double]
+      val uncertainty = predicted match {
+        case x: RegressionResult => x.getStdDevObs.get.head
+        case _: Any => throw new UnsupportedOperationException("Computing oobErrors for classification is not supported.")
+      }
       Some(trainingData(idx)._1, error, uncertainty)
     }
   }

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -31,44 +31,71 @@ class BaggedResultTest {
     }
   }
 
+  /**
+    * Test that uncertainty estimates are within reasonable bounds.
+    */
   @Test
   def testBaggedSingleResultGetUncertainty(): Unit = {
     val noiseLevel = 100.0
     val rng = new Random(237485L)
-    Seq(RegressionTreeLearner(),GuessTheMeanLearner()).foreach{ baseLearner =>
-      Seq(30,100,301).foreach { nRows =>
-        val trainingDataTmp = TestUtils.generateTrainingData(nRows, 1, noise = 0.0, function = _ => 0.0, seed = rng.nextLong())
-        val trainingData = (trainingDataTmp).map { x => (x._1, x._2 + noiseLevel * rng.nextDouble()) }
-        val baggedLearner = Bagger(baseLearner, numBags = 2 * nRows, uncertaintyCalibration = true)
-        val RFMeta = baggedLearner.train(trainingData)
-        val RF = RFMeta.getModel()
-        val results = RF.transform(trainingData.take(1).map(_._1))
 
-        val sigmaObs: Seq[Double] = results.getUncertainty().get.asInstanceOf[Seq[Double]]
-//        sigmaMean.zip(results.asInstanceOf[RegressionResult].getStdDevMean().get).foreach{ case (a,b) =>
-//          assert(a == b, "Expected getUncertainty(observational=false)=getStdDevMean()")
-//        }
-//        val sigmaMean: Seq[Double] = results.getUncertainty(observational = false).get.asInstanceOf[Seq[Double]]
-        sigmaObs.zip(results.asInstanceOf[RegressionResult].getStdDevObs().get).foreach{ case (a,b) =>
-          assert(a == b, "Expected getUncertainty()=getStdDevObs()")
-        }
+    Seq(RegressionTreeLearner(), GuessTheMeanLearner()).foreach { baseLearner =>
+      // These are in Seqs as a convenience for repurposing this test as a diagnostic tool.
+      Seq(128).foreach { nRows =>
+        Seq(16).foreach { nCols =>
+          Seq(2).map { n => n * nRows }.foreach { nBags =>
+            // Used for error output.
+            val configDescription =s"learner=${baseLearner.getClass().toString()}\tnRows=$nRows\tnCols=$nCols\tnumBags=$nBags"
 
-//        sigmaObs.zip(sigmaMean).foreach { case (sObs, sMean) => assert(sObs > sMean, "Uncertainty should be greater when observational = true.") }
+            // Count times getStdDevObs is > and < getStdDevMean
+            var countStdObsGtStdMean = 0.0
+            var countStdObsLtStdMean = 0.0
 
-        // We have strong theoretical guarantees on the behavior of GuessTheMeanLearner, so let's exercise them.
-        // TODO(grobinson): implement similar test for RegressionTreeLearner.
-        if (baseLearner.isInstanceOf[GuessTheMeanLearner]) {
-          // NOTE: these bounds reflect a ~3x systematic variance under-estimation in this particular test setting.
-          val rtolLower = 5.0  // Future recalibration should decrease this number.
-          val rtolUpper = 1.0  // Future recalibration should increase this number.
-          sigmaObs.foreach { s =>
-            assert(rtolLower * s > noiseLevel, "Observational StdDev getUncertainty() is too small.")
-            assert(s < rtolUpper * noiseLevel, "Observational StdDev getUncertainty() is too large.")
+            (1 to 10).foreach { _ =>
+              val trainingDataTmp = TestUtils.generateTrainingData(nRows, nCols, noise = 0.0, function = _ => 0.0, seed = rng.nextLong())
+              val trainingData = (trainingDataTmp).map { x => (x._1, x._2 + noiseLevel * rng.nextDouble()) }
+              val baggedLearner = Bagger(baseLearner, numBags = nBags, uncertaintyCalibration = true)
+              val RFMeta = baggedLearner.train(trainingData)
+              val RF = RFMeta.getModel()
+              val results = RF.transform(trainingData.take(4).map(_._1))
+
+              val sigmaMean: Seq[Double] = results.getUncertainty(observational = false).get.asInstanceOf[Seq[Double]]
+              sigmaMean.zip(results.asInstanceOf[RegressionResult].getStdDevMean().get).foreach{ case (a,b) =>
+                assert(a == b, s"Expected getUncertainty(observational=false)=getStdDevMean() for $configDescription")
+              }
+
+              val sigmaObs: Seq[Double] = results.getUncertainty().get.asInstanceOf[Seq[Double]]
+              sigmaObs.zip(results.asInstanceOf[RegressionResult].getStdDevObs().get).foreach { case (a, b) =>
+                assert(a == b, s"Expected getUncertainty()=getStdDevObs() for $configDescription")
+              }
+
+              sigmaObs.zip(sigmaMean).foreach { case (sObs, sMean) =>
+                // Uncomment for diagnostic output.
+                // println(s"$configDescription\tsObs=$sObs\tsMean=$sMean")
+                if (sObs > sMean) {
+                  countStdObsGtStdMean += 1
+                } else {
+                  countStdObsLtStdMean += 1
+                }
+              }
+
+              // We have strong theoretical guarantees on the behavior of GuessTheMeanLearner, so let's exercise them.
+              // NOTE: these bounds reflect a ~3x systematic variance under-estimation in this particular test setting.
+              var rtolLower = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 3.5 else 10.0 // Future recalibration should decrease this number.
+              var rtolUpper = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 1.0 else 1.0 // Future recalibration should increase this number.
+              sigmaObs.foreach { s =>
+                assert(rtolLower * s > noiseLevel, s"Observational StdDev getUncertainty() is too small for $configDescription")
+                assert(s < rtolUpper * noiseLevel, s"Observational StdDev getUncertainty() is too large for $configDescription")
+              }
+              rtolLower = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 5.0 else 10.0 // Future recalibration should decrease this number.
+              rtolUpper = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 1.0 else 10.0 // Future recalibration should increase this number.
+              sigmaMean.foreach { s =>
+                assert(rtolLower * s > (noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too small for $configDescription.")
+                assert(s < (rtolUpper * noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too large for $configDescription")
+              }
+            assert(countStdObsGtStdMean / (countStdObsGtStdMean + countStdObsLtStdMean) > 0.9, s"Uncertainty should be greater when observational = true for $configDescription" )
           }
-//          sigmaMean.foreach { s =>
-//            assert(rtolLower * s > noiseLevel / Math.sqrt(nRows), "Mean StdDev getUncertainty(observational=false) is too small.")
-//            assert(s < rtolUpper * noiseLevel / Math.sqrt(nRows), "Mean StdDev getUncertainty(observational=false) is too large.")
-//          }
+        }
         }
       }
     }

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo.bags
 
+import breeze.stats.distributions.Beta
 import io.citrine.lolo.{RegressionResult, TestUtils}
 import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.stats.functions.Friedman
@@ -47,11 +48,7 @@ class BaggedResultTest {
             // Used for error output.
             val configDescription = s"learner=${baseLearner.getClass().toString()}\tnRows=$nRows\tnCols=$nCols\tnumBags=$nBags"
 
-            // Count times getStdDevObs is > and < getStdDevMean
-            var countStdObsGtStdMean = 0.0
-            var countStdObsLtStdMean = 0.0
-
-            (1 to 10).foreach { _ =>
+            val sigmaObsAndSigmaMean: Seq[(Double, Double)] = (1 to 20).flatMap { _ =>
               val trainingDataTmp = TestUtils.generateTrainingData(nRows, nCols, noise = 0.0, function = _ => 0.0, seed = rng.nextLong())
               val trainingData = (trainingDataTmp).map { x => (x._1, x._2 + noiseLevel * rng.nextDouble()) }
               val baggedLearner = Bagger(baseLearner, numBags = nBags, uncertaintyCalibration = true)
@@ -60,23 +57,13 @@ class BaggedResultTest {
               val results = RF.transform(trainingData.take(4).map(_._1))
 
               val sigmaMean: Seq[Double] = results.getUncertainty(observational = false).get.asInstanceOf[Seq[Double]]
-              sigmaMean.zip(results.asInstanceOf[RegressionResult].getStdDevMean().get).foreach{ case (a,b) =>
+              sigmaMean.zip(results.asInstanceOf[RegressionResult].getStdDevMean().get).foreach { case (a, b) =>
                 assert(a == b, s"Expected getUncertainty(observational=false)=getStdDevMean() for $configDescription")
               }
 
               val sigmaObs: Seq[Double] = results.getUncertainty().get.asInstanceOf[Seq[Double]]
               sigmaObs.zip(results.asInstanceOf[RegressionResult].getStdDevObs().get).foreach { case (a, b) =>
                 assert(a == b, s"Expected getUncertainty()=getStdDevObs() for $configDescription")
-              }
-
-              sigmaObs.zip(sigmaMean).foreach { case (sObs, sMean) =>
-                // Uncomment for diagnostic output.
-                // println(s"$configDescription\tsObs=$sObs\tsMean=$sMean")
-                if (sObs > sMean) {
-                  countStdObsGtStdMean += 1
-                } else {
-                  countStdObsLtStdMean += 1
-                }
               }
 
               // We have strong theoretical guarantees on the behavior of GuessTheMeanLearner, so let's exercise them.
@@ -98,20 +85,34 @@ class BaggedResultTest {
               {
                 val rtolLower = baseLearner match {
                   case _: GuessTheMeanLearner => 5.0
-                  case _: Any => 10.0
+                  case _: Any => 20.0
                 }
                 val rtolUpper = baseLearner match {
                   case _: GuessTheMeanLearner => 1.0
                   case _: Any => 10.0
                 }
                 sigmaMean.foreach { s =>
-                  assert(rtolLower * s > (noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too small for $configDescription.")
-                  assert(s < (rtolUpper * noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too large for $configDescription")
+                  assert(rtolLower * s > (noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false)=$s is too small for $configDescription.")
+                  assert(s < (rtolUpper * noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false)=$s is too large for $configDescription")
                 }
               }
-            assert(countStdObsGtStdMean / (countStdObsGtStdMean + countStdObsLtStdMean) > 0.9, s"Uncertainty should be greater when observational = true for $configDescription" )
+
+              // Uncomment for diagnostic output.
+              // sigmaObs.zip(sigmaMean).foreach { case (sObs, sMean) =>
+              //   println(s"$configDescription\tsObs=$sObs\tsMean=$sMean")
+              //}
+
+              sigmaObs.zip(sigmaMean)
+            }
+
+            val countSigmaObsGreater = sigmaObsAndSigmaMean.count { case (sObs, sMean) => sObs > sMean }.toDouble
+            // Posterior beta distribution, with Jeffreys prior, over rate at which sObs > sMean.
+            val d = new Beta(countSigmaObsGreater + 0.5, sigmaObsAndSigmaMean.length - countSigmaObsGreater + 0.5)
+            val minRateSigmaObsGreater = 0.9
+            val level = 1e-4
+            val probSigmaObsLess = d.cdf(minRateSigmaObsGreater)
+            assert(probSigmaObsLess < level, s"Uncertainty should be greater when observational = true for $configDescription")
           }
-        }
         }
       }
     }

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -85,7 +85,7 @@ class BaggedResultTest {
               {
                 val rtolLower = baseLearner match {
                   case _: GuessTheMeanLearner => 5.0
-                  case _: Any => 20.0
+                  case _: Any => 1e3
                 }
                 val rtolUpper = baseLearner match {
                   case _: GuessTheMeanLearner => 1.0

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -100,7 +100,7 @@ class BaggedResultTest {
               // Uncomment for diagnostic output.
               // sigmaObs.zip(sigmaMean).foreach { case (sObs, sMean) =>
               //   println(s"$configDescription\tsObs=$sObs\tsMean=$sMean")
-              //}
+              // }
 
               sigmaObs.zip(sigmaMean)
             }

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.bags
 
-import io.citrine.lolo.{RegressionResult, TestUtils}
+import io.citrine.lolo.TestUtils
 import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -98,7 +98,7 @@ class MultiTaskBaggerTest {
               }
               {
                 val rtolLower = baseLearner match {
-                  case _: MultiTaskTreeLearner => 20.0
+                  case _: MultiTaskTreeLearner => 1e3
                   case _: Any => fail("Not implemented.")
                 }
                 val rtolUpper = baseLearner match {

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -113,7 +113,7 @@ class MultiTaskBaggerTest {
                 // Uncomment for diagnostic output.
                 // sigmaObs.zip(sigmaMean).foreach { case (sObs, sMean) =>
                 //   println(s"$configDescription\tsObs=$sObs\tsMean=$sMean")
-                //}
+                // }
               }
 
               sigmaObs.zip(sigmaMean)

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -96,19 +96,35 @@ class MultiTaskBaggerTest {
 
               // We have strong theoretical guarantees on the behavior of GuessTheMeanLearner, so let's exercise them.
               // NOTE: these bounds reflect a ~3x systematic variance under-estimation in this particular test setting.
-              var rtolLower = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 3.5 else 10.0 // Future recalibration should decrease this number.
-              var rtolUpper = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 1.0 else 1.0 // Future recalibration should increase this number.
-              sigmaObs.foreach { s =>
-                assert(rtolLower * s > noiseLevel, s"Observational StdDev getUncertainty() is too small for $configDescription")
-                assert(s < rtolUpper * noiseLevel, s"Observational StdDev getUncertainty() is too large for $configDescription")
+              {
+                val rtolLower = baseLearner match {
+                  case _: GuessTheMeanLearner => 3.5
+                  case _: Any => 10.0
+                }
+                val rtolUpper = baseLearner match {
+                  case _: GuessTheMeanLearner => 1.0
+                  case _: Any => 1.0
+                }
+                sigmaObs.foreach { s =>
+                  assert(rtolLower * s > noiseLevel, s"Observational StdDev getUncertainty() is too small for $configDescription")
+                  assert(s < rtolUpper * noiseLevel, s"Observational StdDev getUncertainty() is too large for $configDescription")
+                }
               }
-              rtolLower = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 5.0 else 10.0 // Future recalibration should decrease this number.
-              rtolUpper = if (baseLearner.isInstanceOf[GuessTheMeanLearner]) 1.0 else 10.0 // Future recalibration should increase this number.
-              sigmaMean.foreach { s =>
-                assert(rtolLower * s > (noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too small for $configDescription.")
-                assert(s < (rtolUpper * noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too large for $configDescription")
+              {
+                val rtolLower = baseLearner match {
+                  case _: GuessTheMeanLearner => 5.0
+                  case _: Any => 10.0
+                }
+                val rtolUpper = baseLearner match {
+                  case _: GuessTheMeanLearner => 1.0
+                  case _: Any => 10.0
+                }
+                sigmaMean.foreach { s =>
+                  assert(rtolLower * s > (noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too small for $configDescription.")
+                  assert(s < (rtolUpper * noiseLevel / Math.sqrt(nRows)), s"Mean StdDev getUncertainty(observational=false) is too large for $configDescription")
+                }
               }
-              assert(countStdObsGtStdMean / (countStdObsGtStdMean + countStdObsLtStdMean) > 0.9, s"Uncertainty should be greater when observational = true for $configDescription" )
+              assert(countStdObsGtStdMean / (countStdObsGtStdMean + countStdObsLtStdMean) > 0.9, s"Uncertainty should be greater when observational = true for $configDescription")
             }
           }
         }


### PR DESCRIPTION
This PR adds a sanity check on reported standard deviations for regression, and re-applies the conversion to using the rescaled bootstrap ensemble for predictive uncertainty and jackknife for standard error. This PR is a step toward fixing https://github.com/CitrineInformatics/lolo/issues/207 and also implements the Bessel correction (https://github.com/CitrineInformatics/lolo/issues/213).