### PR TITLE
Pla 8566/multitask predicted-vs-actual

### DIFF
--- a/src/main/scala/io/citrine/lolo/TrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/TrainingResult.scala
@@ -39,5 +39,5 @@ trait MultiTaskTrainingResult extends TrainingResult {
 
   def getModels(): Seq[Model[PredictionResult[Any]]]
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Seq[Any], Seq[Any])]] = None
+  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Seq[Option[Any]], Seq[Option[Any]])]] = None
 }

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -2,7 +2,7 @@ package io.citrine.lolo.bags
 
 import breeze.linalg.DenseMatrix
 import breeze.stats.distributions.{Poisson, Rand, RandBasis}
-import io.citrine.lolo.stats.metrics.ClassificationMetrics
+import io.citrine.lolo.stats.metrics.{ClassificationMetrics, RegressionMetrics}
 import io.citrine.lolo.util.{Async, InterruptibleExecutionContext}
 import io.citrine.lolo.{Learner, Model, PredictionResult, RegressionResult, TrainingResult}
 
@@ -210,10 +210,8 @@ class BaggedTrainingResult[+T : ClassTag](
   }
 
   lazy val loss: Double = rep match {
-    case _: Double => Math.sqrt(predictedVsActual.map(d => Math.pow(d._2.asInstanceOf[Double] - d._3.asInstanceOf[Double], 2)).sum / predictedVsActual.size)
-    case _: Any =>
-      val f1 = ClassificationMetrics.f1scores(predictedVsActual)
-      if (f1 > 0.0) 1.0 / f1 - 1.0 else Double.MaxValue
+    case _: Double => RegressionMetrics.RMSE(predictedVsActual.asInstanceOf[Seq[(Vector[Any], Double, Double)]])
+    case _: Any => ClassificationMetrics.loss(predictedVsActual)
   }
 
   /**

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -111,27 +111,28 @@ class MultiTaskBaggedTrainingResult(
 
   lazy val model = new MultiTaskBaggedModel(models, Nib, useJackknife, biasModels)
 
-  lazy val predictedVsActual = trainingData.zip(Nib.transpose).flatMap { case ((features, labels), nb) =>
-    // Bagged models that were not trained on this input
-    val oob = models.zip(nb).filter(_._2 == 0).map(_._1)
-    if (oob.isEmpty) {
-      Seq()
-    } else {
-      // "Average" the predictions on each label over the out-of-bag models
-      val oobPredictions = oob.map(_.transform(Seq(features)).getExpected().head)
-      val predicted = oobPredictions.toVector.transpose.zipWithIndex.map {
-        case (predictions, labelIndex) if models.head.getRealLabels(labelIndex) =>
-          predictions.asInstanceOf[Seq[Double]].sum / predictions.size
-        case (predictions, _) => predictions.groupBy(identity).maxBy(_._2.size)._1
+  lazy val predictedVsActual: Seq[(Vector[Any], Seq[Option[Any]], Seq[Option[Any]])] =
+    trainingData.zip(Nib.transpose).flatMap { case ((features, labels), nb) =>
+      // Bagged models that were not trained on this input
+      val oob = models.zip(nb).filter(_._2 == 0).map(_._1)
+      if (oob.isEmpty) {
+        Seq()
+      } else {
+        // "Average" the predictions on each label over the out-of-bag models
+        val oobPredictions = oob.map(_.transform(Seq(features)).getExpected().head)
+        val predicted = oobPredictions.toVector.transpose.zipWithIndex.map {
+          case (predictions, labelIndex) if models.head.getRealLabels(labelIndex) =>
+            predictions.asInstanceOf[Seq[Double]].sum / predictions.size
+          case (predictions, _) => predictions.groupBy(identity).maxBy(_._2.size)._1
+        }
+        // Remove predictions for which the label was not specified
+        val (optionLabels, optionPredicted) = labels.zip(predicted).map {
+          case (l, _) if l == null || (l.isInstanceOf[Double] && l.asInstanceOf[Double].isNaN) => (None, None)
+          case (l, p) => (Some(l), Some(p))
+        }.unzip
+        Seq((features, optionPredicted, optionLabels))
       }
-      // Remove predictions for which the label was not specified
-      val (optionLabels, optionPredicted) = labels.zip(predicted).map {
-        case (l, _) if l == null || (l.isInstanceOf[Double] && l.asInstanceOf[Double].isNaN) => (None, None)
-        case (l, p) => (Some(l), Some(p))
-      }.unzip
-      Seq((features, optionPredicted, optionLabels))
     }
-  }
 
   lazy val loss = {
     val allInputs = predictedVsActual.map(_._1)

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -2,6 +2,7 @@ package io.citrine.lolo.bags
 
 import breeze.stats.distributions.{Poisson, Rand, RandBasis}
 import io.citrine.lolo._
+import io.citrine.lolo.stats.metrics.{ClassificationMetrics, RegressionMetrics}
 import io.citrine.lolo.util.{Async, InterruptibleExecutionContext}
 
 import scala.collection.parallel.ExecutionContextTaskSupport
@@ -110,7 +111,7 @@ class MultiTaskBaggedTrainingResult(
 
   lazy val model = new MultiTaskBaggedModel(models, Nib, useJackknife, biasModels)
 
-  val predictedVsActual = trainingData.zip(Nib.transpose).flatMap { case ((features, labels), nb) =>
+  lazy val predictedVsActual = trainingData.zip(Nib.transpose).flatMap { case ((features, labels), nb) =>
     // Bagged models that were not trained on this input
     val oob = models.zip(nb).filter(_._2 == 0).map(_._1)
     if (oob.isEmpty) {
@@ -123,7 +124,7 @@ class MultiTaskBaggedTrainingResult(
           predictions.asInstanceOf[Seq[Double]].sum / predictions.size
         case (predictions, _) => predictions.groupBy(identity).maxBy(_._2.size)._1
       }
-      // Remove predictions if the label was not specified
+      // Remove predictions for which the label was not specified
       val (optionLabels, optionPredicted) = labels.zip(predicted).map {
         case (l, _) if l == null || (l.isInstanceOf[Double] && l.asInstanceOf[Double].isNaN) => (None, None)
         case (l, p) => (Some(l), Some(p))
@@ -132,15 +133,33 @@ class MultiTaskBaggedTrainingResult(
     }
   }
 
+  lazy val loss = {
+    val allInputs = predictedVsActual.map(_._1)
+    val allPredicted: Seq[Seq[Option[Any]]] = predictedVsActual.map(_._2).transpose
+    val allActual: Seq[Seq[Option[Any]]] = predictedVsActual.map(_._3).transpose
+    (allPredicted, allActual, models.head.getRealLabels).zipped.map { case (labelPredicted, labelActual, isReal) =>
+      // Construct predicted-vs-actual for just this label, only keeping entries for which both predicted and actual are defined
+      val pva = (allInputs, labelPredicted, labelActual).zipped.flatMap {
+        case (input, Some(p), Some(a)) => Some((input, p, a))
+        case _ => None
+      }
+      if (isReal) {
+        RegressionMetrics.RMSE(pva.asInstanceOf[Seq[(Vector[Any], Double, Double)]])
+      } else {
+        ClassificationMetrics.loss(pva)
+      }
+    }
+  }.sum
+
   override def getFeatureImportance(): Option[Vector[Double]] = featureImportance
 
   override def getModel(): MultiTaskBaggedModel = model
 
   override def getModels(): Seq[Model[PredictionResult[Any]]] = {
     val realLabels: Seq[Boolean] = models.head.getRealLabels
-    realLabels.zipWithIndex.map { case (realLabel: Boolean, i: Int) =>
+    realLabels.zipWithIndex.map { case (isReal: Boolean, i: Int) =>
       val thisLabelModels = models.map(_.getModels(i))
-      if (realLabel) {
+      if (isReal) {
         new BaggedModel[Double](thisLabelModels.asInstanceOf[ParSeq[Model[PredictionResult[Double]]]], Nib, useJackknife, biasModels(i), rescaleRatios(i))
       } else {
         new BaggedModel[Any](thisLabelModels.asInstanceOf[ParSeq[Model[PredictionResult[Any]]]], Nib, useJackknife, biasModels(i), rescaleRatios(i))
@@ -149,6 +168,10 @@ class MultiTaskBaggedTrainingResult(
   }
 
   override def getPredictedVsActual(): Option[Seq[(Vector[Any], Seq[Option[Any]], Seq[Option[Any]])]] = Some(predictedVsActual)
+
+  override def getLoss(): Option[Double] = {
+    if (predictedVsActual.nonEmpty) Some(loss) else None
+  }
 }
 
 /**

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -111,6 +111,10 @@ class MultiTaskBaggedTrainingResult(
 
   lazy val model = new MultiTaskBaggedModel(models, Nib, useJackknife, biasModels)
 
+  // Each entry is a tuple, (feature vector, seq of predicted labels, seq of actual labels).
+  // The labels are of type Option[Any] because a given training datum might not have a value for every single label.
+  // If the actual value for a label is None, then the corresponding prediction is recorded as None. The model could generate
+  // a prediction, but that's not useful in this context, since the point is to compare predictions with ground-truth values.
   lazy val predictedVsActual: Seq[(Vector[Any], Seq[Option[Any]], Seq[Option[Any]])] =
     trainingData.zip(Nib.transpose).flatMap { case ((features, labels), nb) =>
       // Bagged models that were not trained on this input

--- a/src/main/scala/io/citrine/lolo/stats/metrics/ClassificationMetrics.scala
+++ b/src/main/scala/io/citrine/lolo/stats/metrics/ClassificationMetrics.scala
@@ -38,4 +38,10 @@ object ClassificationMetrics {
   def f1scores(predicted: Seq[Any], actual: Seq[Any]): Double = {
     f1scores(predicted.zip(actual).map(x => (Vector(), x._1, x._2)))
   }
+
+  /** Compute the loss on a scale from 0 (perfect model, f1 = 1.0) to infinity (f1 = 0, all predictions are incorrect) */
+  def loss(predictedVsActual: Seq[(Vector[Any], Any, Any)]): Double = {
+    val f1 = f1scores(predictedVsActual)
+    if (f1 > 0.0) 1.0 / f1 - 1.0 else Double.MaxValue
+  }
 }

--- a/src/main/scala/io/citrine/lolo/stats/metrics/RegressionMetrics.scala
+++ b/src/main/scala/io/citrine/lolo/stats/metrics/RegressionMetrics.scala
@@ -1,0 +1,10 @@
+package io.citrine.lolo.stats.metrics
+
+object RegressionMetrics {
+
+  /** Compute the root mean squared error. */
+  def RMSE(predictedVsActual: Seq[(Vector[Any], Double, Double)]): Double = {
+    math.sqrt(predictedVsActual.map { case (_, p, a) => math.pow(p - a, 2.0) }.sum / predictedVsActual.length)
+  }
+
+}

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -112,10 +112,10 @@ case class MultiTaskRotatedFeatureTrainingResult(
     RotatedFeatureModel(model, rotatedFeatures, trans)
   }
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Seq[Any], Seq[Any])]] = {
+  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Seq[Option[Any]], Seq[Option[Any]])]] = {
     baseTrainingResult.getPredictedVsActual() match {
       case None => None
-      case Some(predictedVsActual) => Some(predictedVsActual.map { case (inputs: Vector[Any], predicted: Any, actual: Any) =>
+      case Some(predictedVsActual) => Some(predictedVsActual.map { case (inputs: Vector[Any], predicted: Seq[Option[Any]], actual: Seq[Option[Any]]) =>
         (FeatureRotator.applyOneRotation(inputs, rotatedFeatures, trans), predicted, actual)
       })
     }

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -297,6 +297,7 @@ object Standardizer {
     * @return sequence of standardized values
     */
   def applyStandardization(input: Seq[Any], trans: Option[Standardization]): Seq[Any] = {
-    applyStandardization(input.map(Vector(_)), Seq(trans))
+    if (trans.isEmpty) return input
+    input.asInstanceOf[Seq[Double]].map(trans.get.apply)
   }
 }

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -43,8 +43,7 @@ class MultiTaskBaggerTest {
     assert(sigma.forall(_ >= 0.0))
 
     assert(results.getGradient().isEmpty, "Returned a gradient when there shouldn't be one")
-    // TODO (PLA-8566): enable when MultiTaskBagger getLoss is enabled
-    // assert(RFMeta.getLoss().get < 1.0, "Loss of bagger is larger than expected")
+    assert(RFMeta.getLoss().get < 1.0, "Loss of bagger is larger than expected")
   }
 
   /**
@@ -258,8 +257,7 @@ class MultiTaskBaggerTest {
 
     // Make sure we can grab the loss without issue
     assert(!referenceModel.getLoss().get.isNaN, "Single task classification loss was NaN")
-    // TODO (PLA-8566): enable when MultiTaskModel getLoss is enabled
-    // assert(!trainingResult.getLoss().get.isNaN, "Sparse multitask loss was NaN")
+    assert(!trainingResult.getLoss().get.isNaN, "Sparse multitask loss was NaN")
 
     assert(multiF1 > singleF1, s"Multi-task is under-performing single-task")
     assert(multiF1 <= 1.0, "Multitask classification F1 score was greater than 1.0")


### PR DESCRIPTION
Implement `getPredictedVsActual` for multitask bagged model, and in doing so allow for an implementation of `getLoss`. Because we expect to use multitask bagged models inside of a standardizer model, we also implement `getPredictedVsActual` for standardizers.