### PR TITLE
Update dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   lazy val netlibVersion = "1.1.2"
   lazy val junitVersion = "4.13.1"
-  lazy val thetaVersion = "1.1.2"
+  lazy val thetaVersion = "1.1.3"
   lazy val breezeVersion = "1.2"
   lazy val scalaTestVersion = "3.2.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,17 +1,15 @@
 import sbt._
 
 object Dependencies {
-  lazy val netlibVersion = "1.1.2"
   lazy val junitVersion = "4.13.1"
   lazy val thetaVersion = "1.1.2"
-  lazy val breezeVersion = "1.1"
+  lazy val breezeVersion = "1.2"
   lazy val scalaTestVersion = "3.2.2"
 
   // this is used in build.sbt so that it works with both 2.12 and 2.13
   lazy val scalaParallelCollectionsVersion = "1.0.0"
 
   val loloDeps = Seq(
-    "com.github.fommil.netlib" % "all" % netlibVersion,
     "junit" % "junit" % junitVersion % "test",
     "org.scalanlp" %% "breeze" % breezeVersion,
     "io.citrine" %% "theta" % thetaVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,7 @@
 import sbt._
 
 object Dependencies {
+  lazy val netlibVersion = "1.1.2"
   lazy val junitVersion = "4.13.1"
   lazy val thetaVersion = "1.1.2"
   lazy val breezeVersion = "1.2"
@@ -10,9 +11,9 @@ object Dependencies {
   lazy val scalaParallelCollectionsVersion = "1.0.0"
 
   val loloDeps = Seq(
+    "com.github.fommil.netlib" % "all" % netlibVersion pomOnly(),
     "junit" % "junit" % junitVersion % "test",
     "org.scalanlp" %% "breeze" % breezeVersion,
-    "org.scalanlp" %% "breeze-natives" % breezeVersion,
     "io.citrine" %% "theta" % thetaVersion,
     "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,7 @@
 import sbt._
 
 object Dependencies {
+  lazy val netlibVersion = "1.1.2"
   lazy val junitVersion = "4.13.1"
   lazy val thetaVersion = "1.1.2"
   lazy val breezeVersion = "1.2"
@@ -10,6 +11,7 @@ object Dependencies {
   lazy val scalaParallelCollectionsVersion = "1.0.0"
 
   val loloDeps = Seq(
+    "com.github.fommil.netlib" % "all" % netlibVersion pomOnly(),
     "junit" % "junit" % junitVersion % "test",
     "org.scalanlp" %% "breeze" % breezeVersion,
     "io.citrine" %% "theta" % thetaVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,6 @@
 import sbt._
 
 object Dependencies {
-  lazy val netlibVersion = "1.1.2"
   lazy val junitVersion = "4.13.1"
   lazy val thetaVersion = "1.1.2"
   lazy val breezeVersion = "1.2"
@@ -11,9 +10,9 @@ object Dependencies {
   lazy val scalaParallelCollectionsVersion = "1.0.0"
 
   val loloDeps = Seq(
-    "com.github.fommil.netlib" % "all" % netlibVersion pomOnly(),
     "junit" % "junit" % junitVersion % "test",
     "org.scalanlp" %% "breeze" % breezeVersion,
+    "org.scalanlp" %% "breeze-natives" % breezeVersion,
     "io.citrine" %% "theta" % thetaVersion,
     "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",


### PR DESCRIPTION
This bumps the version of breeze from 1.1 to 1.2, upgrades theta to the latest version and adds netlib as a pom-only dependency. (Not including netlib as pom-only is causing issues downstream and is the main reason for this PR.)