### PR TITLE
Make `CategoricalEncoder` serializable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
   include:
   - stage: test
     script:
-    - sbt +test
+    - sbt -sbt-launch-repo https://repo1.maven.org/maven2 +test
   - stage: test
     before_install:
       - - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -44,7 +44,7 @@ jobs:
     - nosetests
   - stage: release
     name: maven central
-    script: sbt ci-release
+    script: sbt -sbt-launch-repo https://repo1.maven.org/maven2 ci-release
   - stage: release
     name: pypi
     addons:

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,3 +1,3 @@
 all:
-	cd ..; sbt assembly
+	cd ..; sbt -sbt-launch-repo https://repo1.maven.org/maven2 assembly
 	pip install -e .

--- a/src/main/scala/io/citrine/lolo/encoders/CategoricalEncoder.scala
+++ b/src/main/scala/io/citrine/lolo/encoders/CategoricalEncoder.scala
@@ -10,7 +10,9 @@ package io.citrine.lolo.encoders
 class CategoricalEncoder[T](encoding: Map[T, Char]) extends Serializable {
 
   /** Inverse of the encoding */
-  lazy val decoding: Map[Char, T] = encoding.groupBy(_._2).mapValues(_.keys.head).toMap
+  lazy val decoding: Map[Char, T] = encoding
+    .groupBy { case (_, value) => value }
+    .map { case (key, value) => key -> value.keys.head }
 
   /**
     * Just call the encoding.  Use 0 for unknown inputs

--- a/src/test/scala/io/citrine/lolo/encoders/CategoricalEncoderTest.scala
+++ b/src/test/scala/io/citrine/lolo/encoders/CategoricalEncoderTest.scala
@@ -1,6 +1,8 @@
 package io.citrine.lolo.encoders
 
-import org.junit.Test
+import org.junit.{ Assert, Test }
+
+import java.io._
 
 /**
   * Created by maxhutch on 12/1/16.
@@ -15,13 +17,50 @@ class CategoricalEncoderTest {
   def testStringEncoder(): Unit = {
     val inputs = Seq("foo", "bar", "foobar")
     val encoder = CategoricalEncoder.buildEncoder(inputs)
-    val testValues = inputs ++ Seq("barfoo")
-    for (test <- testValues) {
-      assert(encoder.encode(test) == encoder.encode(test))
-    }
-    assert(encoder.encode("barfoo") == 0)
+    assertEncode(encoder, inputs ++ Seq("barfoo"))
+    Assert.assertEquals(0, encoder.encode("barfoo"))
   }
 
+  @Test
+  def testSerializable(): Unit = {
+    val inputs = Seq("foo", "bar", "foobar")
+    val encoder: CategoricalEncoder[String] = CategoricalEncoder.buildEncoder(inputs)
+    for (k <- encoder.decoding.keySet) {
+      encoder.decode(k)
+    }
+    val deserialized = deserialize(serialize(encoder))
+    assertEncode(deserialized, inputs)
+  }
+
+  private def assertEncode(encoder: CategoricalEncoder[String], testValues: Seq[String]): Unit = {
+    for (test <- testValues) {
+      Assert.assertEquals(encoder.encode(test), encoder.encode(test))
+    }
+  }
+
+  private def serialize(encoder: CategoricalEncoder[String]): Array[Byte] = {
+    val outputStream = new ByteArrayOutputStream(512)
+    val out = new ObjectOutputStream(outputStream)
+    try {
+      out.writeObject(encoder)
+      outputStream.toByteArray
+    } catch {
+      case _: IOException => throw new AssertionError("cannot serialize")
+    } finally {
+      if (out != null) out.close()
+    }
+  }
+
+  private def deserialize(bytes: Array[Byte]): CategoricalEncoder[String] = {
+    val in = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    try {
+      in.readObject().asInstanceOf[CategoricalEncoder[String]]
+    } catch {
+      case _: IOException => throw new AssertionError("cannot deserialize")
+    } finally {
+      if (in != null) in.close()
+    }
+  }
 }
 
 /** Companion driver */
@@ -33,5 +72,6 @@ object CategoricalEncoderTest {
     */
   def main(argv: Array[String]): Unit = {
     new CategoricalEncoderTest().testStringEncoder()
+    new CategoricalEncoderTest().testSerializable()
   }
 }


### PR DESCRIPTION
Use `.map` instead of `.mapValues` to make `decoding` field in `CategoricalEncoder` serializable.

Fixes #237