### PR TITLE
Removing scalactic

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val junitVersion = "4.13.1"
   lazy val thetaVersion = "1.1.2"
   lazy val breezeVersion = "1.1"
-  lazy val scalaticVersion = "3.2.2"
+  lazy val scalaTestVersion = "3.2.2"
 
   // this is used in build.sbt so that it works with both 2.12 and 2.13
   lazy val scalaParallelCollectionsVersion = "1.0.0"
@@ -15,8 +15,7 @@ object Dependencies {
     "junit" % "junit" % junitVersion % "test",
     "org.scalanlp" %% "breeze" % breezeVersion,
     "io.citrine" %% "theta" % thetaVersion,
-    "org.scalactic" %% "scalactic" % scalaticVersion,
-    "org.scalatest" %% "scalatest" % scalaticVersion % "test",
+    "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.knowm.xchart" % "xchart" % "3.5.2"
   )

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -77,7 +77,6 @@ case class MultiTaskBagger(
      */
     type arg = ((ParSeq[Model[PredictionResult[Any]]], Seq[Option[Vector[Double]]]), Int)
     models.transpose.zip(importances.seq.transpose).zipWithIndex.map { xx: arg =>
-      println("Got here")
       xx match {
         case ((m: ParSeq[Model[PredictionResult[Any]]], i: Seq[Option[Vector[Double]]]), k: Int) =>
           val averageImportance: Option[Vector[Double]] = i.reduce {


### PR DESCRIPTION
Removing scalactic library from lolo as it is not being used. This transitive dependency is being pulled into the platform-backend causing a version clash.