### PR TITLE
Make tests less flaky.

### DIFF
--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -292,6 +292,12 @@ class RandomForestMixin(BaseLoloLearner):
         self.random_seed = random_seed
 
     def _make_learner(self):
+        rng = self.gateway.jvm.scala.util.Random(
+            getattr(self.gateway.jvm.scala.util.Random,
+                    "$lessinit$greater$default$1")() if self.random_seed is None
+            else self.gateway.jvm.scala.util.Random(self.random_seed)
+        )
+
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
         #  TODO: that ^^, please
         learner = self.gateway.jvm.io.citrine.lolo.learners.RandomForest(
@@ -308,7 +314,7 @@ class RandomForestMixin(BaseLoloLearner):
             self.uncertainty_calibration,
             self.randomize_pivot_location,
             self.randomly_rotate_features,
-            random.getrandbits(64) if self.random_seed is None else self.random_seed
+            self.rng
         )
         return learner
 
@@ -356,10 +362,10 @@ class RegressionTreeLearner(BaseLoloRegressor):
             "$lessinit$greater$default$5"
         )()
 
-        rng = self.gateway.jvm.scala.Random(
-            getattr(self.gateway.jvm.scala.Random,
+        rng = self.gateway.jvm.scala.util.Random(
+            getattr(self.gateway.jvm.scala.util.Random,
                     "$lessinit$greater$default$1")() if self.random_seed is None
-            else self.gateway.jvm.scala.Random(self.random_seed)
+            else self.gateway.jvm.scala.util.Random(self.random_seed)
         )
 
         return self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner(

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -3,6 +3,7 @@ from abc import abstractmethod, ABCMeta
 import numpy as np
 from lolopy.loloserver import get_java_gateway
 from lolopy.utils import send_feature_array, send_1D_array
+import random
 from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin, is_regressor
 from sklearn.exceptions import NotFittedError
 
@@ -253,7 +254,7 @@ class RandomForestMixin(BaseLoloLearner):
     def __init__(self, num_trees=-1, use_jackknife=True, bias_learner=None,
                  leaf_learner=None, subset_strategy="auto", min_leaf_instances=1,
                  max_depth=2**30, uncertainty_calibration=False, randomize_pivot_location=False,
-                 randomly_rotate_features=False):
+                 randomly_rotate_features=False, random_seed=None):
         """Initialize the RandomForest
 
         Args:
@@ -273,6 +274,7 @@ class RandomForestMixin(BaseLoloLearner):
             uncertainty_calibration (bool): whether to re-calibrate the predicted uncertainty based on out-of-bag residuals
             randomize_pivot_location (bool): whether to draw pivots randomly or always select the midpoint
             randomly_rotate_features (bool): whether to randomly rotate real features for each tree in the forest
+            random_seed (int): random number generator seed used for nondeterministic functionality
         """
         super(RandomForestMixin, self).__init__()
 
@@ -287,6 +289,7 @@ class RandomForestMixin(BaseLoloLearner):
         self.uncertainty_calibration = uncertainty_calibration
         self.randomize_pivot_location = randomize_pivot_location
         self.randomly_rotate_features = randomly_rotate_features
+        self.random_seed = random_seed
 
     def _make_learner(self):
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
@@ -304,7 +307,8 @@ class RandomForestMixin(BaseLoloLearner):
             self.max_depth,
             self.uncertainty_calibration,
             self.randomize_pivot_location,
-            self.randomly_rotate_features
+            self.randomly_rotate_features,
+            random.getrandbits(64) if self.random_seed is None else self.random_seed
         )
         return learner
 

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -324,7 +324,7 @@ class RandomForestClassifier(BaseLoloClassifier, RandomForestMixin):
 class RegressionTreeLearner(BaseLoloRegressor):
     """Regression tree learner, based on the RandomTree algorithm."""
 
-    def __init__(self, num_features=-1, max_depth=30, min_leaf_instances=1, leaf_learner=None):
+    def __init__(self, num_features=-1, max_depth=30, min_leaf_instances=1, leaf_learner=None, random_seed=None):
         """Initialize the learner
 
         Args:
@@ -338,6 +338,7 @@ class RegressionTreeLearner(BaseLoloRegressor):
         self.max_depth = max_depth
         self.min_leaf_instances = min_leaf_instances
         self.leaf_learner = leaf_learner
+        self.random_seed = random_seed
 
     def _make_learner(self):
         if self.leaf_learner is None:
@@ -355,9 +356,15 @@ class RegressionTreeLearner(BaseLoloRegressor):
             "$lessinit$greater$default$5"
         )()
 
+        rng = self.gateway.jvm.scala.Random(
+            getattr(self.gateway.jvm.scala.Random,
+                    "$lessinit$greater$default$1")() if self.random_seed is None
+            else self.gateway.jvm.scala.Random(self.random_seed)
+        )
+
         return self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner(
             self.num_features, self.max_depth, self.min_leaf_instances,
-            leaf_learner, splitter
+            leaf_learner, splitter, rng
         )
 
 class LinearRegression(BaseLoloRegressor):

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -292,11 +292,7 @@ class RandomForestMixin(BaseLoloLearner):
         self.random_seed = random_seed
 
     def _make_learner(self):
-        rng = self.gateway.jvm.scala.util.Random(
-            getattr(self.gateway.jvm.scala.util.Random,
-                    "$lessinit$greater$default$1")() if self.random_seed is None
-            else self.gateway.jvm.scala.util.Random(self.random_seed)
-        )
+        rng = self.gateway.jvm.scala.util.Random() if self.random_seed is None else self.gateway.jvm.scala.util.Random(self.random_seed)
 
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
         #  TODO: that ^^, please
@@ -314,7 +310,7 @@ class RandomForestMixin(BaseLoloLearner):
             self.uncertainty_calibration,
             self.randomize_pivot_location,
             self.randomly_rotate_features,
-            self.rng
+            rng
         )
         return learner
 
@@ -362,11 +358,7 @@ class RegressionTreeLearner(BaseLoloRegressor):
             "$lessinit$greater$default$5"
         )()
 
-        rng = self.gateway.jvm.scala.util.Random(
-            getattr(self.gateway.jvm.scala.util.Random,
-                    "$lessinit$greater$default$1")() if self.random_seed is None
-            else self.gateway.jvm.scala.util.Random(self.random_seed)
-        )
+        rng = self.gateway.jvm.scala.util.Random() if self.random_seed is None else self.gateway.jvm.scala.util.Random(self.random_seed)
 
         return self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner(
             self.num_features, self.max_depth, self.min_leaf_instances,

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -27,7 +27,11 @@ def _call_lolo_merit(metric_name, y_true, y_pred, y_std=None, *args):
 
     # Get the metric object
     gateway = get_java_gateway()
-    metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)(*args)
+    metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
+    if len(args) > 0:
+        metric = metric(*args)
+    else:
+        metric = metric()
 
     # Convert the data arrays to Java
     y_true_java = send_1D_array(gateway, y_true, True)
@@ -83,7 +87,7 @@ def standard_error(y_true, y_pred, y_std, rescale=1.0):
     return _call_lolo_merit('StandardError', y_true, y_pred, y_std, float(rescale))
 
 
-def uncertainty_correlation(y_true, y_pred, y_std):
+def uncertainty_correlation(y_true, y_pred, y_std, random_seed=None):
     """Measure of the correlation between the predicted uncertainty and error magnitude
     
     Args:
@@ -94,6 +98,8 @@ def uncertainty_correlation(y_true, y_pred, y_std):
         (double):
     """
 
-    return _call_lolo_merit('UncertaintyCorrelation', y_true, y_pred, y_std)
+    gateway = get_java_gateway()
+    rng = gateway.jvm.scala.util.Random() if random_seed is None else self.gateway.jvm.scala.util.Random(random_seed)
+    return _call_lolo_merit('UncertaintyCorrelation', y_true, y_pred, y_std, rng)
 
 

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -16,7 +16,7 @@ def _call_lolo_merit(metric_name, y_true, y_pred, y_std=None, *args):
         y_true ([double]): True value
         y_pred ([double]): Predicted values
         y_uncert ([double]): Prediction uncertainties
-        *args (list): Any paramters to the constructor of the Metric
+        *args (list): Any parameters to the constructor of the Metric
     Returns:
         (double): Metric score
     """
@@ -27,9 +27,7 @@ def _call_lolo_merit(metric_name, y_true, y_pred, y_std=None, *args):
 
     # Get the metric object
     gateway = get_java_gateway()
-    metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
-    if len(args) > 0:
-        metric = metric(*args)
+    metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)(*args)
 
     # Convert the data arrays to Java
     y_true_java = send_1D_array(gateway, y_true, True)

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -8,7 +8,7 @@ from lolopy.utils import send_1D_array
 import numpy as np
 
 
-def _call_lolo_merit(metric_name, y_true, y_pred, y_std=None, *args):
+def _call_lolo_merit(metric_name, y_true, y_pred, rng, y_std=None, *args):
     """Call a metric from lolopy
     
     Args:
@@ -25,13 +25,13 @@ def _call_lolo_merit(metric_name, y_true, y_pred, y_std=None, *args):
     if y_std is None:
         y_std = np.ones(len(y_true))
 
-    # Get the metric object
     gateway = get_java_gateway()
+    # Get default rng
+    rng = rng if rng else gateway.jvm.scala.util.Random()
+    # Get the metric object
     metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
     if len(args) > 0:
         metric = metric(*args)
-    else:
-        metric = metric()
 
     # Convert the data arrays to Java
     y_true_java = send_1D_array(gateway, y_true, True)
@@ -42,10 +42,10 @@ def _call_lolo_merit(metric_name, y_true, y_pred, y_std=None, *args):
     pred_result = gateway.jvm.io.citrine.lolo.util.LoloPyDataLoader.makeRegressionPredictionResult(y_pred_java, y_std_java)
 
     # Run the prediction result through the metric
-    return metric.evaluate(pred_result, y_true_java)
+    return metric.evaluate(pred_result, y_true_java, rng)
 
 
-def root_mean_squared_error(y_true, y_pred):
+def root_mean_squared_error(y_true, y_pred, rng=None):
     """Compute the root mean squared error
     
     Args:
@@ -55,10 +55,10 @@ def root_mean_squared_error(y_true, y_pred):
         (double): RMSE
     """
 
-    return _call_lolo_merit('RootMeanSquareError', y_true, y_pred)
+    return _call_lolo_merit('RootMeanSquareError', y_true, y_pred, rng)
 
 
-def standard_confidence(y_true, y_pred, y_std):
+def standard_confidence(y_true, y_pred, y_std, rng=None):
     """Fraction of entries that have errors within the predicted confidence interval. 
     
     Args:
@@ -69,10 +69,10 @@ def standard_confidence(y_true, y_pred, y_std):
         (double): standard confidence
     """
 
-    return _call_lolo_merit('StandardConfidence', y_true, y_pred, y_std)
+    return _call_lolo_merit('StandardConfidence', y_true, y_pred, rng, y_std)
 
 
-def standard_error(y_true, y_pred, y_std, rescale=1.0):
+def standard_error(y_true, y_pred, y_std, rng=None, rescale=1.0):
     """Root mean square of the error divided by the predicted uncertainty 
     
     Args:
@@ -84,10 +84,10 @@ def standard_error(y_true, y_pred, y_std, rescale=1.0):
         (double): standard error
     """
 
-    return _call_lolo_merit('StandardError', y_true, y_pred, y_std, float(rescale))
+    return _call_lolo_merit('StandardError', y_true, y_pred, rng, y_std, float(rescale))
 
 
-def uncertainty_correlation(y_true, y_pred, y_std, random_seed=None):
+def uncertainty_correlation(y_true, y_pred, y_std, rng=None):
     """Measure of the correlation between the predicted uncertainty and error magnitude
     
     Args:
@@ -97,9 +97,4 @@ def uncertainty_correlation(y_true, y_pred, y_std, random_seed=None):
     Returns:
         (double):
     """
-
-    gateway = get_java_gateway()
-    rng = gateway.jvm.scala.util.Random() if random_seed is None else self.gateway.jvm.scala.util.Random(random_seed)
-    return _call_lolo_merit('UncertaintyCorrelation', y_true, y_pred, y_std, rng)
-
-
+    return _call_lolo_merit('UncertaintyCorrelation', y_true, y_pred, rng, y_std)

--- a/python/lolopy/tests/test_metrics.py
+++ b/python/lolopy/tests/test_metrics.py
@@ -1,3 +1,4 @@
+from lolopy.loloserver import get_java_gateway
 from lolopy.metrics import (root_mean_squared_error, standard_confidence, standard_error, uncertainty_correlation)
 from numpy.random import multivariate_normal, uniform, normal, seed
 from unittest import TestCase
@@ -10,16 +11,20 @@ class TestMetrics(TestCase):
         self.assertAlmostEqual(root_mean_squared_error([4, 5], [1, 2]), 3)
 
     def test_standard_confidene(self):
-        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 0.9]), 0.5)
-        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 1.1]), 1)
+        gateway = get_java_gateway()
+        rng = gateway.jvm.scala.util.Random(367894)
+        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 0.9]), 0.5, rng)
+        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 1.1]), 1, rng)
 
     def test_standard_error(self):
         self.assertAlmostEqual(standard_error([1, 2], [1, 2], [1, 1]), 0)
         self.assertAlmostEqual(standard_error([4, 5], [1, 2], [3, 3]), 1)
 
     def test_uncertainty_correlation(self):
-        seed(1)
+        seed(3893789455)
         sample_size = 2 ** 15
+        gateway = get_java_gateway()
+        rng = gateway.jvm.scala.util.Random(783245)
         for expected in [0, 0.75]:
             # Make the error distribution
             y_true = uniform(0, 1, sample_size)
@@ -32,6 +37,6 @@ class TestMetrics(TestCase):
             y_std = [abs(d[1]) for d in draw]
 
             # Test with a very large tolerance for now
-            measured_corr = uncertainty_correlation(y_true, y_pred, y_std)
+            measured_corr = uncertainty_correlation(y_true, y_pred, y_std, rng = rng)
             corr_error = abs(measured_corr - expected)
             self.assertLess(corr_error, 0.25, 'Error for {:.2f}: {:.2f}'.format(expected, corr_error))

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.bags
 
-import breeze.stats.distributions.Poisson
+import breeze.stats.distributions.{Poisson, Rand, RandBasis}
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.util.{Async, InterruptibleExecutionContext}
 import io.citrine.lolo.{Learner, Model, PredictionResult, RegressionResult, TrainingResult}
@@ -22,7 +22,8 @@ case class Bagger(
                    numBags: Int = -1,
                    useJackknife: Boolean = true,
                    biasLearner: Option[Learner] = None,
-                   uncertaintyCalibration: Boolean = false
+                   uncertaintyCalibration: Boolean = false,
+                   randBasis: RandBasis = Rand
                  ) extends Learner {
 
   /**
@@ -66,7 +67,7 @@ case class Bagger(
     )
 
     /* Compute the number of instances of each training row in each training sample */
-    val dist = new Poisson(1.0)
+    val dist = new Poisson(1.0)(randBasis)
     val Nib: Vector[Vector[Int]] = Iterator.continually{
       // Generate Poisson distributed weights, filtering out any that don't have the minimum required number
       // of non-zero training weights

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.bags
 
-import breeze.stats.distributions.Poisson
+import breeze.stats.distributions.{Poisson, Rand, RandBasis}
 import io.citrine.lolo._
 import io.citrine.lolo.util.{Async, InterruptibleExecutionContext}
 
@@ -18,7 +18,8 @@ case class MultiTaskBagger(
                             numBags: Int = -1,
                             useJackknife: Boolean = true,
                             biasLearner: Option[Learner] = None,
-                            uncertaintyCalibration: Boolean = false
+                            uncertaintyCalibration: Boolean = false,
+                            randBasis: RandBasis = Rand
                           ) extends MultiTaskLearner {
 
   private def combineImportance(v1: Option[Vector[Double]], v2: Option[Vector[Double]]): Option[Vector[Double]] = {
@@ -52,7 +53,7 @@ case class MultiTaskBagger(
     }
 
     /* Compute the number of instances of each training row in each training sample */
-    val dist = new Poisson(1.0)
+    val dist = new Poisson(1.0)(randBasis)
     val Nib = Vector.tabulate(actualBags) { _ =>
       Vector.tabulate(inputs.size) { _ =>
         dist.draw()

--- a/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
@@ -11,7 +11,7 @@ import scala.util.Random
   * calls.
   * Created by maxhutch on 12/7/16.
   */
-class RandomHyperOptimizer() extends HyperOptimizer {
+class RandomHyperOptimizer(rng: Random = Random) extends HyperOptimizer {
 
   /** Keep track of the best hypers outside of the optimize call so it persists across calls */
   var best: Map[String, Any] = Map()
@@ -29,7 +29,7 @@ class RandomHyperOptimizer() extends HyperOptimizer {
     /* Just draw numIteration times */
     (0 until numIterations).foreach { i =>
       val testHypers = hyperGrids.map { case (n, v) =>
-        n -> Random.shuffle(v).head
+        n -> rng.shuffle(v).head
       }
       val testLearner = builder(testHypers)
       val res = testLearner.train(trainingData)

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -26,7 +26,7 @@ import scala.util.Random
   * @param uncertaintyCalibration whether to empirically recalibrate the predicted uncertainties (default: false)
   * @param randomizePivotLocation whether generate splits randomly between the data points (default: false)
   * @param randomlyRotateFeatures whether to randomly rotate real features for each tree in the forest (default: false)
-  * @param randomSeed     to use for stochastic functionality (default of Long.MaxValue sets a new random seed for each invocation)
+  * @param rng            random number generator to use for stochastic functionality
   */
 case class RandomForest(
                          numTrees: Int = -1,
@@ -39,14 +39,8 @@ case class RandomForest(
                          uncertaintyCalibration: Boolean = false,
                          randomizePivotLocation: Boolean = false,
                          randomlyRotateFeatures: Boolean = false,
-                         randomSeed: Long = Long.MaxValue
+                         rng: Random = Random
                        ) extends Learner {
-
-  val rng: Random = if (randomSeed == Long.MaxValue) {
-    new Random()
-  } else {
-    new Random(randomSeed)
-  }
 
   /**
     * Train a random forest model

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -7,7 +7,7 @@ import scala.util.Random
 /**
   * Created by maxhutch on 11/15/16.
   */
-case class GuessTheMeanLearner() extends Learner {
+case class GuessTheMeanLearner(rng: Random = Random) extends Learner {
 
   /**
     * Train a model
@@ -20,7 +20,7 @@ case class GuessTheMeanLearner() extends Learner {
     val data = trainingData.map(_._2).zip(weights.getOrElse(Seq.fill(trainingData.size)(1.0)))
     val mean = data.head._1 match {
       case x: Double => data.asInstanceOf[Seq[(Double, Double)]].map(p => p._1 * p._2).sum / data.map(_._2).sum
-      case x: Any => Random.shuffle(data.groupBy(_._1).mapValues(_.map(_._2).sum).toSeq).maxBy(_._2)._1
+      case x: Any => rng.shuffle(data.groupBy(_._1).mapValues(_.map(_._2).sum).toSeq).maxBy(_._2)._1
     }
 
     new GuessTheMeanTrainingResult(new GuessTheMeanModel(mean))

--- a/src/main/scala/io/citrine/lolo/stats/functions/Linear.scala
+++ b/src/main/scala/io/citrine/lolo/stats/functions/Linear.scala
@@ -21,10 +21,10 @@ object Linear {
     * @param magnitude of the gradient (default: 1)
     * @return linear function with specified gradient magnitude in a random direction
     */
-  def randomDirection(nDim: Int, magnitude: Double = 1.0): Linear = {
+  def randomDirection(nDim: Int, magnitude: Double = 1.0, rng: Random = Random): Linear = {
     val gradient = {
       // Draw guassian so the direction is random rather than preferring corners
-      val unnormalized = Seq.fill(nDim){Random.nextGaussian()}
+      val unnormalized = Seq.fill(nDim){rng.nextGaussian()}
       val norm = Math.sqrt(unnormalized.map(Math.pow(_, 2)).sum)
       unnormalized.map(x => x * magnitude / norm)
     }

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -6,6 +6,8 @@ import io.citrine.lolo.trees.splits.{ClassificationSplitter, NoSplit, Splitter}
 import io.citrine.lolo.trees.{ModelNode, TrainingLeaf, TrainingNode, TreeMeta}
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 
+import scala.util.Random
+
 
 /**
   * Created by maxhutch on 12/2/16.
@@ -17,10 +19,11 @@ case class ClassificationTreeLearner(
                                       maxDepth: Int = 30,
                                       minLeafInstances: Int = 1,
                                       leafLearner: Option[Learner] = None,
-                                      splitter: Splitter[Char] = ClassificationSplitter()
+                                      splitter: Splitter[Char] = ClassificationSplitter(),
+                                      rng: Random = Random
                                     ) extends Learner {
 
-  @transient private lazy val myLeafLearner: Learner = leafLearner.getOrElse(new GuessTheMeanLearner)
+  @transient private lazy val myLeafLearner: Learner = leafLearner.getOrElse(GuessTheMeanLearner(rng = rng))
 
   /**
     * Train classification tree

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
@@ -5,6 +5,8 @@ import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.trees.splits.{MultiTaskSplitter, NoSplit}
 import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingLeaf}
 
+import scala.util.Random
+
 /**
   * Node in a multi-task training tree, which can produce nodes for its model trees
   *
@@ -12,18 +14,19 @@ import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingLeaf}
   */
 class MultiTaskTrainingNode(
                              inputs: Seq[(Vector[AnyVal], Array[AnyVal], Double)],
-                             randomizePivotLocation: Boolean = false
+                             randomizePivotLocation: Boolean = false,
+                             rng: Random = Random
                            ) {
 
   // Compute a split
-  val (split, _) = MultiTaskSplitter.getBestSplit(inputs, inputs.head._1.size, 1, randomizePivotLocation)
+  val (split, _) = MultiTaskSplitter(rng = rng).getBestSplit(inputs, inputs.head._1.size, 1, randomizePivotLocation)
 
   // Try to construct left and right children
   val (leftChild: Option[MultiTaskTrainingNode], rightChild: Option[MultiTaskTrainingNode]) = split match {
     case _: NoSplit => (None, None)
     case _: Any =>
       val (leftData, rightData) = inputs.partition(row => split.turnLeft(row._1))
-      (Some(new MultiTaskTrainingNode(leftData, randomizePivotLocation)), Some(new MultiTaskTrainingNode(rightData, randomizePivotLocation)))
+      (Some(new MultiTaskTrainingNode(leftData, randomizePivotLocation, rng = rng)), Some(new MultiTaskTrainingNode(rightData, randomizePivotLocation, rng = rng)))
   }
 
   // Construct the model node for the `index`th label

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -6,12 +6,15 @@ import io.citrine.lolo.trees.classification.ClassificationTree
 import io.citrine.lolo.trees.regression.RegressionTree
 import io.citrine.lolo.{Model, MultiTaskLearner, PredictionResult, TrainingResult}
 
+import scala.util.Random
+
 /**
   * Multi-task tree learner, which produces multiple decision trees with the same split structure
   *
   */
 case class MultiTaskTreeLearner(
-                                 randomizePivotLocation: Boolean = false
+                                 randomizePivotLocation: Boolean = false,
+                                 rng: Random = Random
                                ) extends MultiTaskLearner {
 
   /**

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -7,6 +7,8 @@ import io.citrine.lolo.trees.splits.{NoSplit, RegressionSplitter}
 import io.citrine.lolo.trees.{ModelNode, TrainingNode, TreeMeta}
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 
+import scala.util.Random
+
 /**
   * Learner for regression trees
   *
@@ -22,10 +24,11 @@ case class RegressionTreeLearner(
                                   maxDepth: Int = 30,
                                   minLeafInstances: Int = 1,
                                   leafLearner: Option[Learner] = None,
-                                  splitter: Splitter[Double] = RegressionSplitter()
+                                  splitter: Splitter[Double] = RegressionSplitter(),
+                                  rng: Random = Random
                                 ) extends Learner {
   /** Learner to use for training the leaves */
-  @transient private lazy val myLeafLearner = leafLearner.getOrElse(GuessTheMeanLearner())
+  @transient private lazy val myLeafLearner = leafLearner.getOrElse(GuessTheMeanLearner(rng))
 
   /**
     * Train the tree by recursively partitioning (splitting) the training data on a single feature

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -28,7 +28,7 @@ case class RegressionTreeLearner(
                                   rng: Random = Random
                                 ) extends Learner {
   /** Learner to use for training the leaves */
-  @transient private lazy val myLeafLearner = leafLearner.getOrElse(GuessTheMeanLearner(rng))
+  @transient private lazy val myLeafLearner = leafLearner.getOrElse(GuessTheMeanLearner(rng = rng))
 
   /**
     * Train the tree by recursively partitioning (splitting) the training data on a single feature

--- a/src/main/scala/io/citrine/lolo/trees/splits/BoltzmannSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/BoltzmannSplitter.scala
@@ -30,7 +30,7 @@ import scala.util.Random
   * @param temperature used to control how sensitive the probability of a split is to its change in variance.
   *                    The temperature can be thought of as a hyperparameter.
   */
-case class BoltzmannSplitter(temperature: Double) extends Splitter[Double] {
+case class BoltzmannSplitter(temperature: Double, rng: Random = Random) extends Splitter[Double] {
   require(temperature >= Float.MinPositiveValue, s"Temperature must be >= ${Float.MinPositiveValue} to avoid numerical underflows")
 
   /**
@@ -58,11 +58,11 @@ case class BoltzmannSplitter(temperature: Double) extends Splitter[Double] {
     /* Try every feature index */
     val featureIndices: Seq[Int] = rep._1.indices
 
-    val possibleSplits: Seq[SplitterResult] = Random.shuffle(featureIndices).take(numFeatures).flatMap { index =>
+    val possibleSplits: Seq[SplitterResult] = rng.shuffle(featureIndices).take(numFeatures).flatMap { index =>
       /* Use different spliters for each type */
       rep._1(index) match {
-        case _: Double => BoltzmannSplitter.getBestRealSplit(data, calculator, index, minInstances, beta)
-        case _: Char => BoltzmannSplitter.getBestCategoricalSplit(data, calculator, index, minInstances, beta)
+        case _: Double => BoltzmannSplitter.getBestRealSplit(data, calculator, index, minInstances, beta, rng)
+        case _: Char => BoltzmannSplitter.getBestCategoricalSplit(data, calculator, index, minInstances, beta, rng)
         case _: Any => throw new IllegalArgumentException("Trying to split unknown feature type")
       }
     }
@@ -79,7 +79,7 @@ case class BoltzmannSplitter(temperature: Double) extends Splitter[Double] {
 
     // select from a discrete probability distribution by drawing a random number and then computing the CDF
     // where the "draw" is the bin for which the CDF crosses the drawn number
-    val draw = Random.nextDouble() * totalProbability
+    val draw = rng.nextDouble() * totalProbability
     // could be a scanLeft + find, but this is more readable
     var cumSum: Double = 0.0
     possibleSplits.foreach { case SplitterResult(split, variance, score, base) =>
@@ -125,7 +125,8 @@ object BoltzmannSplitter {
                         calculator: VarianceCalculator,
                         index: Int,
                         minCount: Int,
-                        beta: Double
+                        beta: Double,
+                        rng: Random
                       ): Option[SplitterResult] = {
     /* Pull out the feature that's considered here and sort by it */
     val thinData = data.map(dat => (dat._1(index).asInstanceOf[Double], dat._2, dat._3)).sortBy(_._1)
@@ -144,7 +145,7 @@ object BoltzmannSplitter {
       val right = thinData(j)._1
       if (j + 1 >= minCount && Splitter.isDifferent(left, right)) {
         val score = -totalVariance * beta
-        val pivot = (left - right) * Random.nextDouble() + right
+        val pivot = (left - right) * rng.nextDouble() + right
         Some(score, pivot, totalVariance)
       } else {
         None
@@ -157,7 +158,7 @@ object BoltzmannSplitter {
 
     val base: Double = possibleSplits.map(_._1).max
     val totalScore = possibleSplits.map { case (s, _, _) => Math.exp(s - base) }.sum
-    val draw = Random.nextDouble() * totalScore
+    val draw = rng.nextDouble() * totalScore
     var cumSum: Double = 0.0
     possibleSplits.foreach { case (score, pivot, variance) =>
       cumSum = cumSum + Math.exp(score - base)
@@ -184,7 +185,8 @@ object BoltzmannSplitter {
                                calculator: VarianceCalculator,
                                index: Int,
                                minCount: Int,
-                               beta: Double
+                               beta: Double,
+                               rng: Random
                              ): Option[SplitterResult] = {
     /* Extract the features at the index */
     val thinData = data.map(dat => (dat._1(index).asInstanceOf[Char], dat._2, dat._3))
@@ -230,7 +232,7 @@ object BoltzmannSplitter {
 
     val base: Double = possibleSplits.map(_._1).max
     val totalScore = possibleSplits.map { case (s, _, _) => Math.exp(s - base) }.sum
-    val draw = Random.nextDouble() * totalScore
+    val draw = rng.nextDouble() * totalScore
     var cumSum: Double = 0.0
     possibleSplits.foreach { case (score, includeSet, variance) =>
       cumSum = cumSum + Math.exp(score - base)

--- a/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
@@ -9,7 +9,7 @@ import scala.util.Random
   *
   * Created by maxhutch on 12/2/16.
   */
-case class ClassificationSplitter(randomizedPivotLocation: Boolean = false) extends Splitter[Char]{
+case class ClassificationSplitter(randomizedPivotLocation: Boolean = false, rng: Random = Random) extends Splitter[Char]{
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)
@@ -33,7 +33,7 @@ case class ClassificationSplitter(randomizedPivotLocation: Boolean = false) exte
     val rep = data.head
     /* Try every feature index */
     val featureIndices: Seq[Int] = rep._1.indices
-    Random.shuffle(featureIndices).take(numFeatures).foreach { index =>
+    rng.shuffle(featureIndices).take(numFeatures).foreach { index =>
 
       /* Use different spliters for each type */
       val (possibleSplit, possibleImpurity) = rep._1(index) match {
@@ -98,7 +98,7 @@ case class ClassificationSplitter(randomizedPivotLocation: Boolean = false) exte
         val left = thinData(j + 1)._1
         val right = thinData(j)._1
         bestPivot = if (randomizePivotLocation) {
-          (left - right) * Random.nextDouble() + right
+          (left - right) * rng.nextDouble() + right
         } else {
           (left + right) / 2.0
         }

--- a/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
@@ -8,7 +8,7 @@ import scala.util.Random
   *
   * Created by maxhutch on 11/29/16.
   */
-object MultiTaskSplitter {
+case class MultiTaskSplitter(rng: Random = Random) {
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)
@@ -33,7 +33,7 @@ object MultiTaskSplitter {
 
     /* Try every feature index */
     val featureIndices: Seq[Int] = rep._1.indices
-    Random.shuffle(featureIndices).take(numFeatures).foreach { index =>
+    rng.shuffle(featureIndices).take(numFeatures).foreach { index =>
 
       /* Use different spliters for each type */
       val (possibleSplit, possibleImpurity) = rep._1(index) match {
@@ -82,7 +82,7 @@ object MultiTaskSplitter {
         val left = features(j + 1)
         val right = features(j)
         val pivot = if (randomizePivotLocation) {
-          (left - right) * Random.nextDouble() + right
+          (left - right) * rng.nextDouble() + right
         } else {
           (left + right) / 2.0
         }

--- a/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
@@ -20,7 +20,7 @@ import scala.util.Random
   *
   * Created by maxhutch on 11/29/16.
   */
-case class RegressionSplitter(randomizePivotLocation: Boolean = false) extends Splitter[Double] {
+case class RegressionSplitter(randomizePivotLocation: Boolean = false, rng: Random = Random) extends Splitter[Double] {
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)
@@ -44,7 +44,7 @@ case class RegressionSplitter(randomizePivotLocation: Boolean = false) extends S
 
     /* Try every feature index */
     val featureIndices: Seq[Int] = rep._1.indices
-    Random.shuffle(featureIndices).take(numFeatures).foreach { index =>
+    rng.shuffle(featureIndices).take(numFeatures).foreach { index =>
 
       /* Use different spliters for each type */
       val (possibleSplit, possibleVariance) = rep._1(index) match {
@@ -111,7 +111,7 @@ case class RegressionSplitter(randomizePivotLocation: Boolean = false) extends S
         bestVariance = totalVariance
         /* Try pivots at the midpoints between consecutive member values */
         bestPivot = if (randomizePivotLocation) {
-          (left - right) * Random.nextDouble() + right
+          (left - right) * rng.nextDouble() + right
         } else {
           (left + right) / 2.0
         }

--- a/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
@@ -7,7 +7,7 @@ import scala.util.Random
 /**
   * Methods tha use cross-validation to calculate predicted-vs-actual data and metric estimates
   */
-case class CrossValidation(rng: Random = Random) {
+case object CrossValidation {
 
   /**
     * Driver to apply named metrics to k-fold cross-validated predicted-vs-actual
@@ -17,6 +17,7 @@ case class CrossValidation(rng: Random = Random) {
     * @param metrics      apply to the predicted-vs-actual data
     * @param k            number of folds
     * @param nTrial       number of times to refold the data to improve statistics
+    * @param rng          random number generator to use in choosing folds
     * @tparam T type of the response, e.g. Double for scalar regression
     * @return a Map from the name of the metric to its mean value and the error in that mean
     */
@@ -25,11 +26,13 @@ case class CrossValidation(rng: Random = Random) {
                                learner: Learner,
                                metrics: Map[String, Merit[T]],
                                k: Int = 8,
-                               nTrial: Int = 1
+                               nTrial: Int = 1,
+                               rng: Random = Random
                              ): Map[String, (Double, Double)] = {
     Merit.estimateMerits(
-      kFoldPvA(trainingData, learner, k, nTrial).iterator,
-      metrics
+      kFoldPvA(trainingData, learner, k, nTrial, rng).iterator,
+      metrics,
+      rng
     )
   }
 
@@ -47,7 +50,8 @@ case class CrossValidation(rng: Random = Random) {
                    trainingData: Seq[(Vector[Any], T)],
                    learner: Learner,
                    k: Int = 8,
-                   nTrial: Int = 1
+                   nTrial: Int = 1,
+                   rng: Random = Random
                  ): Iterable[(PredictionResult[T], Seq[T])] = {
     val nTest: Int = Math.ceil(trainingData.size.toDouble / k).toInt
     (0 until nTrial).flatMap { _ =>

--- a/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
@@ -7,7 +7,7 @@ import scala.util.Random
 /**
   * Methods tha use cross-validation to calculate predicted-vs-actual data and metric estimates
   */
-object CrossValidation {
+case class CrossValidation(rng: Random = Random) {
 
   /**
     * Driver to apply named metrics to k-fold cross-validated predicted-vs-actual
@@ -51,7 +51,7 @@ object CrossValidation {
                  ): Iterable[(PredictionResult[T], Seq[T])] = {
     val nTest: Int = Math.ceil(trainingData.size.toDouble / k).toInt
     (0 until nTrial).flatMap { _ =>
-      val folds: Seq[Seq[(Vector[Any], T)]] = Random.shuffle(trainingData).grouped(nTest).toSeq
+      val folds: Seq[Seq[(Vector[Any], T)]] = rng.shuffle(trainingData).grouped(nTest).toSeq
 
       folds.indices.map { idx =>
         val (testFolds, trainFolds) = folds.zipWithIndex.partition(_._2 == idx)

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -18,7 +18,7 @@ trait Merit[T] {
     *
     * @return the value of the figure of merit
     */
-  def evaluate(predictionResult: PredictionResult[T], actual: Seq[T]): Double
+  def evaluate(predictionResult: PredictionResult[T], actual: Seq[T], rng: Random = Random): Double
 
   /**
     * Estimate the merit and the uncertainty in the merit over batches of predicted and ground-truth values
@@ -26,8 +26,8 @@ trait Merit[T] {
     * @param pva predicted-vs-actual data as an iterable over [[PredictionResult]] and ground-truth tuples
     * @return the estimate of the merit value and the uncertainty in that estimate
     */
-  def estimate(pva: Iterable[(PredictionResult[T], Seq[T])]): (Double, Double) = {
-    val samples = pva.map { case (prediction, actual) => evaluate(prediction, actual) }
+  def estimate(pva: Iterable[(PredictionResult[T], Seq[T])], rng: Random = Random): (Double, Double) = {
+    val samples = pva.map { case (prediction, actual) => evaluate(prediction, actual, rng) }
     val mean: Double = samples.sum / samples.size
     val variance: Double = (samples.size / (samples.size - 1)) * samples.map(x => Math.pow(x - mean, 2)).sum / samples.size
     (mean, Math.sqrt(variance / samples.size))
@@ -37,8 +37,8 @@ trait Merit[T] {
 /**
   * Square root of the mean square error. For an unbiased estimator, this is equal to the standard deviation of the difference between predicted and actual values.
   */
-case class RootMeanSquareError() extends Merit[Double] {
-  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
+case object RootMeanSquareError extends Merit[Double] {
+  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
     Math.sqrt(
       (predictionResult.getExpected(), actual).zipped.map {
         case (x, y) => Math.pow(x - y, 2)
@@ -50,8 +50,8 @@ case class RootMeanSquareError() extends Merit[Double] {
 /**
   * R2 = 1 - MSE(y) / Var(y), where y is the predicted variable
   */
-case class CoefficientOfDetermination() extends Merit[Double] {
-  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
+case object CoefficientOfDetermination extends Merit[Double] {
+  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
     val averageActual = actual.sum / actual.size
     val sumOfSquares = actual.map(x => Math.pow(x - averageActual, 2)).sum
     val sumOfResiduals = predictionResult.getExpected().zip(actual).map { case (x, y) => Math.pow(x - y, 2.0) }.sum
@@ -62,8 +62,8 @@ case class CoefficientOfDetermination() extends Merit[Double] {
 /**
   * The fraction of predictions that fall within the predicted uncertainty
   */
-case class StandardConfidence() extends Merit[Double] {
-  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
+case object StandardConfidence extends Merit[Double] {
+  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
     if (predictionResult.getUncertainty().isEmpty) return 0.0
 
     (predictionResult.getExpected(), predictionResult.getUncertainty().get, actual).zipped.count {
@@ -76,7 +76,7 @@ case class StandardConfidence() extends Merit[Double] {
   * Root mean square of (the error divided by the predicted uncertainty)
   */
 case class StandardError(rescale: Double = 1.0) extends Merit[Double] {
-  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
+  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
     if (predictionResult.getUncertainty().isEmpty) return Double.PositiveInfinity
     val standardized = (predictionResult.getExpected(), predictionResult.getUncertainty().get, actual).zipped.map {
       case (x, sigma: Double, y) => (x - y) / sigma
@@ -96,8 +96,8 @@ case class StandardError(rescale: Double = 1.0) extends Merit[Double] {
   * In the absence of a closed form for that coefficient, it is model empirically by drawing from N(0, x) to produce
   * an "ideal" error series from which the correlation coefficient can be estimated.
   */
-case class UncertaintyCorrelation(rng: Random = Random) extends Merit[Double] {
-  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
+case object UncertaintyCorrelation extends Merit[Double] {
+  override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
     val predictedUncertaintyActual: Seq[(Double, Double, Double)] = (
       predictionResult.getExpected(),
       predictionResult.getUncertainty().get.asInstanceOf[Seq[Double]],
@@ -145,12 +145,13 @@ object Merit {
     */
   def estimateMerits[T](
                           pva: Iterator[(PredictionResult[T], Seq[T])],
-                          merits: Map[String, Merit[T]]
+                          merits: Map[String, Merit[T]],
+                          rng: Random = Random
                         ): Map[String, (Double, Double)] = {
 
     pva.flatMap { case (predictions, actual) =>
       // apply all the merits to the batch at the same time so the batch can fall out of memory
-      merits.mapValues(f => f.evaluate(predictions, actual)).toSeq
+      merits.mapValues(f => f.evaluate(predictions, actual, rng)).toSeq
     }.toIterable.groupBy(_._1).mapValues { x =>
       val meritResults = x.map(_._2)
       val mean = meritResults.sum / meritResults.size
@@ -167,6 +168,7 @@ object Merit {
     * @param merits          to apply at each parameter value
     * @param logScale        whether the parameters should be plotted on a log scale
     * @param pvaBuilder      function that takes the parameter to predicted-vs-actual data
+    * @param rng             random number generator to use
     * @return an [[XYChart]] that plots the merits vs the parameter value
     */
   def plotMeritScan[T](
@@ -175,7 +177,8 @@ object Merit {
                          merits: Map[String, Merit[T]],
                          logScale: Boolean = false,
                          yMin: Option[Double] = None,
-                         yMax: Option[Double] = None
+                         yMax: Option[Double] = None,
+                         rng: Random = Random
                        )(
                          pvaBuilder: Double => Iterator[(PredictionResult[T], Seq[T])]
                        ): XYChart = {
@@ -189,7 +192,7 @@ object Merit {
 
     parameterValues.foreach { param =>
       val pva = pvaBuilder(param)
-      val meritResults = Merit.estimateMerits(pva, merits)
+      val meritResults = Merit.estimateMerits(pva, merits, rng)
       meritResults.foreach { case (name, (mean, err)) =>
         seriesData(name).add(mean)
         seriesData(s"${name}_err").add(err)

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -37,7 +37,7 @@ trait Merit[T] {
 /**
   * Square root of the mean square error. For an unbiased estimator, this is equal to the standard deviation of the difference between predicted and actual values.
   */
-case object RootMeanSquareError extends Merit[Double] {
+case class RootMeanSquareError() extends Merit[Double] {
   override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
     Math.sqrt(
       (predictionResult.getExpected(), actual).zipped.map {
@@ -50,7 +50,7 @@ case object RootMeanSquareError extends Merit[Double] {
 /**
   * R2 = 1 - MSE(y) / Var(y), where y is the predicted variable
   */
-case object CoefficientOfDetermination extends Merit[Double] {
+case class CoefficientOfDetermination() extends Merit[Double] {
   override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
     val averageActual = actual.sum / actual.size
     val sumOfSquares = actual.map(x => Math.pow(x - averageActual, 2)).sum
@@ -62,7 +62,7 @@ case object CoefficientOfDetermination extends Merit[Double] {
 /**
   * The fraction of predictions that fall within the predicted uncertainty
   */
-case object StandardConfidence extends Merit[Double] {
+case class StandardConfidence() extends Merit[Double] {
   override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
     if (predictionResult.getUncertainty().isEmpty) return 0.0
 
@@ -96,7 +96,7 @@ case class StandardError(rescale: Double = 1.0) extends Merit[Double] {
   * In the absence of a closed form for that coefficient, it is model empirically by drawing from N(0, x) to produce
   * an "ideal" error series from which the correlation coefficient can be estimated.
   */
-case object UncertaintyCorrelation extends Merit[Double] {
+case class UncertaintyCorrelation(rng: Random = Random) extends Merit[Double] {
   override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double]): Double = {
     val predictedUncertaintyActual: Seq[(Double, Double, Double)] = (
       predictionResult.getExpected(),
@@ -105,7 +105,7 @@ case object UncertaintyCorrelation extends Merit[Double] {
     ).zipped.toSeq
 
     val ideal = predictedUncertaintyActual.map { case (_, uncertainty, actual) =>
-      val error = Random.nextGaussian() * uncertainty
+      val error = rng.nextGaussian() * uncertainty
       (actual + error, uncertainty, actual)
     }
 

--- a/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
@@ -7,7 +7,7 @@ import scala.util.Random
 /**
   * Methods that draw data from a distribution and compute predicted-vs-actual data
   */
-object StatisticalValidation {
+case class StatisticalValidation(rng: Random = Random) {
 
   /**
     * Generate predicted-vs-actual data given a source of ground truth data and a learner
@@ -69,7 +69,7 @@ object StatisticalValidation {
                                nRound: Int
                              ): Iterator[(PredictionResult[T], Seq[T])] = {
     Iterator.tabulate(nRound) { _ =>
-      val subset = Random.shuffle(source).take(nTrain + nTest)
+      val subset = rng.shuffle(source).take(nTrain + nTest)
       val (trainingData: Seq[(Vector[Any], T)], testData: Seq[(Vector[Any], T)]) = subset.splitAt(nTrain)
       val model = learner.train(trainingData).getModel()
       val predictions: PredictionResult[T] = model.transform(testData.map(_._1)).asInstanceOf[PredictionResult[T]]

--- a/src/test/scala/io/citrine/lolo/AccuracyTest.scala
+++ b/src/test/scala/io/citrine/lolo/AccuracyTest.scala
@@ -12,6 +12,7 @@ import scala.util.Random
   * Created by maxhutch on 7/10/17.
   */
 class AccuracyTest {
+  val rng = new Random(234785L)
 
   val noiseLevel: Double = 0.000
   val nFeat: Int = 10
@@ -34,7 +35,7 @@ class AccuracyTest {
     */
   @Test
   def testRandomForest(): Unit = {
-    val baseLearner = RegressionTreeLearner(numFeatures = nFeat / 3, minLeafInstances = minInstances, rng = new Random(1232346L))
+    val baseLearner = RegressionTreeLearner(numFeatures = nFeat / 3, minLeafInstances = minInstances, rng = rng)
     val learner = new Bagger(baseLearner, numBags = nRow * nScal)
     val error = computeMetrics(learner)
     assert(error > noiseLevel, s"Can't do better than noise")
@@ -49,20 +50,20 @@ class AccuracyTest {
     val errorStandardTree = {
       val baseLearner = RegressionTreeLearner(
         numFeatures = nFeat,
-        splitter = RegressionSplitter(randomizePivotLocation = true, rng = new Random(47346L)),
-        rng = new Random(47346L)
+        splitter = RegressionSplitter(randomizePivotLocation = true, rng = rng),
+        rng = rng
       )
-      val learner = new Bagger(baseLearner, numBags = nRow * 16)
+      val learner = new Bagger(baseLearner, numBags = nRow * 16, randBasis = TestUtils.getBreezeRandBasis(rng.nextLong()))
       // println(s"Normal train time: ${Stopwatch.time(computeMetrics(learner))}")
       computeMetrics(learner)
     }
     val errorAnnealingTree = {
       val baseLearner = RegressionTreeLearner(
         numFeatures = nFeat,
-        splitter = BoltzmannSplitter(temperature = Float.MinPositiveValue, rng = new Random(47346L)),
-        rng = new Random(47346L)
+        splitter = BoltzmannSplitter(temperature = Float.MinPositiveValue, rng = rng),
+        rng = rng
       )
-      val learner = new Bagger(baseLearner, numBags = nRow * 16)
+      val learner = new Bagger(baseLearner, numBags = nRow * 16, randBasis = TestUtils.getBreezeRandBasis(rng.nextLong()))
       // println(s"Annealing train time: ${Stopwatch.time(computeMetrics(learner))}")
       computeMetrics(learner)
     }

--- a/src/test/scala/io/citrine/lolo/AccuracyTest.scala
+++ b/src/test/scala/io/citrine/lolo/AccuracyTest.scala
@@ -6,6 +6,8 @@ import io.citrine.lolo.trees.splits.{BoltzmannSplitter, RegressionSplitter}
 import io.citrine.theta.Stopwatch
 import org.junit.Test
 
+import scala.util.Random
+
 /**
   * Created by maxhutch on 7/10/17.
   */
@@ -32,7 +34,7 @@ class AccuracyTest {
     */
   @Test
   def testRandomForest(): Unit = {
-    val baseLearner = RegressionTreeLearner(numFeatures = nFeat / 3, minLeafInstances = minInstances)
+    val baseLearner = RegressionTreeLearner(numFeatures = nFeat / 3, minLeafInstances = minInstances, rng = new Random(1232346L))
     val learner = new Bagger(baseLearner, numBags = nRow * nScal)
     val error = computeMetrics(learner)
     assert(error > noiseLevel, s"Can't do better than noise")
@@ -47,7 +49,8 @@ class AccuracyTest {
     val errorStandardTree = {
       val baseLearner = RegressionTreeLearner(
         numFeatures = nFeat,
-        splitter = RegressionSplitter(randomizePivotLocation = true)
+        splitter = RegressionSplitter(randomizePivotLocation = true, rng = new Random(47346L)),
+        rng = new Random(47346L)
       )
       val learner = new Bagger(baseLearner, numBags = nRow * 16)
       // println(s"Normal train time: ${Stopwatch.time(computeMetrics(learner))}")
@@ -56,7 +59,8 @@ class AccuracyTest {
     val errorAnnealingTree = {
       val baseLearner = RegressionTreeLearner(
         numFeatures = nFeat,
-        splitter = BoltzmannSplitter(temperature = Float.MinPositiveValue)
+        splitter = BoltzmannSplitter(temperature = Float.MinPositiveValue, rng = new Random(47346L)),
+        rng = new Random(47346L)
       )
       val learner = new Bagger(baseLearner, numBags = nRow * 16)
       // println(s"Annealing train time: ${Stopwatch.time(computeMetrics(learner))}")
@@ -102,7 +106,8 @@ object AccuracyTest {
     val baseLearner = RegressionTreeLearner(
       numFeatures = nFeatSub,
       splitter = splitter,
-      minLeafInstances = minInstances
+      minLeafInstances = minInstances,
+      rng = new Random(247895L)
     )
     val learner = new Bagger(baseLearner, numBags = nRow * nScal, biasLearner = None)
     val model = learner.train(trainingData).getModel()

--- a/src/test/scala/io/citrine/lolo/AccuracyTest.scala
+++ b/src/test/scala/io/citrine/lolo/AccuracyTest.scala
@@ -31,6 +31,56 @@ class AccuracyTest {
   }
 
   /**
+    * Test that setting rng yields repeatable results.
+    */
+  /**
+    * DISABLED until implementing perfect reproducibility.
+  @Test
+  def testRepeatable(): Unit = {
+    val (errorsStandardTree, errorsAnnealingTree, errorsUnrandomizedTree) = (1 to 4).map { _ =>
+      val seed = 354128L
+      val rng = new Random(seed)
+      val errorStandardTree = {
+        val baseLearner = RegressionTreeLearner(
+          numFeatures = nFeat,
+          splitter = RegressionSplitter(randomizePivotLocation = true, rng = rng),
+          rng = rng
+        )
+        val learner = new Bagger(baseLearner, numBags = nRow * 8, randBasis = TestUtils.getBreezeRandBasis(rng.nextLong()))
+        computeMetrics(learner)
+      }
+      rng.setSeed(seed)
+      val errorAnnealingTree = {
+        val baseLearner = RegressionTreeLearner(
+          numFeatures = nFeat,
+          splitter = BoltzmannSplitter(temperature = Float.MinPositiveValue, rng = rng),
+          rng = rng
+        )
+        val learner = new Bagger(baseLearner, numBags = nRow * 8, randBasis = TestUtils.getBreezeRandBasis(rng.nextLong()))
+        computeMetrics(learner)
+      }
+      rng.setSeed(seed)
+      val randBasis = TestUtils.getBreezeRandBasis(rng.nextLong())
+      val errorUnrandomizedTree = {
+        val baseLearner = RegressionTreeLearner(
+          numFeatures = nFeat,
+          splitter = RegressionSplitter(randomizePivotLocation = false, rng = rng),
+          rng = rng
+        )
+        val learner = new Bagger(baseLearner, numBags = nRow * 8, randBasis = randBasis)
+        computeMetrics(learner)
+      }
+      (errorStandardTree, errorAnnealingTree, errorUnrandomizedTree)
+    }.unzip3
+
+    val atol = 1e-12
+    assert(errorsStandardTree.forall{ e => Math.abs(e - errorsStandardTree.head) < atol })
+    assert(errorsAnnealingTree.forall{ e => Math.abs(e - errorsStandardTree.head) < atol })
+    assert(errorsUnrandomizedTree.forall{ e => Math.abs(e - errorsUnrandomizedTree.head) < atol })
+  }
+  */
+
+  /**
     * Quick sanity check of the test setup
     */
   @Test
@@ -83,7 +133,7 @@ class AccuracyTest {
 object AccuracyTest {
 
   val trainingDataFull: Seq[(Vector[Any], Double)] = TestUtils.binTrainingData(
-    TestUtils.generateTrainingData(2048, 48),
+    TestUtils.generateTrainingData(2048, 48, seed = 283467L),
     inputBins = Seq((2, 32)) // bin the 3rd feature into a categorical
   ).asInstanceOf[Seq[(Vector[Any], Double)]]
 

--- a/src/test/scala/io/citrine/lolo/TestUtils.scala
+++ b/src/test/scala/io/citrine/lolo/TestUtils.scala
@@ -79,6 +79,6 @@ object TestUtils {
     outputData
   }
 
-  def getBreezeRandBasis(seed: Long) = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
+  def getBreezeRandBasis(seed: Long): RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
 
 }

--- a/src/test/scala/io/citrine/lolo/TestUtils.scala
+++ b/src/test/scala/io/citrine/lolo/TestUtils.scala
@@ -1,6 +1,8 @@
 package io.citrine.lolo
 
+import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import io.citrine.lolo.stats.functions.Friedman
+import org.apache.commons.math3.random.MersenneTwister
 
 import scala.util.{Random, Try}
 
@@ -76,5 +78,7 @@ object TestUtils {
     }
     outputData
   }
+
+  def getBreezeRandBasis(seed: Long) = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
 
 }

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -55,7 +55,7 @@ class BaggerTest {
   @Test
   def testClassificationBagger(): Unit = {
     val trainingData = TestUtils.binTrainingData(
-      TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
+      TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman, seed = rng.nextLong()),
       inputBins = Seq((0, 8)), responseBins = Some(8)
     )
     val DTLearner = ClassificationTreeLearner()

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -18,6 +18,7 @@ import scala.util.Random
   */
 @Test
 class MultiTaskBaggerTest {
+  val rng = new Random(37895L)
 
   /**
     * Test that we get a reasonable output on a single regression problem
@@ -31,7 +32,7 @@ class MultiTaskBaggerTest {
     val inputs = trainingData.map(_._1)
     val labels = trainingData.map(_._2)
     val DTLearner = MultiTaskTreeLearner()
-    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size)
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size, randBasis = TestUtils.getBreezeRandBasis(10478L))
     val RFMeta = baggedLearner.train(inputs, Seq(labels)).head
     val RF = RFMeta.getModel()
 
@@ -51,7 +52,6 @@ class MultiTaskBaggerTest {
   @Test
   def testBaggedMultiTaskGetUncertainty(): Unit = {
     val noiseLevel = 100.0
-    val rng = new Random(237485L)
 
     Seq(MultiTaskTreeLearner()).foreach { baseLearner =>
       // These are in Seqs as a convenience for repurposing this test as a diagnostic tool.
@@ -66,7 +66,7 @@ class MultiTaskBaggerTest {
               val trainingData = trainingDataTmp.map { x => (x._1, x._2 + noiseLevel * rng.nextDouble()) }
               val inputs = trainingData.map(_._1)
               val labels = trainingData.map(_._2)
-              val baggedLearner = MultiTaskBagger(baseLearner, numBags = nBags, uncertaintyCalibration = true)
+              val baggedLearner = MultiTaskBagger(baseLearner, numBags = nBags, uncertaintyCalibration = true, randBasis = TestUtils.getBreezeRandBasis(7835178L))
               val RFMeta = baggedLearner.train(inputs, Seq(labels)).head
               val RF = RFMeta.getModel()
               val results = RF.transform(trainingData.take(4).map(_._1))
@@ -144,7 +144,7 @@ class MultiTaskBaggerTest {
     val inputs = trainingData.map(_._1)
     val labels = trainingData.map(_._2)
     val DTLearner = MultiTaskTreeLearner()
-    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size)
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size, randBasis = TestUtils.getBreezeRandBasis(478L))
     val RFMeta = baggedLearner.train(inputs, Seq(labels)).head
     val RF = RFMeta.getModel()
 
@@ -176,7 +176,7 @@ class MultiTaskBaggerTest {
     val realLabel: Seq[Double] = raw.map(_._2)
     val catLabel: Seq[Boolean] = raw.map(_._2 > realLabel.max / 2.0)
     val DTLearner = MultiTaskTreeLearner()
-    val baggedLearner = MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new RegressionTreeLearner(maxDepth = 2)))
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new RegressionTreeLearner(maxDepth = 2)), randBasis = TestUtils.getBreezeRandBasis(78495L))
     val RFMeta = baggedLearner.train(inputs, Seq(realLabel, catLabel)).last
     val RF = RFMeta.getModel()
 
@@ -196,14 +196,14 @@ class MultiTaskBaggerTest {
     val realLabel: Seq[Double] = raw.map(_._2)
     val catLabel: Seq[Boolean] = raw.map(_._2 > realLabel.max / 2.0)
     val sparseCat = catLabel.map(x =>
-      if (Random.nextDouble() > 0.125) {
+      if (rng.nextDouble() > 0.125) {
         null
       } else {
         x
       }
     )
     val sparseReal = realLabel.map(x =>
-      if (Random.nextDouble() > 0.5) {
+      if (rng.nextDouble() > 0.5) {
         Double.NaN
       } else {
         x
@@ -211,7 +211,7 @@ class MultiTaskBaggerTest {
     )
 
     val DTLearner = MultiTaskTreeLearner()
-    val baggedLearner = MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(new GuessTheMeanLearner))
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = inputs.size, biasLearner = Some(GuessTheMeanLearner(rng = rng)), randBasis = TestUtils.getBreezeRandBasis(7839L))
     val trainingResult = baggedLearner.train(inputs, Seq(sparseReal, sparseCat))
     val RFMeta = trainingResult.last
     val RF = RFMeta.getModel()

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -55,7 +55,7 @@ class MultiTaskBaggerTest {
 
     Seq(MultiTaskTreeLearner()).foreach { baseLearner =>
       // These are in Seqs as a convenience for repurposing this test as a diagnostic tool.
-      Seq(128).foreach { nRows =>
+      Seq(64).foreach { nRows =>
         Seq(16).foreach { nCols =>
           Seq(2).map { n => n * nRows }.foreach { nBags =>
             // Used for error output.

--- a/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
+++ b/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
@@ -10,6 +10,7 @@ import scala.util.Random
   */
 @Test
 class LinearRegressionTest {
+  val rng = new Random(783578L)
   /** Number of training rows */
   val n = 6
   /** Number of features in each row */
@@ -46,7 +47,7 @@ class LinearRegressionTest {
     */
   @Test
   def testRegression(): Unit = {
-    val int0 = Random.nextDouble()
+    val int0 = rng.nextDouble()
     val result = data * beta0 + int0
 
     val trainingData = (0 until n).map { i =>
@@ -69,7 +70,7 @@ class LinearRegressionTest {
     */
   @Test
   def testWeightedRegression(): Unit = {
-    val int0 = Random.nextDouble()
+    val int0 = rng.nextDouble()
     val result = data * beta0 + int0
 
     val trainingData = (0 until n).map { i =>
@@ -77,7 +78,7 @@ class LinearRegressionTest {
     }
 
     val lr = new LinearRegressionLearner()
-    val lrm = lr.train(trainingData, weights = Some(Seq.tabulate(n)(i => Math.abs(Random.nextDouble()))))
+    val lrm = lr.train(trainingData, weights = Some(Seq.tabulate(n)(i => Math.abs(rng.nextDouble()))))
     val model = lrm.getModel()
     val output = model.transform(trainingData.map(_._1))
     val predicted = output.getExpected()
@@ -121,7 +122,7 @@ class LinearRegressionTest {
     */
   @Test
   def testCategoricalValue(): Unit = {
-    val int0 = Random.nextDouble()
+    val int0 = rng.nextDouble()
     val result = data * beta0 + int0
 
     val trainingData = (0 until n).map { i =>

--- a/src/test/scala/io/citrine/lolo/stats/correlations/DistanceCorrelationTest.scala
+++ b/src/test/scala/io/citrine/lolo/stats/correlations/DistanceCorrelationTest.scala
@@ -9,6 +9,7 @@ import scala.util.Random
   */
 @Test
 class DistanceCorrelationTest {
+  val rng = new Random(36783677836L)
 
   val N: Int = 512
 
@@ -16,8 +17,8 @@ class DistanceCorrelationTest {
 
   @Test
   def testIndependent(): Unit = {
-    val X: Seq[Double] = Seq.tabulate(N)(i => Random.nextGaussian())
-    val Y: Seq[Double] = Seq.tabulate(N)(i => Random.nextGaussian())
+    val X: Seq[Double] = Seq.tabulate(N)(i => rng.nextGaussian())
+    val Y: Seq[Double] = Seq.tabulate(N)(i => rng.nextGaussian())
     val dcorr = DistanceCorrelation.distanceCorrelation(X, Y, dist)
 
     assert(dcorr < 0.15, s"dCorr for independent vars is ${dcorr}")
@@ -26,7 +27,7 @@ class DistanceCorrelationTest {
 
   @Test
   def testLinear(): Unit = {
-    val X: Seq[Double] = Seq.tabulate(N)(i => Random.nextDouble())
+    val X: Seq[Double] = Seq.tabulate(N)(i => rng.nextDouble())
     val Y: Seq[Double] = X.map(v => v * 10)
     val dcorr = DistanceCorrelation.distanceCorrelation(X, Y, dist)
 
@@ -35,7 +36,7 @@ class DistanceCorrelationTest {
 
   @Test
   def testQuadratic(): Unit = {
-    val X: Seq[Double] = Seq.tabulate(N)(i => Random.nextDouble() - .5)
+    val X: Seq[Double] = Seq.tabulate(N)(i => rng.nextDouble() - .5)
     val Y: Seq[Double] = X.map(v => v * v * 2)
     val dcorr = DistanceCorrelation.distanceCorrelation(X, Y, dist)
 
@@ -44,7 +45,7 @@ class DistanceCorrelationTest {
 
   @Test
   def testSin(): Unit = {
-    val X: Seq[Double] = Seq.tabulate(N)(i => Random.nextDouble() - .5)
+    val X: Seq[Double] = Seq.tabulate(N)(i => rng.nextDouble() - .5)
     val Y: Seq[Double] = X.map(v => Math.sin(2 * Math.PI * v))
     val dcorr = DistanceCorrelation.distanceCorrelation(X, Y, dist)
 

--- a/src/test/scala/io/citrine/lolo/stats/metrics/ClassificationMetricsTest.scala
+++ b/src/test/scala/io/citrine/lolo/stats/metrics/ClassificationMetricsTest.scala
@@ -9,6 +9,7 @@ import scala.util.Random
   */
 @Test
 class ClassificationMetricsTest {
+  val rng = new Random(9230L)
 
   /**
     * Test that the metric works on a sparse confusion matrix
@@ -17,7 +18,7 @@ class ClassificationMetricsTest {
     val N = 512
     /* Make random predictions */
     val pva = Seq.tabulate(N) { i =>
-      (Vector(0.0), Random.nextInt(N).toString, Random.nextInt(N).toString)
+      (Vector(0.0), rng.nextInt(N).toString, rng.nextInt(N).toString)
     }
     val loss = ClassificationMetrics.f1scores(pva)
     /* The loss should be in (0.0, 1.0) */

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -18,11 +18,13 @@ import scala.util.Random
 @Test
 class FeatureRotatorTest {
 
+  val rng = new Random(1297843L)
+
   val data: Seq[(Vector[Any], Any)] = TestUtils.binTrainingData(
     TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman),
     inputBins = Seq((0, 8))
   )
-  val weights: Vector[Double] = Vector.fill(data.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
+  val weights: Vector[Double] = Vector.fill(data.size)(if (rng.nextBoolean()) rng.nextDouble() else 0.0)
 
   @Test
   def testRandomRotation(): Unit = {
@@ -106,11 +108,11 @@ class FeatureRotatorTest {
     */
   @Test
   def testRotatedGTM(): Unit = {
-    val learner = GuessTheMeanLearner()
+    val learner = GuessTheMeanLearner(rng = rng)
     val model = learner.train(data).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
-    val rotatedLearner = FeatureRotator(GuessTheMeanLearner())
+    val rotatedLearner = FeatureRotator(GuessTheMeanLearner(rng = rng))
     val rotatedModel = rotatedLearner.train(data).getModel()
     val rotatedResult = rotatedModel.transform(data.map(_._1)).getExpected()
 
@@ -245,7 +247,7 @@ class FeatureRotatorTest {
     val catLabel = inputs.map(x => Friedman.friedmanGrosseSilverman(x) > 15.0)
 
     // Sparsify the categorical labels
-    val sparseCatLabel = catLabel.map(x => if (Random.nextBoolean()) x else null)
+    val sparseCatLabel = catLabel.map(x => if (rng.nextBoolean()) x else null)
 
     // Train and evaluate rotated models on original and rotated features
     val baseLearner = new MultiTaskTreeLearner()

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -15,9 +15,10 @@ import scala.util.Random
   */
 @Test
 class StandardizerTest {
+  val rng = new Random(823478686L)
 
   val data: Vector[(Vector[Double], Double)] = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
-  val weights: Vector[Double] = Vector.fill(data.size)(if (Random.nextBoolean()) Random.nextDouble() else 0.0)
+  val weights: Vector[Double] = Vector.fill(data.size)(if (rng.nextBoolean()) rng.nextDouble() else 0.0)
 
   // Creating another dataset which has 1 feature that has 0 variance.
   val dataWithConstant: Vector[(Vector[Double], Double)] = data.map(d => (0.0 +: d._1, d._2))
@@ -53,11 +54,11 @@ class StandardizerTest {
     */
   @Test
   def testStandardGTM(): Unit = {
-    val learner = GuessTheMeanLearner()
+    val learner = GuessTheMeanLearner(rng = rng)
     val model = learner.train(data).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
-    val standardLearner = Standardizer(GuessTheMeanLearner())
+    val standardLearner = Standardizer(GuessTheMeanLearner(rng = rng))
     val standardModel = standardLearner.train(data).getModel()
     val standardResult = standardModel.transform(data.map(_._1)).getExpected()
 
@@ -177,7 +178,7 @@ class StandardizerTest {
     val catLabel = inputs.map(x => Friedman.friedmanGrosseSilverman(x) > 15.0)
 
     // Sparsify the categorical labels
-    val sparseCatLabel = catLabel.map(x => if (Random.nextBoolean()) x else null)
+    val sparseCatLabel = catLabel.map(x => if (rng.nextBoolean()) x else null)
 
     // Screw up the scale of the double labels
     val scale = 10000.0

--- a/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
@@ -15,9 +15,10 @@ import scala.util.Random
   */
 @Test
 class MultiTaskTreeTest {
+  val rng = new Random(1012795L)
 
   /* Setup some data */
-  val raw: Seq[(Vector[Double], Double)] = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman)
+  val raw: Seq[(Vector[Double], Double)] = TestUtils.generateTrainingData(1024, 12, noise = 0.1, function = Friedman.friedmanSilverman, seed = rng.nextLong())
   val inputs: Seq[Vector[Double]] = raw.map(_._1)
   val realLabel: Seq[Double] = raw.map(_._2)
   val catLabel: Seq[Boolean] = raw.map(_._2 > realLabel.max / 2.0)
@@ -27,7 +28,7 @@ class MultiTaskTreeTest {
     */
   @Test
   def testTwoLabels(): Unit = {
-    val learner = new MultiTaskTreeLearner()
+    val learner = MultiTaskTreeLearner()
     val models = learner.train(inputs, Seq(realLabel, catLabel)).map(_.getModel())
     assert(models.size == 2)
     assert(models.head.isInstanceOf[RegressionTree])
@@ -45,14 +46,14 @@ class MultiTaskTreeTest {
   @Test
   def testSparseExact(): Unit = {
     val sparseCat = catLabel.map(x =>
-      if (Random.nextBoolean()) {
+      if (rng.nextBoolean()) {
         null
       } else {
         x
       }
     )
 
-    val learner = new MultiTaskTreeLearner()
+    val learner = MultiTaskTreeLearner()
     val models = learner.train(inputs, Seq(realLabel, sparseCat)).map(_.getModel())
     val realResults = models.head.transform(inputs).getExpected().asInstanceOf[Seq[Double]]
     val catResults = models.last.transform(inputs).getExpected().asInstanceOf[Seq[Boolean]]
@@ -67,7 +68,7 @@ class MultiTaskTreeTest {
   @Test
   def testSparseQuantitative(): Unit = {
     val sparseCat = catLabel.map(x =>
-      if (Random.nextDouble() > 0.125) {
+      if (rng.nextDouble() > 0.125) {
         null
       } else {
         x

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -16,6 +16,7 @@ import scala.util.Random
   */
 @Test
 class RegressionTreeTest {
+  val rng = new Random(90476L)
 
   /**
     * Trivial models with no splits should have finite feature importance.
@@ -215,7 +216,7 @@ class RegressionTreeTest {
     val linearLearner = LinearRegressionLearner(regParam = Some(1.0))
     val DTLearner = RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 1)
     val DTMeta = DTLearner.train(trainingData, weights = Some(Seq.fill(trainingData.size) {
-      Random.nextInt(8)
+      rng.nextInt(8)
     }))
     val DT = DTMeta.getModel()
 

--- a/src/test/scala/io/citrine/lolo/trees/splits/BoltzmannSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/BoltzmannSplitterTest.scala
@@ -5,15 +5,16 @@ import org.junit.Test
 import scala.util.Random
 
 class BoltzmannSplitterTest {
+  val rng = new Random(45321L)
 
   /**
     * Test that uniform labels result in "NoSplit" with zero reduced impurity
     */
   @Test
   def testZeroVariance(): Unit = {
-    val splitter = BoltzmannSplitter(1.0e-9)
+    val splitter = BoltzmannSplitter(1.0e-9, rng = rng)
     val testData = Seq.fill(64){
-      val x = Random.nextDouble()
+      val x = rng.nextDouble()
       val y = 1.0
       val weight = 1.0
       (Vector(x), y, weight)
@@ -32,10 +33,10 @@ class BoltzmannSplitterTest {
     */
   @Test
   def testLowVariance(): Unit = {
-    val splitter = BoltzmannSplitter(1.0e-18)
+    val splitter = BoltzmannSplitter(1.0e-18, rng = rng)
     val testData = Seq.fill(256){
-      val x = Random.nextDouble()
-      val y = Random.nextGaussian() * 1.0e-9 + 1.0
+      val x = rng.nextDouble()
+      val y = rng.nextGaussian() * 1.0e-9 + 1.0
       val weight = 1.0
       (Vector(x), y, weight)
     }

--- a/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
@@ -3,12 +3,15 @@ package io.citrine.lolo.trees.splits
 import io.citrine.lolo.trees.impurity.MultiImpurityCalculator
 import org.junit.Test
 
+import scala.util.Random
+
 
 /**
   * Created by maxhutch on 12/1/16.
   */
 @Test
 class MultiTaskSplitterTest {
+  val rng = new Random(38945L)
 
   /**
     * Test that the real split goes in the right place
@@ -23,7 +26,8 @@ class MultiTaskSplitterTest {
     )
     val calculator = MultiImpurityCalculator.build(data.map(_._2), data.map(_._3))
 
-    val (pivot, impurity) = MultiTaskSplitter.getBestRealSplit(data, calculator, 0, 1)
+    val splitter = MultiTaskSplitter(rng = rng)
+    val (pivot, impurity) = splitter.getBestRealSplit(data, calculator, 0, 1)
     val turns = data.map(x => pivot.turnLeft(x._1))
     assert(turns == Seq(true, false, false, false))
     assert(impurity == 0.5)
@@ -42,7 +46,8 @@ class MultiTaskSplitterTest {
     )
     val calculator = MultiImpurityCalculator.build(data.map(_._2), data.map(_._3))
 
-    val (pivot, impurity) = MultiTaskSplitter.getBestCategoricalSplit(data, calculator, 0, 1)
+    val splitter = MultiTaskSplitter(rng = rng)
+    val (pivot, impurity) = splitter.getBestCategoricalSplit(data, calculator, 0, 1)
     val turns = data.map(x => pivot.turnLeft(x._1)).take(3)
     println(turns)
     assert(turns == Seq(true, false, false))
@@ -63,7 +68,8 @@ class MultiTaskSplitterTest {
     val data = inputs.indices.map { i =>
       (inputs(i), labels(i).asInstanceOf[Array[AnyVal]], weights(i))
     }
-    val (pivot, impurity) = MultiTaskSplitter.getBestSplit(data, data.head._1.size, 1)
+    val splitter = MultiTaskSplitter(rng = rng)
+    val (pivot, impurity) = splitter.getBestSplit(data, data.head._1.size, 1)
     assert(!pivot.isInstanceOf[NoSplit])
   }
 }

--- a/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
@@ -10,14 +10,15 @@ import scala.util.Random
   */
 @Test
 class SplitterTest {
+  val rng = new Random(39578L)
 
   /**
     * Test different variance formulations
     */
   @Test
   def testTotalVarianceCalculation(): Unit = {
-    val values = (0 until 16).map(i => Random.nextDouble())
-    val (left, right) = values.partition(f => Random.nextBoolean())
+    val values = (0 until 16).map(i => rng.nextDouble())
+    val (left, right) = values.partition(f => rng.nextBoolean())
 
     val totalSquareSum = values.map(v => v * v).sum
     val totalNum = values.size
@@ -54,7 +55,7 @@ class SplitterTest {
   def testLargeDuplicates(): Unit = {
     val base: Double = 3.0e9
     val trainingData = Seq.fill(8) {
-      (Vector(base + Random.nextDouble()), Random.nextDouble(), 1.0)
+      (Vector(base + rng.nextDouble()), rng.nextDouble(), 1.0)
     }
 
     val calculator = new VarianceCalculator(0.0, 0.0, 8.0)

--- a/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
@@ -55,10 +55,11 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of training rows",
         Seq(16, 32, 64, 128, 256, 512),
-        Map("R2" -> CoefficientOfDetermination(), "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
         logScale = true,
         yMin = Some(0.0),
-        yMax = Some(1.0)
+        yMax = Some(1.0),
+        rng = rng
       ) { nTrain: Double =>
         val nTree = ratio * nTrain
         val learner = Bagger(
@@ -90,10 +91,11 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of trees",
         Seq(16, 32, 64, 128, 256, 512, 1024, 2048, 4096),
-        Map("R2" -> CoefficientOfDetermination(), "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
         logScale = true,
         yMin = Some(0.0),
-        yMax = Some(1.0)
+        yMax = Some(1.0),
+        rng = rng
       ) { nTree: Double =>
         val learner = Bagger(
           RegressionTreeLearner(
@@ -131,10 +133,11 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of training points",
         Seq(16, 32, 64, 128, 256, 512, 1024),
-        Map("R2" -> CoefficientOfDetermination(), "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
         logScale = true,
         yMin = Some(0.0),
-        yMax = Some(1.0)
+        yMax = Some(1.0),
+        rng = rng
       ) { nTrain: Double =>
         val learner = Bagger(
           RegressionTreeLearner(
@@ -209,7 +212,8 @@ object CalibrationStudy {
     BitmapEncoder.saveBitmap(pva, s"./pva_${funcName}-nTrain.${nTrain}-nTree.${nTree}", BitmapFormat.PNG)
     Merit.estimateMerits(
       dataStream.iterator,
-      Map("R2" -> CoefficientOfDetermination(), "confidence" -> StandardConfidence(), "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation())
+      Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+      rng = rng
     )
   }
 
@@ -280,10 +284,11 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of training points",
         Seq(16, 32, 64, 128, 256, 512, 1024),
-        Map("R2" -> CoefficientOfDetermination(), "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
         logScale = true,
         yMin = Some(0.0),
-        yMax = Some(1.0)
+        yMax = Some(1.0),
+        rng = rng
       ) { nTrain: Double =>
         val learner = Bagger(
           RegressionTreeLearner(
@@ -353,7 +358,8 @@ object CalibrationStudy {
     BitmapEncoder.saveBitmap(pva, s"./pva_hcep-nTrain.${nTrain}-nTree.${nTree}", BitmapFormat.PNG)
     Merit.estimateMerits(
       dataStream.iterator,
-      Map("R2" -> CoefficientOfDetermination(), "confidence" -> StandardConfidence(), "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation())
+      Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+      rng = rng
     )
   }
 

--- a/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
@@ -5,7 +5,10 @@ import io.citrine.lolo.learners.RandomForest
 import io.citrine.lolo.stats.functions.Friedman
 import org.junit.Test
 
+import scala.util.Random
+
 class CrossValidationTest {
+  val rng = new Random(92486L)
 
   /**
     * Test that CV results are consistent with out-of-bag estimates from the bagged learner
@@ -15,10 +18,10 @@ class CrossValidationTest {
   @Test
   def testCompareToOutOfBag(): Unit = {
     val learner = RandomForest()
-    val data = TestUtils.generateTrainingData(128, 8, Friedman.friedmanSilverman)
+    val data = TestUtils.generateTrainingData(128, 8, Friedman.friedmanSilverman, seed = rng.nextLong())
 
-    val metric = RootMeanSquareError
-    val (rmseFromCV, uncertainty) = CrossValidation.kFoldCrossvalidation(data, learner, Map("rmse" -> metric), k = 3)("rmse")
+    val metric = RootMeanSquareError()
+    val (rmseFromCV, uncertainty) = CrossValidation(rng = rng).kFoldCrossvalidation(data, learner, Map("rmse" -> metric), k = 3)("rmse")
 
     val trainingResult = learner.train(data)
     val rmseFromPVA = Math.sqrt(

--- a/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
@@ -20,8 +20,8 @@ class CrossValidationTest {
     val learner = RandomForest()
     val data = TestUtils.generateTrainingData(128, 8, Friedman.friedmanSilverman, seed = rng.nextLong())
 
-    val metric = RootMeanSquareError()
-    val (rmseFromCV, uncertainty) = CrossValidation(rng = rng).kFoldCrossvalidation(data, learner, Map("rmse" -> metric), k = 3)("rmse")
+    val metric = RootMeanSquareError
+    val (rmseFromCV, uncertainty) = CrossValidation.kFoldCrossvalidation(data, learner, Map("rmse" -> metric), k = 3)("rmse")
 
     val trainingResult = learner.train(data)
     val rmseFromPVA = Math.sqrt(

--- a/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
@@ -66,7 +66,7 @@ class MeritTest {
   @Test
   def testRMSE(): Unit = {
     val pva = getNormalPVA(batchSize = 256, numBatch = 32)
-    val (rmse, uncertainty) = RootMeanSquareError().estimate(pva)
+    val (rmse, uncertainty) = RootMeanSquareError.estimate(pva)
     assert(Math.abs(rmse - 1.0) < 3 * uncertainty, "RMSE estimate was not accurate enough")
     assert(uncertainty < 0.05, s"RMSE estimate was not precise enough")
   }
@@ -80,7 +80,7 @@ class MeritTest {
   def testCoefficientOfDeterminization(): Unit = {
     val pva = getNormalPVA(noiseScale = 0.1, batchSize = 256, numBatch = 32)
     val expected = 1 - 12 * 0.1 * 0.1
-    val (r2, uncertainty) = CoefficientOfDetermination().estimate(pva)
+    val (r2, uncertainty) = CoefficientOfDetermination.estimate(pva)
     assert(Math.abs(r2 - expected) < 3 * uncertainty, "R^2 estimate was not accurate enough")
     assert(uncertainty < 0.05, s"R^2 estimate was not precise enough")
   }
@@ -94,7 +94,7 @@ class MeritTest {
   def testStandardConfidence(): Unit = {
     val pva = getNormalPVA(uncertaintyCorrelation = 1.0, batchSize = 256, numBatch = 32)
     val expected = 0.68
-    val (confidence, uncertainty) = StandardConfidence().estimate(pva)
+    val (confidence, uncertainty) = StandardConfidence.estimate(pva)
     assert(Math.abs(confidence - expected) < 3 * uncertainty, "Confidence estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Confidence estimate was not precise enough")
   }
@@ -123,7 +123,7 @@ class MeritTest {
   def testPerfectUncertaintyCorrelation(): Unit = {
     val pva = getNormalPVA(noiseScale = 0.01, uncertaintyCorrelation = 1.0, batchSize = 256, numBatch = 32)
     val expected = 1.0
-    val (corr, uncertainty) = UncertaintyCorrelation().estimate(pva)
+    val (corr, uncertainty) = UncertaintyCorrelation.estimate(pva)
     assert(Math.abs(corr - expected) < 3 * uncertainty, "Uncertainty correlation estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Uncertainty correlation estimate was not precise enough")
   }
@@ -137,7 +137,7 @@ class MeritTest {
   def testZeroUncertaintyCorrelation(): Unit = {
     val pva = getNormalPVA(noiseScale = 0.01, uncertaintyCorrelation = 0.0, batchSize = 256, numBatch = 32)
     val expected = 0.0
-    val (corr, uncertainty) = UncertaintyCorrelation().estimate(pva)
+    val (corr, uncertainty) = UncertaintyCorrelation.estimate(pva)
     assert(Math.abs(corr - expected) < 3 * uncertainty, "Uncertainty correlation estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Uncertainty correlation estimate was not precise enough")
   }

--- a/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.Assertions._
 import scala.util.{Random, Try}
 
 class MeritTest {
+  val rng = new Random(34578L)
 
   /**
     * Generate test data by adding Gaussian noise to a uniformly distributed response
@@ -38,9 +39,9 @@ class MeritTest {
 
     Seq.fill(numBatch) {
       val pua = Seq.fill(batchSize) {
-        val y = Random.nextDouble()
+        val y = rng.nextDouble()
         val draw = errorDistribution.sample().toSeq
-        val error: Double = draw(0) * Random.nextGaussian()
+        val error: Double = draw(0) * rng.nextGaussian()
         val uncertainty = if (uncertaintyCorrelation >= maximumCorrelation) {
           Math.abs(draw(0))
         } else {
@@ -65,7 +66,7 @@ class MeritTest {
   @Test
   def testRMSE(): Unit = {
     val pva = getNormalPVA(batchSize = 256, numBatch = 32)
-    val (rmse, uncertainty) = RootMeanSquareError.estimate(pva)
+    val (rmse, uncertainty) = RootMeanSquareError().estimate(pva)
     assert(Math.abs(rmse - 1.0) < 3 * uncertainty, "RMSE estimate was not accurate enough")
     assert(uncertainty < 0.05, s"RMSE estimate was not precise enough")
   }
@@ -79,7 +80,7 @@ class MeritTest {
   def testCoefficientOfDeterminization(): Unit = {
     val pva = getNormalPVA(noiseScale = 0.1, batchSize = 256, numBatch = 32)
     val expected = 1 - 12 * 0.1 * 0.1
-    val (r2, uncertainty) = CoefficientOfDetermination.estimate(pva)
+    val (r2, uncertainty) = CoefficientOfDetermination().estimate(pva)
     assert(Math.abs(r2 - expected) < 3 * uncertainty, "R^2 estimate was not accurate enough")
     assert(uncertainty < 0.05, s"R^2 estimate was not precise enough")
   }
@@ -93,7 +94,7 @@ class MeritTest {
   def testStandardConfidence(): Unit = {
     val pva = getNormalPVA(uncertaintyCorrelation = 1.0, batchSize = 256, numBatch = 32)
     val expected = 0.68
-    val (confidence, uncertainty) = StandardConfidence.estimate(pva)
+    val (confidence, uncertainty) = StandardConfidence().estimate(pva)
     assert(Math.abs(confidence - expected) < 3 * uncertainty, "Confidence estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Confidence estimate was not precise enough")
   }
@@ -122,7 +123,7 @@ class MeritTest {
   def testPerfectUncertaintyCorrelation(): Unit = {
     val pva = getNormalPVA(noiseScale = 0.01, uncertaintyCorrelation = 1.0, batchSize = 256, numBatch = 32)
     val expected = 1.0
-    val (corr, uncertainty) = UncertaintyCorrelation.estimate(pva)
+    val (corr, uncertainty) = UncertaintyCorrelation().estimate(pva)
     assert(Math.abs(corr - expected) < 3 * uncertainty, "Uncertainty correlation estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Uncertainty correlation estimate was not precise enough")
   }
@@ -136,7 +137,7 @@ class MeritTest {
   def testZeroUncertaintyCorrelation(): Unit = {
     val pva = getNormalPVA(noiseScale = 0.01, uncertaintyCorrelation = 0.0, batchSize = 256, numBatch = 32)
     val expected = 0.0
-    val (corr, uncertainty) = UncertaintyCorrelation.estimate(pva)
+    val (corr, uncertainty) = UncertaintyCorrelation().estimate(pva)
     assert(Math.abs(corr - expected) < 3 * uncertainty, "Uncertainty correlation estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Uncertainty correlation estimate was not precise enough")
   }

--- a/src/test/scala/io/citrine/lolo/validation/StatisticalValidationTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/StatisticalValidationTest.scala
@@ -5,19 +5,22 @@ import io.citrine.lolo.learners.RandomForest
 import io.citrine.lolo.stats.functions.Friedman
 import org.junit.Test
 
+import scala.util.Random
+
 class StatisticalValidationTest {
+  val rng = new Random(783443769L)
 
   @Test
   def testCompareToKFolds(): Unit = {
     val learner = RandomForest()
-    val dataSet = TestUtils.generateTrainingData(128, 8, Friedman.friedmanSilverman)
+    val dataSet = TestUtils.generateTrainingData(128, 8, Friedman.friedmanSilverman, seed = rng.nextLong())
     val dataGenerator = TestUtils.iterateTrainingData(8, Friedman.friedmanSilverman)
 
-    val metrics = Map("rmse" -> RootMeanSquareError)
-    val (rmseFromCV, uncertaintyFromCV) = CrossValidation.kFoldCrossvalidation(dataSet, learner, metrics, k = 4, nTrial = 4)("rmse")
+    val metrics = Map("rmse" -> RootMeanSquareError())
+    val (rmseFromCV, uncertaintyFromCV) = CrossValidation(rng = rng).kFoldCrossvalidation(dataSet, learner, metrics, k = 4, nTrial = 4)("rmse")
 
     val (rmseFromStats, uncertaintyFromStats) = Merit.estimateMerits(
-      StatisticalValidation.generativeValidation(dataGenerator, learner, 96, 32, 16),
+      StatisticalValidation(rng = rng).generativeValidation(dataGenerator, learner, 96, 32, 16),
       metrics
     )("rmse")
 

--- a/src/test/scala/io/citrine/lolo/validation/StatisticalValidationTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/StatisticalValidationTest.scala
@@ -16,8 +16,8 @@ class StatisticalValidationTest {
     val dataSet = TestUtils.generateTrainingData(128, 8, Friedman.friedmanSilverman, seed = rng.nextLong())
     val dataGenerator = TestUtils.iterateTrainingData(8, Friedman.friedmanSilverman)
 
-    val metrics = Map("rmse" -> RootMeanSquareError())
-    val (rmseFromCV, uncertaintyFromCV) = CrossValidation(rng = rng).kFoldCrossvalidation(dataSet, learner, metrics, k = 4, nTrial = 4)("rmse")
+    val metrics = Map("rmse" -> RootMeanSquareError)
+    val (rmseFromCV, uncertaintyFromCV) = CrossValidation.kFoldCrossvalidation(dataSet, learner, metrics, k = 4, nTrial = 4)("rmse")
 
     val (rmseFromStats, uncertaintyFromStats) = Merit.estimateMerits(
       StatisticalValidation(rng = rng).generativeValidation(dataGenerator, learner, 96, 32, 16),


### PR DESCRIPTION
There are probably a few places where tests still aren't passing through an rng parameter, but this should *dramatically* reduce the incidence of false failures, and this exposes an interface that Mithril can use to decrease its false failure rate as well.

Most of these edits are non-breaking -- I think the breaking changes are limited to the following:
* `Merit` is now a case class so that objects can have unique state (`UncertaintyCorrelation` draws random numbers)
* `StatisticalValidation` is also now a case class for the same reason.