### PR TITLE
Pla 8537/implement several correlations

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -533,7 +533,7 @@ case class MultiTaskBaggedResult(
         }.map(_.toScalaVector())
         // For each prediction, rectify the covariance scores to compute correlation
         Some(
-          scores.lazyZip(sigmaISeq).lazyZip(sigmaJSeq).map { (trainingContributions, sigmaI, sigmaJ) =>
+          (scores, sigmaISeq, sigmaJSeq).zipped.map { (trainingContributions, sigmaI, sigmaJ) =>
             BaggedResult.rectifyCorrelationScores(trainingContributions, sigmaI, sigmaJ)
           }
         )

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -558,7 +558,7 @@ case class MultiTaskBaggedResult(
         }.map(_.toScalaVector())
         // For each prediction, rectify the covariance scores to compute correlation
         Some(
-          (scores, sigmaISeq, sigmaJSeq).zipped.map { (trainingContributions, sigmaI, sigmaJ) =>
+          scores.lazyZip(sigmaISeq).lazyZip(sigmaJSeq).map { (trainingContributions, sigmaI, sigmaJ) =>
             BaggedResult.rectifyCorrelationScores(trainingContributions, sigmaI, sigmaJ)
           }
         )

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -263,7 +263,7 @@ case class MultiPredictionBaggedResult(
 
   override def numPredictions: Int = expectedMatrix.length
 
-  /* transpose to be training-wise */
+  /* transpose to be (# training) x (# models) */
   lazy val Nib: Vector[Vector[Int]] = NibIn.transpose
 
   /* Make a matrix of the tree-wise predictions */
@@ -411,7 +411,7 @@ case class MultiTaskBaggedResult(
                                   trainingWeights: Seq[Double]
                                 ) extends BaggedResult[Seq[Any]] with MultiTaskModelPredictionResult {
 
-  /* transpose to be training-wise */
+  /* transpose to be (# training) x (# models) */
   lazy val Nib: Vector[Vector[Int]] = NibIn.transpose
 
   lazy val NibJMat = BaggedResult.getJackknifeAfterBootstrapMatrix(Nib)
@@ -702,7 +702,8 @@ object BaggedResult {
     * Calculate the correlation coefficient given a sequence of covariance scores for each training point.
     * In theory, the covariance is the sum of the individual covariance scores. But because each covariance score
     * is noisy, the resulting sum can be larger in absolute value than `sigmaX * sigmaY`, which would translate into
-    * a correlation coefficient that is outside [-1.0, 1.0].
+    * a correlation coefficient that is outside [-1.0, 1.0], and hence we cannot calculate a conditional probability.
+    * The implementation here is to set rho equal to 0 if it is less than -0.999 or greater than 0.999.
     *
     * @param covarianceScores sequence of Monte Carlo corrected covariance contributions for each training point
     * @param sigmaX           uncertainty in first label

--- a/src/main/scala/io/citrine/lolo/bags/CorrelationMethods.scala
+++ b/src/main/scala/io/citrine/lolo/bags/CorrelationMethods.scala
@@ -1,0 +1,8 @@
+package io.citrine.lolo.bags
+
+/** Enumerates the ways in which uncertainty correlation can be calculated. */
+object CorrelationMethods extends Enumeration {
+  type CorrelationMethod = Value
+
+  val Trivial, FromTraining, Bootstrap, Jackknife, JackknifeExplicit = Value
+}

--- a/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
@@ -31,7 +31,7 @@ object StatsUtils {
     val totalWeight = actualWeights.sum
     val muX = mean(X, Some(actualWeights))
     val muY = mean(Y, Some(actualWeights))
-    X.lazyZip(Y).lazyZip(actualWeights).map { case (x, y, w) => (x - muX) * (y - muY) * w }.sum / totalWeight
+    (X, Y, actualWeights).zipped.map { case (x, y, w) => (x - muX) * (y - muY) * w }.sum / totalWeight
   }
 
   /** Compute the (weighted) correlation coefficient between two vectors, X and Y, of the same length. */

--- a/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
@@ -4,7 +4,7 @@ import io.citrine.lolo.linear.LinearRegressionLearner
 
 import scala.util.Random
 
-object utils {
+object StatsUtils {
 
   /** Compute the mean of a (weighted) vector, X */
   def mean(X: Seq[Double], weights: Option[Seq[Double]] = None): Double = {

--- a/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
@@ -31,7 +31,7 @@ object StatsUtils {
     val totalWeight = actualWeights.sum
     val muX = mean(X, Some(actualWeights))
     val muY = mean(Y, Some(actualWeights))
-    (X, Y, actualWeights).zipped.map { case (x, y, w) => (x - muX) * (y - muY) * w }.sum / totalWeight
+    X.lazyZip(Y).lazyZip(actualWeights).map { case (x, y, w) => (x - muX) * (y - muY) * w }.sum / totalWeight
   }
 
   /** Compute the (weighted) correlation coefficient between two vectors, X and Y, of the same length. */

--- a/src/main/scala/io/citrine/lolo/stats/utils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/utils.scala
@@ -1,5 +1,9 @@
 package io.citrine.lolo.stats
 
+import io.citrine.lolo.linear.LinearRegressionLearner
+
+import scala.util.Random
+
 object utils {
 
   /** Compute the mean of a (weighted) vector, X */
@@ -37,6 +41,30 @@ object utils {
     val sigma2Y = variance(Y, Some(actualWeights), dof = 0)
     if (sigma2X == 0 || sigma2Y == 0) return 0.0
     covariance(X, Y, Some(actualWeights)) / math.sqrt(sigma2X * sigma2Y)
+  }
+
+  /** Given a univariate data set, construct a corresponding data set with the desired Pearson correlation coefficient.
+    * The procedure is to generate new data randomly, calculate the residuals of a linear regression,
+    * and then create a suitable linear combination of X and the residuals.
+    * Source: https://stats.stackexchange.com/a/313138
+    *
+    * @param X    sequence of values
+    * @param rho  desired Pearson correlation coefficient
+    * @param rng  random number generator
+    * @return     sequence of values that have desired correlation with X
+    */
+  def makeLinearCorrelatedData(X: Seq[Double], rho: Double, rng: Random = new Random()): Seq[Double] = {
+    require(rho >= -1.0 && rho <= 1.0, "correlation coefficient must be between -1.0 and 1.0")
+    val Y = Seq.fill(X.length)(rng.nextGaussian())
+    val linearLearner = LinearRegressionLearner()
+    val linearModel = linearLearner.train(X.zip(Y).map { case (x, y) => (Vector(x), y) } ).getModel()
+    val yPred = linearModel.transform(X.map(Vector(_))).getExpected()
+    val residuals = Y.zip(yPred).map { case (actual, predicted) => actual - predicted }
+    val muX = mean(X)
+    val stdX = math.sqrt(variance(X))
+    val muResiduals = mean(residuals)
+    val stdResiduals = math.sqrt(variance(residuals))
+    X.zip(residuals).map { case (x, residual) => rho * stdResiduals * x + math.sqrt(1 - rho * rho) * stdX * residual}
   }
 
 }

--- a/src/main/scala/io/citrine/lolo/stats/utils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/utils.scala
@@ -1,0 +1,42 @@
+package io.citrine.lolo.stats
+
+object utils {
+
+  /** Compute the mean of a (weighted) vector, X */
+  def mean(X: Seq[Double], weights: Option[Seq[Double]] = None): Double = {
+    val actualWeights = weights.getOrElse(Seq.fill(X.length)(1.0))
+    val totalWeight = actualWeights.sum
+    require(totalWeight > 0.0, s"total weight must be positive, instead got $totalWeight")
+    X.zip(actualWeights).map { case (x, w) => x * w }.sum / totalWeight
+  }
+
+  /** Compute the variance of a (weighted) vector, X, with dof degrees of freedom. */
+  def variance(X: Seq[Double], weights: Option[Seq[Double]] = None, dof: Int = 0): Double = {
+    val actualWeights = weights.getOrElse(Seq.fill(X.length)(1.0))
+    val totalWeight = actualWeights.sum
+    require(dof >= 0, s"degrees of freedom must be non-negative, instead got $dof")
+    require(totalWeight > dof, s"Cannot compute variance on a sequence of weight $totalWeight with $dof degrees of freedom.")
+    val mu = mean(X, Some(actualWeights))
+    X.zip(actualWeights).map { case (x, w) => math.pow(x - mu, 2.0) * w }.sum / (totalWeight - dof)
+  }
+
+  /** Compute the (weighted) covariance between two vectors, X and Y, of the same length. */
+  def covariance(X: Seq[Double], Y: Seq[Double], weights: Option[Seq[Double]] = None): Double = {
+    require(X.length == Y.length, s"Cannot compute covariance between sequences of different lengths (lengths are ${X.length} and ${Y.length}).")
+    val actualWeights = weights.getOrElse(Seq.fill(X.length)(1.0))
+    val totalWeight = actualWeights.sum
+    val muX = mean(X, Some(actualWeights))
+    val muY = mean(Y, Some(actualWeights))
+    (X, Y, actualWeights).zipped.map { case (x, y, w) => (x - muX) * (y - muY) * w }.sum / totalWeight
+  }
+
+  /** Compute the (weighted) correlation coefficient between two vectors, X and Y, of the same length. */
+  def correlation(X: Seq[Double], Y: Seq[Double], weights: Option[Seq[Double]] = None): Double = {
+    val actualWeights = weights.getOrElse(Seq.fill(X.length)(1.0))
+    val sigma2X = variance(X, Some(actualWeights), dof = 0)
+    val sigma2Y = variance(Y, Some(actualWeights), dof = 0)
+    if (sigma2X == 0 || sigma2Y == 0) return 0.0
+    covariance(X, Y, Some(actualWeights)) / math.sqrt(sigma2X * sigma2Y)
+  }
+
+}

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -3,7 +3,7 @@ package io.citrine.lolo.bags
 import breeze.stats.distributions.Beta
 import io.citrine.lolo.TestUtils
 import io.citrine.lolo.linear.GuessTheMeanLearner
-import io.citrine.lolo.stats.utils.makeLinearCorrelatedData
+import io.citrine.lolo.stats.StatsUtils.makeLinearCorrelatedData
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner

--- a/src/test/scala/io/citrine/lolo/stats/UtilsTest.scala
+++ b/src/test/scala/io/citrine/lolo/stats/UtilsTest.scala
@@ -13,8 +13,8 @@ class UtilsTest {
     val rng = new Random()
     val rho = rng.nextDouble() * 2.0 - 1.0
     val X = Seq.fill(24)(rng.nextDouble())
-    val Y = utils.makeLinearCorrelatedData(X, rho)
-    assert(math.abs(utils.correlation(X, Y) - rho) < 1e-8)
+    val Y = StatsUtils.makeLinearCorrelatedData(X, rho)
+    assert(math.abs(StatsUtils.correlation(X, Y) - rho) < 1e-8)
   }
 
 }

--- a/src/test/scala/io/citrine/lolo/stats/UtilsTest.scala
+++ b/src/test/scala/io/citrine/lolo/stats/UtilsTest.scala
@@ -1,0 +1,20 @@
+package io.citrine.lolo.stats
+
+import org.junit.Test
+import org.scalatest.Assertions._
+
+import scala.util.Random
+
+class UtilsTest {
+
+  /** Test that a linearly correlated data set has the expected correlation coefficient. */
+  @Test
+  def testLinearCorrelatedData(): Unit = {
+    val rng = new Random()
+    val rho = rng.nextDouble() * 2.0 - 1.0
+    val X = Seq.fill(24)(rng.nextDouble())
+    val Y = utils.makeLinearCorrelatedData(X, rho)
+    assert(math.abs(utils.correlation(X, Y) - rho) < 1e-8)
+  }
+
+}


### PR DESCRIPTION
This PR implements several ways of calculating the uncertainty correlation for a multitask bagged model. Assuming the two labels are distinct and both correspond to real values, then we have the following options:
* always predict rho = 0 (this is the trivial method)
* calculate rho using the correlation over training data
* calculate rho using the bootstrap predictions
* calculate rho from the infinitesimal jackknife & jackknife-after-bootstrap covariance, divided by the square root of the associated variances

The last method is implemented in two different ways. One is more explicit and uses loops. It can be easily compared to the published method in Wager et. al. (2014). The other is more performant and uses matrix arithmetic. The two are tested against each other for consistency.