### PR TITLE
Split NaN and non-NaN values in RealSplit

### DIFF
--- a/src/main/scala/io/citrine/lolo/trees/splits/Split.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/Split.scala
@@ -57,7 +57,13 @@ class RealSplit(index: Int, pivot: Double) extends Split {
     * @return true if input takes the left split
     */
   override def turnLeft(input: Vector[AnyVal]): Boolean = {
-    input(index).asInstanceOf[Double] <= pivot
+    if (pivot.isNaN) {
+      // the normal sort order for scala puts NaN >> any other double
+      // so if the pivot is NaN and the value is not, then it is 'less than' the pivot
+      !input(index).asInstanceOf[Double].isNaN
+    } else {
+      input(index).asInstanceOf[Double] <= pivot
+    }
   }
 
   /**

--- a/src/test/scala/io/citrine/lolo/trees/splits/SplitTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/SplitTest.scala
@@ -1,0 +1,19 @@
+package io.citrine.lolo.trees.splits
+
+import org.junit.Test
+
+class SplitTest {
+
+  /**
+    * Make sure that splits on NaN will distinguish between NaN and non-NaN values.
+    */
+  @Test
+  def testSplitNaN(): Unit = {
+    val split = new RealSplit(0, Double.NaN)
+    assert(
+      split.turnLeft(Vector(0.0)) != split.turnLeft(Vector(Double.NaN)),
+      "NaN and non-Nan values are split in the same direction."
+    )
+  }
+
+}


### PR DESCRIPTION
Since 0 < NaN is false but also 0 >= NaN is false, NaN pivots
were putting everything into the same split, which was breaking
an assertion later in the code.  This checks to see if the pivot
is NaN and, if so, splits on `isNaN`.