### PR TITLE
Remove sbt-launch-repo, which was a hack and isn't standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
   include:
   - stage: test
     script:
-    - sbt -sbt-launch-repo https://repo1.maven.org/maven2 +test
+    - sbt +test
   - stage: test
     before_install:
       - - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -44,7 +44,7 @@ jobs:
     - nosetests
   - stage: release
     name: maven central
-    script: sbt -sbt-launch-repo https://repo1.maven.org/maven2 ci-release
+    script: sbt ci-release
   - stage: release
     name: pypi
     addons:

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,3 +1,3 @@
 all:
-	cd ..; sbt -sbt-launch-repo https://repo1.maven.org/maven2 assembly
+	cd ..; sbt assembly
 	pip install -e .


### PR DESCRIPTION
We added sbt-launch-repo to deal with a sbt hosting migration.
Now that's over, and we shouldn't need it anymore, which is good
because it is not part of standard SBT