### PR TITLE
Update master -> main; describe tag releases; contributors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 stages:
   - name: test
   - name: release
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+    if: ((branch = main AND type = push) OR (tag IS present)) AND NOT fork
 
 jobs:
   include:
@@ -69,6 +69,7 @@ jobs:
     deploy:
       provider: pypi
       skip_cleanup: true
+      skip_existing: true
       user: CitrineInformatics
       password:
         secure: fb/NiAH7E1zA2iRUT+NMywH7dh0HF3qLM/JhjWLQWQ8l/pxOy7HPgk1CDEkZip/4emH2ur5+bGAD0pm0ewfDWfvjTPA+woV5IEebK2KL3Gm4Oam4fZP27NZ5zfYs6Q1dx3YPjRUgI3gtJ+0Y1tVKvZrUaZHityDMJDuEsYjdmPnFsA6s6U/5GYeQfWaYjZcflqYd01H8K9kbCeBsRBlOUm1lCXmt13R4uBOoMNAkuR7knYUOE1VM6VJWTN2T0iKphS9agxPHh/9/B9gjCQExhynOWSs5E2WhhDnWUoAJgyaZdxZQOxT2jJKA4dJGMCtyQScWItjsglcpthd+DsNtx/0vF1fDV3tvdjRVfegnhcF9fMUeI30O5jGTqNhimkiQsV1L+Sn6LFVAJKZ2yGzjqyS+8wn/uGOLQ04R46aw7KcfDJthzPU+dx0W78scTnkOnOx0R6eLH/HBn619h415JSsYpQ/D4A2VzODhHfScgzEe9xoL61ArhYz/wAqEAvit8WbFs4D7ZVnBc/98wsBD2NKUlmTZfkjPDAZQr49S1Na6UKlK6p4gLkXE6hfwgkFwxLiaQxOMfg0u/7VbbJzfrB2568HerS/oilDq+Bp+jNKUwyo08P0qD+8a4Gif1uk1UcipixDWbCvNlfr1H7+2FrN0+b92Xmfjd+CTMKmfv7o=

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Lolo
 ====
 
-![Travis](https://travis-ci.org/CitrineInformatics/lolo.svg?branch=develop)
+![Travis](https://travis-ci.org/CitrineInformatics/lolo.svg?branch=main)
 
 Lolo is a [random forest](https://en.wikipedia.org/wiki/Lolo_National_Forest)-centered machine learning library in Scala.
 
@@ -34,7 +34,7 @@ Lolo is on the central repository, and can be used by simply adding the followin
 <dependency>
     <groupId>io.citrine</groupId>
     <artifactId>lolo</artifactId>
-    <version>3.0.1</version>
+    <version>3.1.1</version>
 </dependency>
 ```
 Lolo provides higher level wrappers for common learner combinations.
@@ -60,12 +60,17 @@ On an [Ivy Bridge](http://ark.intel.com/products/77780/Intel-Core-i7-4930K-Proce
 
 
 # Contributing
-We welcome bug reports, feature requests, and pull requests.  Pull requests should be made following the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow).  As contributions expand, we'll put more information here.
+We welcome bug reports, feature requests, and pull requests.
+Pull requests should be made following the [feature branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow): branching off of and opening PRs into `main`.
+
+Production releases are triggered by tags.
+The [sbt-ci-release plugin](https://github.com/olafurpg/sbt-ci-release) will use the tag as the `lolo` version.
+On the other hand, `lolopy` versions are still read from `setup.py`, so version bumps are needed for successful releases.
+Failing to bump the `lolopy` version number will result in a skipped `lolopy` release rather than a build failure.
 
 # Authors
- * [Max Hutchinson](https://github.com/maxhutch/)
- * [Sean Paradiso](https://github.com/sparadiso)
- * [Logan Ward](https://github.com/WardLT)
+
+See [Contributors](https://github.com/CitrineInformatics/lolo/graphs/contributors)
  
 # Related projects
  * [randomForestCI](https://github.com/swager/randomForestCI) is an R-based implementation of jackknife variance estimates by S. Wager


### PR DESCRIPTION
Simplify the branching pattern from gitflow to feature branch flow,
base it on main instead of master, and otherwise update the readme a
bit.