### PR TITLE
Pla 8639/correlation test harness

### DIFF
--- a/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
@@ -14,6 +14,11 @@ object StatsUtils {
     X.zip(actualWeights).map { case (x, w) => x * w }.sum / totalWeight
   }
 
+  def median(X: Seq[Double]): Double = {
+    val (lower, upper) = X.sorted.splitAt(X.size / 2)
+    if (X.size % 2 == 0) (lower.last + upper.head) / 2.0 else upper.head
+  }
+
   /** Compute the variance of a (weighted) vector, X, with dof degrees of freedom. */
   def variance(X: Seq[Double], weights: Option[Seq[Double]] = None, dof: Int = 0): Double = {
     val actualWeights = weights.getOrElse(Seq.fill(X.length)(1.0))

--- a/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
@@ -65,9 +65,7 @@ object StatsUtils {
     val linearModel = linearLearner.train(X.zip(Y).map { case (x, y) => (Vector(x), y) } ).getModel()
     val yPred = linearModel.transform(X.map(Vector(_))).getExpected()
     val residuals = Y.zip(yPred).map { case (actual, predicted) => actual - predicted }
-    val muX = mean(X)
     val stdX = math.sqrt(variance(X))
-    val muResiduals = mean(residuals)
     val stdResiduals = math.sqrt(variance(residuals))
     X.zip(residuals).map { case (x, residual) => rho * stdResiduals * x + math.sqrt(1 - rho * rho) * stdX * residual}
   }

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -160,7 +160,7 @@ case class NegativeLogProbabilityDensity2d(i: Int, j: Int, method: CorrelationMe
   def NLPD(pvas: Seq[PredictedVsActualTwoDimensions]): Seq[Double] = {
     pvas.map { pva =>
       val term1 = math.log(2 * math.Pi * pva.sigmaX * pva.sigmaY * math.sqrt(1 - math.pow(pva.rho, 2.0)))
-      val term2 = 1/2 * pva.mahalanobisSquared
+      val term2 = 0.5 * pva.mahalanobisSquared
       term1 + term2
     }
   }

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -1,8 +1,10 @@
 package io.citrine.lolo.validation
 
 import java.util
-
 import io.citrine.lolo.PredictionResult
+import io.citrine.lolo.bags.CorrelationMethods.CorrelationMethod
+import io.citrine.lolo.bags.MultiTaskBaggedResult
+import io.citrine.lolo.stats.StatsUtils
 import org.knowm.xchart.XYChart
 
 import scala.collection.JavaConverters._
@@ -129,6 +131,77 @@ case object UncertaintyCorrelation extends Merit[Double] {
 
     val covar = error.zip(sigma).map { case (x, y) => (x - meanError) * (y - meanSigma) }.sum / sigma.size
     covar / Math.sqrt(varError * varSigma)
+  }
+
+  /**
+    * Negative Log Probability Density (NLPD) in two dimensions
+    * NLPD is calculated for each point and the median value is returned.
+    *
+    * @param i index of the first label to be compared
+    * @param j index of the second label to be compared
+    * @param method method to calculate correlation coefficient
+    * @param observational whether or not to calculate the observational uncertainty
+    */
+  case class NegativeLogProbabilityDensity2d(i: Int, j: Int, method: CorrelationMethod, observational: Boolean) extends Merit[Seq[Any]] {
+    override def evaluate(predictionResult: PredictionResult[Seq[Any]], actual: Seq[Seq[Any]], rng: Random): Double = {
+      val allPredictions = predictionResult.getExpected()
+      val predictionsI = extractComponentByIndex(allPredictions, i)
+      val predictionsJ = extractComponentByIndex(allPredictions, j)
+      val actualI = extractComponentByIndex(actual, i)
+      val actualJ = extractComponentByIndex(actual, j)
+      val errorI = predictionsI.zip(actualI).map(pa => pa._1 - pa._2)
+      val errorJ = predictionsJ.zip(actualJ).map(pa => pa._1 - pa._2)
+      val allSigma = predictionResult.asInstanceOf[MultiTaskBaggedResult].getUncertainty(observational).get
+      val sigmaI = extractComponentByIndex(allSigma, i, Some(0.0))
+      val sigmaJ = extractComponentByIndex(allSigma, j, Some(0.0))
+      val rho = predictionResult.asInstanceOf[MultiTaskBaggedResult].getUncertaintyCorrelationBuffet(i, j, method).get
+      val nlpd = NLPD(errorI, errorJ, sigmaI, sigmaJ, rho)
+      StatsUtils.median(nlpd)
+    }
+
+    /**
+      * A convenience method for slicing a two dimensional data structure
+      *
+      * @param data a sequence of sequences
+      * @param index to slice (must correspond to real-valued data)
+      * @param default default to use in case the values are Option[Double]
+      * @return
+      */
+    private def extractComponentByIndex(data: Seq[Seq[Any]], index: Int, default: Option[Double] = None): Seq[Double] = {
+      data.map { row =>
+        row(index) match {
+          case x: Double => x
+          case x: Option[Double] => x.getOrElse(default.get)
+        }
+      }
+    }
+
+    /**
+      * Bivariate negative log probability density calculation
+      * log(2 * pi * sigma_x * sigma_y * sqrt(1 - rho**2)) +
+      *   1/(2 * (1 - rho**2)) * [(x / sigma_x)**2 + (y / sigma_y)**2 - 2 * rho * x * y / (sigma_x * sigma_y)]
+      * @param dx sequence of prediction errors in first label
+      * @param dy sequence of prediction errors in second label
+      * @param sigmaX sequence of uncertainty values of first label
+      * @param sigmaY sequence of uncertainty values of second label
+      * @param rho sequence of correlation coefficients for predictions
+      * @return sequence of NLPD value for each prediction
+      */
+    def NLPD(dx: Seq[Double], dy: Seq[Double], sigmaX: Seq[Double], sigmaY: Seq[Double], rho: Seq[Double]): Seq[Double] = {
+      Seq(dx, dy, sigmaX, sigmaY, rho).transpose.map { values =>
+        val x = values.head
+        val y = values(1)
+        val sx = values(2)
+        val sy = values(3)
+        val r = values(4)
+        val r2 = math.pow(r, 2.0)
+        val term1 = math.log(2 * math.Pi * sx * sy * math.sqrt(1 - r2))
+        val normX = x / sx
+        val normY = y / sy
+        val term2 = 1/(2 * (1 - r2)) * (math.pow(normX, 2.0) + math.pow(normY, 2.0) - 2 * r * normX * normY)
+        term1 + term2
+      }
+    }
   }
 }
 

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -203,6 +203,8 @@ case object UncertaintyCorrelation extends Merit[Double] {
       }
     }
   }
+
+  // TODO: add a multidimensional standard confidence as a merit
 }
 
 object Merit {

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -55,7 +55,7 @@ object CorrelationStudy {
       numTrain = numTrainRows,
       numTest = numTestRows,
       numCols = numCols,
-      observational = false,
+      observational = true,
       samplingNoise = 0.0,
       rhoTrain = 0.0,
       quadraticCorrelationFuzz = 0.0,

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -32,7 +32,9 @@ case object Noise extends VariedParameter {
 case object Bags extends VariedParameter {
   def name: String = "number of bags"
 }
-// TODO: add number of training rows as a varied parameter
+case object NumTraining extends VariedParameter {
+  def name: String = "number of training rows"
+}
 
 object CorrelationStudy {
 
@@ -93,7 +95,7 @@ object CorrelationStudy {
       quadraticCorrelationFuzz = quadraticCorrelationFuzz,
       rng = rng
     )
-    BitmapEncoder.saveBitmap(chart, fname.appendedAll(".png"), BitmapFormat.PNG)
+    BitmapEncoder.saveBitmap(chart, fname + ".png", BitmapFormat.PNG)
   }
 
   def makeChart(
@@ -125,22 +127,77 @@ object CorrelationStudy {
       case TrainRho =>
         rho => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
-          runTrial(numTrain, numTest, numCols, numTrain, rho, quadraticCorrelationFuzz, samplingNoise, observational, thisRng)
+          runTrial(
+            numTrain = numTrain,
+            numTest = numTest,
+            numCols = numCols,
+            numBags = numTrain,
+            rhoTrain = rho,
+            quadraticCorrelationFuzz = quadraticCorrelationFuzz,
+            samplingNoise = samplingNoise,
+            observational = observational,
+            rng = thisRng
+          )
         }
       case Noise =>
-        s => Iterator.tabulate(numTrials) { _ =>
+        noiseLevel => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
-          runTrial(numTrain, numTest, numCols, numTrain, rhoTrain, quadraticCorrelationFuzz, s, observational, thisRng)
+          runTrial(
+            numTrain = numTrain,
+            numTest = numTest,
+            numCols = numCols,
+            numBags = numTrain,
+            rhoTrain = rhoTrain,
+            quadraticCorrelationFuzz = quadraticCorrelationFuzz,
+            samplingNoise = noiseLevel,
+            observational = observational,
+            rng = thisRng
+          )
         }
       case TrainQuadraticFuzz =>
         fuzz => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
-          runTrial(numTrain, numTest, numCols, numTrain, rhoTrain, fuzz, samplingNoise, observational, thisRng)
+          runTrial(
+            numTrain = numTrain,
+            numTest = numTest,
+            numCols = numCols,
+            numBags = numTrain,
+            rhoTrain = rhoTrain,
+            quadraticCorrelationFuzz = fuzz,
+            samplingNoise = samplingNoise,
+            observational = observational,
+            rng = thisRng
+          )
         }
       case Bags =>
-        b => Iterator.tabulate(numTrials) { _ =>
+        numBags => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
-          runTrial(numTrain, numTest, numCols, b.toInt, rhoTrain, quadraticCorrelationFuzz, samplingNoise, observational, thisRng)
+          runTrial(
+            numTrain = numTrain,
+            numTest = numTest,
+            numCols = numCols,
+            numBags = numBags.toInt,
+            rhoTrain = rhoTrain,
+            quadraticCorrelationFuzz = quadraticCorrelationFuzz,
+            samplingNoise = samplingNoise,
+            observational = observational,
+            rng = thisRng
+          )
+        }
+      case NumTraining =>
+        numTraining => Iterator.tabulate(numTrials) { _ =>
+          val thisRng = new Random(rng.nextLong())
+          runTrial(
+            numTrain = numTraining.toInt,
+            numTest = numTest,
+            numCols = numCols,
+            numBags = numTraining.toInt,
+            rhoTrain = rhoTrain,
+            quadraticCorrelationFuzz = quadraticCorrelationFuzz,
+            samplingNoise = samplingNoise,
+            observational = observational,
+            rng = thisRng
+          )
         }
     }
     Merit.plotMeritScan(

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -1,0 +1,5 @@
+package io.citrine.lolo.bags
+
+object CorrelationStudy {
+
+}

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -5,8 +5,7 @@ import io.citrine.lolo.{PredictionResult, TestUtils}
 import io.citrine.lolo.stats.StatsUtils.makeLinearCorrelatedData
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
-import io.citrine.lolo.validation.Merit
-import io.citrine.lolo.validation.UncertaintyCorrelation.NegativeLogProbabilityDensity2d
+import io.citrine.lolo.validation.{Merit, NegativeLogProbabilityDensity2d, StandardConfidence2d}
 import org.apache.commons.math3.random.MersenneTwister
 import org.knowm.xchart.{BitmapEncoder, XYChart}
 import org.knowm.xchart.BitmapEncoder.BitmapFormat
@@ -39,30 +38,27 @@ case object NumTraining extends VariedParameter {
 object CorrelationStudy {
 
   def main(args: Array[String]): Unit = {
-    val seed = 52109317L
-    val mainRng = new Random(seed)
+    val mainRng = new Random(52109317L)
 
-    val function: Seq[Double] => Double = Friedman.friedmanSilverman
     val numTrials = 10
     val numTrainRows = 128
     val numTestRows = 128
     val numCols = 12
-    // TODO: add the ability to change the test function
 
     makeAndSaveChart(
-      fname = "./linear-problem-prediction-no-noise-rho-0.7-fuzz-0.5",
-      variedParameter = Bags,
-      parameterValues = Seq(32, 64, 128, 256, 512, 1024),
+      fname = "./test",
+      variedParameter = TrainRho,
+      parameterValues = Seq(0.0, 0.25, 0.50, 0.75, 0.9, 0.99),
       testProblem = Linear,
-      function = function,
+      function = Friedman.friedmanSilverman,
       numTrials = numTrials,
       numTrain = numTrainRows,
       numTest = numTestRows,
       numCols = numCols,
-      observational = true,
+      observational = false,
       samplingNoise = 0.0,
-      rhoTrain = 0.7,
-      quadraticCorrelationFuzz = 0.5,
+      rhoTrain = 0.0,
+      quadraticCorrelationFuzz = 0.0,
       rng = mainRng
     )
   }

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -32,6 +32,7 @@ case object Noise extends VariedParameter {
 case object Bags extends VariedParameter {
   def name: String = "number of bags"
 }
+// TODO: add number of training rows as a varied parameter
 
 object CorrelationStudy {
 
@@ -43,6 +44,7 @@ object CorrelationStudy {
     val numTrainRows = 128
     val numTestRows = 128
     val numCols = 12
+    // TODO: add the ability to change the test function
 
     makeAndSaveChart(
       fname = "./linear-problem-prediction-no-noise-rho-0.7-fuzz-0.5",
@@ -76,6 +78,7 @@ object CorrelationStudy {
                         quadraticCorrelationFuzz: Double,
                         rng: Random
                       ): Unit = {
+    // TODO: also save the raw data in a csv
     val chart = makeChart(
       variedParameter = variedParameter,
       parameterValues = parameterValues,

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -71,7 +71,8 @@ case object Noise extends VariedParameter {
 case object Bags extends VariedParameter {
   def name: String = "number of bags"
 }
-case object NumTraining extends VariedParameter {
+/** The number of bags can optionally be fixed. If it is None, then numBags = numTrain */
+case class NumTraining(numBags: Option[Int] = None) extends VariedParameter {
   def name: String = "number of training rows"
 }
 
@@ -272,14 +273,14 @@ object CorrelationStudy {
             rng = thisRng
           )
         }
-      case NumTraining =>
+      case NumTraining(optionNumBags) =>
         numTraining => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
           runTrial(
             function = function,
             numTrain = numTraining.toInt,
             numTest = numTest,
-            numBags = numTraining.toInt,
+            numBags = optionNumBags.getOrElse(numTraining.toInt),
             rhoTrain = rhoTrain,
             quadraticCorrelationFuzz = quadraticCorrelationFuzz,
             samplingNoise = samplingNoise,
@@ -404,9 +405,9 @@ object CorrelationStudy {
         case TrainQuadraticFuzz => thisQuadadraticFuzz = parameterValue
         case Noise => thisSamplingNoise = parameterValue
         case Bags => thisNumBags = parameterValue.toInt
-        case NumTraining =>
+        case NumTraining(optionNumBags) =>
           thisNumTrain = parameterValue.toInt
-          thisNumBags = parameterValue.toInt
+          thisNumBags = optionNumBags.getOrElse(parameterValue.toInt)
       }
       // For each metric, pull out the result for this parameter value and write a row of the CSV
       chart.getSeriesMap.forEach { case (key, series) =>

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -25,11 +25,11 @@ sealed trait TrueFunction {
   val numCols: Int
   def name: String
 }
-case class FriedmanSilvermanFunction(numCols) extends TrueFunction {
+case class FriedmanSilvermanFunction(numCols: Int) extends TrueFunction {
   def name = s"Friedman-Silverman, $numCols columns"
   def function: Seq[Double] => Double = Friedman.friedmanSilverman
 }
-case class FriedmanGrosseSilvermanFunction(numCols) extends TrueFunction {
+case class FriedmanGrosseSilvermanFunction(numCols: Int) extends TrueFunction {
   def name = s"Friedman-Grosse-Silverman, $numCols columns"
   def function: Seq[Double] => Double = Friedman.friedmanGrosseSilverman
 }

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -42,6 +42,7 @@ object CorrelationStudy {
     val seed = 52109317L
     val mainRng = new Random(seed)
 
+    val function: Seq[Double] => Double = Friedman.friedmanSilverman
     val numTrials = 10
     val numTrainRows = 128
     val numTestRows = 128
@@ -53,6 +54,7 @@ object CorrelationStudy {
       variedParameter = Bags,
       parameterValues = Seq(32, 64, 128, 256, 512, 1024),
       testProblem = Linear,
+      function = function,
       numTrials = numTrials,
       numTrain = numTrainRows,
       numTest = numTestRows,
@@ -70,6 +72,7 @@ object CorrelationStudy {
                         variedParameter: VariedParameter,
                         parameterValues: Seq[Double],
                         testProblem: TestProblems,
+                        function: Seq[Double] => Double,
                         numTrials: Int,
                         numTrain: Int,
                         numTest: Int,
@@ -85,6 +88,7 @@ object CorrelationStudy {
       variedParameter = variedParameter,
       parameterValues = parameterValues,
       testProblem = testProblem,
+      function = function,
       numTrials = numTrials,
       numTrain = numTrain,
       numTest = numTest,
@@ -102,6 +106,7 @@ object CorrelationStudy {
                  variedParameter: VariedParameter,
                  parameterValues: Seq[Double],
                  testProblem: TestProblems,
+                 function: Seq[Double] => Double,
                  numTrials: Int,
                  numTrain: Int,
                  numTest: Int,
@@ -128,6 +133,7 @@ object CorrelationStudy {
         rho => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
           runTrial(
+            function = function,
             numTrain = numTrain,
             numTest = numTest,
             numCols = numCols,
@@ -143,6 +149,7 @@ object CorrelationStudy {
         noiseLevel => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
           runTrial(
+            function = function,
             numTrain = numTrain,
             numTest = numTest,
             numCols = numCols,
@@ -158,6 +165,7 @@ object CorrelationStudy {
         fuzz => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
           runTrial(
+            function = function,
             numTrain = numTrain,
             numTest = numTest,
             numCols = numCols,
@@ -173,6 +181,7 @@ object CorrelationStudy {
         numBags => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
           runTrial(
+            function = function,
             numTrain = numTrain,
             numTest = numTest,
             numCols = numCols,
@@ -188,6 +197,7 @@ object CorrelationStudy {
         numTraining => Iterator.tabulate(numTrials) { _ =>
           val thisRng = new Random(rng.nextLong())
           runTrial(
+            function = function,
             numTrain = numTraining.toInt,
             numTest = numTest,
             numCols = numCols,
@@ -209,6 +219,7 @@ object CorrelationStudy {
   }
 
   def runTrial(
+                function: Seq[Double] => Double,
                 numTrain: Int,
                 numTest: Int,
                 numCols: Int,
@@ -230,7 +241,7 @@ object CorrelationStudy {
       numTrain + numTest,
       numCols,
       noise = 0.0, // Add noise later, after computing covariate labels
-      function = Friedman.friedmanSilverman,
+      function = function,
       seed = dataGenSeed
     )
 

--- a/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala
@@ -1,5 +1,219 @@
 package io.citrine.lolo.bags
 
+import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
+import io.citrine.lolo.{PredictionResult, TestUtils}
+import io.citrine.lolo.stats.StatsUtils.makeLinearCorrelatedData
+import io.citrine.lolo.stats.functions.Friedman
+import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
+import io.citrine.lolo.validation.Merit
+import io.citrine.lolo.validation.UncertaintyCorrelation.NegativeLogProbabilityDensity2d
+import org.apache.commons.math3.random.MersenneTwister
+import org.knowm.xchart.{BitmapEncoder, XYChart}
+import org.knowm.xchart.BitmapEncoder.BitmapFormat
+
+import scala.util.Random
+
+sealed trait TestProblems
+case object Linear extends TestProblems
+case object Quadratic extends TestProblems
+
+sealed trait VariedParameter {
+  def name: String
+}
+case object TrainRho extends VariedParameter {
+  def name: String = "linear training correlation"
+}
+case object TrainQuadraticFuzz extends VariedParameter {
+  def name: String = "shift to decorrelate quadratic data"
+}
+case object Noise extends VariedParameter {
+  def name: String = "observational noise level"
+}
+case object Bags extends VariedParameter {
+  def name: String = "number of bags"
+}
+
 object CorrelationStudy {
+
+  def main(args: Array[String]): Unit = {
+    val seed = 52109317L
+    val mainRng = new Random(seed)
+
+    val numTrials = 10
+    val numTrainRows = 128
+    val numTestRows = 128
+    val numCols = 12
+
+    makeAndSaveChart(
+      fname = "./linear-problem-prediction-no-noise-rho-0.7-fuzz-0.5",
+      variedParameter = Bags,
+      parameterValues = Seq(32, 64, 128, 256, 512, 1024),
+      testProblem = Linear,
+      numTrials = numTrials,
+      numTrain = numTrainRows,
+      numTest = numTestRows,
+      numCols = numCols,
+      observational = true,
+      samplingNoise = 0.0,
+      rhoTrain = 0.7,
+      quadraticCorrelationFuzz = 0.5,
+      rng = mainRng
+    )
+  }
+
+  def makeAndSaveChart(
+                        fname: String,
+                        variedParameter: VariedParameter,
+                        parameterValues: Seq[Double],
+                        testProblem: TestProblems,
+                        numTrials: Int,
+                        numTrain: Int,
+                        numTest: Int,
+                        numCols: Int,
+                        observational: Boolean,
+                        samplingNoise: Double,
+                        rhoTrain: Double,
+                        quadraticCorrelationFuzz: Double,
+                        rng: Random
+                      ): Unit = {
+    val chart = makeChart(
+      variedParameter = variedParameter,
+      parameterValues = parameterValues,
+      testProblem = testProblem,
+      numTrials = numTrials,
+      numTrain = numTrain,
+      numTest = numTest,
+      numCols = numCols,
+      observational = observational,
+      samplingNoise = samplingNoise,
+      rhoTrain = rhoTrain,
+      quadraticCorrelationFuzz = quadraticCorrelationFuzz,
+      rng = rng
+    )
+    BitmapEncoder.saveBitmap(chart, fname.appendedAll(".png"), BitmapFormat.PNG)
+  }
+
+  def makeChart(
+                 variedParameter: VariedParameter,
+                 parameterValues: Seq[Double],
+                 testProblem: TestProblems,
+                 numTrials: Int,
+                 numTrain: Int,
+                 numTest: Int,
+                 numCols: Int,
+                 observational: Boolean,
+                 samplingNoise: Double,
+                 rhoTrain: Double,
+                 quadraticCorrelationFuzz: Double,
+                 rng: Random
+               ): XYChart = {
+    val index: Int = testProblem match {
+      case Linear => 1
+      case Quadratic => 2
+    }
+    val merits = Map(
+      "Trivial" -> NegativeLogProbabilityDensity2d(0, index, CorrelationMethods.Trivial, observational),
+      "Training Data" -> NegativeLogProbabilityDensity2d(0, index, CorrelationMethods.FromTraining, observational),
+      "Bootstrap" -> NegativeLogProbabilityDensity2d(0, index, CorrelationMethods.Bootstrap, observational),
+      "Jackknife" -> NegativeLogProbabilityDensity2d(0, index, CorrelationMethods.Jackknife, observational)
+    )
+
+    val pvaBuilder: Double => Iterator[(PredictionResult[Seq[Any]], Seq[Seq[Any]])] = variedParameter match {
+      case TrainRho =>
+        rho => Iterator.tabulate(numTrials) { _ =>
+          val thisRng = new Random(rng.nextLong())
+          runTrial(numTrain, numTest, numCols, numTrain, rho, quadraticCorrelationFuzz, samplingNoise, observational, thisRng)
+        }
+      case Noise =>
+        s => Iterator.tabulate(numTrials) { _ =>
+          val thisRng = new Random(rng.nextLong())
+          runTrial(numTrain, numTest, numCols, numTrain, rhoTrain, quadraticCorrelationFuzz, s, observational, thisRng)
+        }
+      case TrainQuadraticFuzz =>
+        fuzz => Iterator.tabulate(numTrials) { _ =>
+          val thisRng = new Random(rng.nextLong())
+          runTrial(numTrain, numTest, numCols, numTrain, rhoTrain, fuzz, samplingNoise, observational, thisRng)
+        }
+      case Bags =>
+        b => Iterator.tabulate(numTrials) { _ =>
+          val thisRng = new Random(rng.nextLong())
+          runTrial(numTrain, numTest, numCols, b.toInt, rhoTrain, quadraticCorrelationFuzz, samplingNoise, observational, thisRng)
+        }
+    }
+    Merit.plotMeritScan(
+      parameterName = variedParameter.name,
+      parameterValues = parameterValues,
+      merits = merits,
+      rng = new Random(0L) // this is irrelevant unless we were to compute Uncertainty Correlation
+    )(pvaBuilder)
+  }
+
+  def runTrial(
+                numTrain: Int,
+                numTest: Int,
+                numCols: Int,
+                numBags: Int,
+                rhoTrain: Double,
+                quadraticCorrelationFuzz: Double,
+                samplingNoise: Double,
+                observational: Boolean,
+                rng: Random
+              ): (PredictionResult[Seq[Any]], Seq[Seq[Any]]) = {
+    val dataGenSeed = rng.nextLong()
+    val dataNoiseSeed = new Random(rng.nextLong())
+    val trainRng = new Random(rng.nextLong())
+    val bagSeed = rng.nextLong()
+    val linearCorrelationRng = new Random(rng.nextLong())
+    val quadraticCorrelationRng = new Random(rng.nextLong())
+
+    val fullData: Seq[(Vector[Double], Double)] = TestUtils.generateTrainingData(
+      numTrain + numTest,
+      numCols,
+      noise = 0.0, // Add noise later, after computing covariate labels
+      function = Friedman.friedmanSilverman,
+      seed = dataGenSeed
+    )
+
+    val inputs: Seq[Vector[Double]] = fullData.map(_._1)
+    val realLabel: Seq[Double] = fullData.map(_._2)
+    val linearLabel: Seq[Double] = makeLinearCorrelatedData(realLabel, rhoTrain, linearCorrelationRng)
+    val quadraticLabel: Seq[Double] = makeQuadraticCorrelatedData(realLabel, quadraticCorrelationFuzz, quadraticCorrelationRng)
+
+    val realLabelNoise = realLabel.map(_ + samplingNoise * dataNoiseSeed.nextGaussian())
+    val linearLabelNoise = linearLabel.map(_ + samplingNoise * dataNoiseSeed.nextGaussian())
+    val quadraticLabelNoise = quadraticLabel.map(_ + samplingNoise * dataNoiseSeed.nextGaussian())
+
+    val learner = MultiTaskTreeLearner(rng = trainRng)
+    val baggedLearner = MultiTaskBagger(
+      learner,
+      numBags =  numBags,
+      randBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(bagSeed)))
+    )
+
+    val RF = baggedLearner.train(
+      inputs.take(numTrain),
+      Seq(realLabelNoise.take(numTrain), linearLabelNoise.take(numTrain), quadraticLabelNoise.take(numTrain))
+    ).getModel()
+
+    val predictionResult = RF.transform(inputs.drop(numTrain))
+    val trueLabels = Seq(
+      realLabel.drop(numTrain),
+      linearLabel.drop(numTrain),
+      quadraticLabel.drop(numTrain)
+    ).transpose
+    val observedLabels = Seq(
+      realLabelNoise.drop(numTrain),
+      linearLabelNoise.drop(numTrain),
+      quadraticLabelNoise.drop(numTrain)
+    ).transpose
+    val actualLabels = if (observational) observedLabels else trueLabels
+    (predictionResult, actualLabels)
+  }
+
+  def makeQuadraticCorrelatedData(X: Seq[Double], fuzz: Double = 0.0, rng: Random = new Random()): Seq[Double] = {
+    require(fuzz >= 0.0)
+    val mu = X.sum / X.size
+    X.map(x => math.pow(x - mu, 2.0) + fuzz * rng.nextGaussian())
+  }
 
 }

--- a/src/test/scala/io/citrine/lolo/stats/UtilsTest.scala
+++ b/src/test/scala/io/citrine/lolo/stats/UtilsTest.scala
@@ -17,4 +17,11 @@ class UtilsTest {
     assert(math.abs(StatsUtils.correlation(X, Y) - rho) < 1e-8)
   }
 
+  /** Test the implementation of median */
+  @Test
+  def testMedian(): Unit = {
+    assert(StatsUtils.median(Seq(14.0, 17.0, 12.0, 13.0, 13.0)) == 13.0)
+    assert(StatsUtils.median(Seq(1.0, 0.0, 3.0, 4.0)) == 2.0)
+  }
+
 }


### PR DESCRIPTION
Create a harness that we can use to study the accuracy of correlation estimates. This code is not expected to make its way into main. Instead, it will turn into a stand-alone branch that one will be able to run to reproduce the results of the upcoming correlation study.

You can pull the branch and run `main` to verify that it makes a figure and csv. I'm mostly looking for the following things in a review:
* suggestions for other metrics that would be worth including
* suggestions for other test problems that would be worth including (see below for a discussion of the current metrics and test problems)
* a check for bugs in the metric code
* general methodological suggestions

I'm less interested in suggestions around code organization because this code won't go into production, and the primary goal is to make it easy to run multiple trials sequentially. There's some boiler plate, especially around adapting the `plotMeritScan` function so that we can switch out the independent variable. But I don't think that's an issue in this case.

For a given set of parameters, a single trial goes as follows:
1. Generate ground-truth data according to some function, y = f(x)
2. Generate a label that has some fixed linear correlation with y. There's a parameter, `trainRho`, that can vary from 0 (uncorrelated) to 1 (perfectly correlated)
3. Generate a label that has a quadratic relationship with y. This is done by setting `z = (y-\bar{y})^2` and then adding a normally distributed random variable to `z`. The scale of this random variable, called "fuzz" allows us to tune the relationship. At `fuzz=0` the two variables are strongly correlated, albeit in a non-linear way. As `fuzz->\infty`, the two variables become uncorrelated.
4. Add normally distributed sampling noise to all of the labels. This gives us the "experimentally observed" values.
5. Split the data into train and test sets
6. Train a multitask random forest on the noised training data
7. Apply the trained model to the test data
8. Apply some metric (either NLPD or standard confidence) to the predictions. Whether we compare the prediction to the ground-truth values or the noised values depends on whether `observational` equals true or false (are we judging the ability to compute a confidence interval or to compute a prediction interval)

This is repeated `numTrials` times to get a mean and standard error, and some parameter is swept to produce a graph.

I made the reproducibility as high as I could. The generation of training/test data, the application of sampling noise, the Poisson draws for creating the bags, and the rng that is passed to training are all repeatable. **But** the bags are trained in parallel and the order in which they are trained is not repeatable. Since we don't have splittable random numbers, this means that a given bag will encounter the rng in a different state, depending on the order of training.

Though not perfect, re-running a set of trials produces very similar results. It's repeatable enough that when I introduced a bug (see commit #88477d3), I was able to catch it because the results changed in a non-trivial way.