### PR TITLE
Rectify noisy covariance

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -699,8 +699,9 @@ object BaggedResult {
     * Calculate the correlation coefficient given a sequence of covariance scores for each training point.
     * In theory, the covariance is the sum of the individual covariance scores. But because each covariance score
     * is noisy, the resulting sum can be larger in absolute value than `sigmaX * sigmaY`, which would translate into
-    * a correlation coefficient that is outside [-1.0, 1.0], and hence we cannot calculate a conditional probability.
-    * The implementation here is to set rho equal to 0 if it is less than -0.999 or greater than 0.999.
+    * a correlation coefficient that is outside (-1.0, 1.0), and hence we cannot calculate a conditional probability.
+    * The implementation here is to set rho equal to 0 if it is less than -0.999 or greater than 0.999, where the value of
+    * 0.999 is a heuristic. Empirically, this approach was found to work well on a few test problems.
     *
     * @param covarianceScores sequence of Monte Carlo corrected covariance contributions for each training point
     * @param sigmaX           uncertainty in first label
@@ -711,8 +712,6 @@ object BaggedResult {
     require(sigmaX >= 0.0 && sigmaY >= 0.0)
     if (sigmaX == 0 || sigmaY == 0) return 0.0
     val rho = covarianceScores.sum / (sigmaX * sigmaY)
-    // If the calculated rho is too large or too small, then the calculation is noisy and we set rho to 0.0
-    // TODO (PLA-8597): figure out a better way to rectify covariance noise
     if (rho < -0.999 || rho > 0.999) {
       logger.warn("The covariance estimate is noisy; rectifying. Please consider increasing the ensemble size.")
       0.0


### PR DESCRIPTION
As part of using the jackknife approach to calculate covariance, it is possible that the noisy bias correction term leads to an unphysical result. Specifically, it can predict a correlation coefficient (rho) that is < -1 or > 1, both of which are nonsensical and cause numerical issues (we cannot draw from the resulting distribution). This is similar to how the estimates of variance can yield a negative number because of sampling noise, which we solve through a [heuristic rectification procedure](https://github.com/CitrineInformatics/lolo/blob/PLA-8597/rectify-noisy-covariance/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala#L672).

I studied 4 ways to resolve this issue.
1. If rho is outside of the allowed range*, set it to the edge of that range
2. If rho is outside of the allowed range, set it to 0
3. If any individual term in the sum is outside of an allowed range**, set it to the edge of that range
4. If any individual term in the sum is outside of an allowed range, set is to 0

These four approaches can be seen [here](https://github.com/CitrineInformatics/lolo/blob/PLA-8597/rectify-noisy-covariance/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala#L726-L766). I used the [correlations study harness](https://github.com/CitrineInformatics/lolo/pull/249) to study the effect of these four methods. The figures below can be reproduced by running [main](https://github.com/CitrineInformatics/lolo/blob/PLA-8597/rectify-noisy-covariance/src/test/scala/io/citrine/lolo/bags/CorrelationStudy.scala#L80).

For each figure below, the underlying data are generated from the Friedman-Silverman function. In addition to the output of the function, a corresponding set of data is generated that has a linear correlation coefficient of 0.9 with the outputs. A corresponding set of data is also generated that has a quadratic relationship with the function output. Finally, normally distributed noise with scale 1.0 is added to all data. There are 128 test and 128 train points. The number of bags is varied, and we plot either the negative log probability density (NLPD) or the standard confidence, calculated over the test data.

As the number of bags increases, the bias correction term vanishes and both methods 1 and 2 should approach the same, "correct" answer. The ideal method will approach this limit as quickly as possible. We find that method 2 performs best, and that's what we already have implemented, so we keep it.

Here is the NLPD when estimating the correlation coefficient for predictions made on the output and the linearly correlated data. As expected, methods 1 and 2 approach the same limiting value. But method 2 performs well even when the number of trees is small. Methods 3 and 4 are less accurate.
![image](https://user-images.githubusercontent.com/5777644/141849949-15bac7de-ebae-423f-8b98-9679513aaf45.png)

The result is similar when making estimating the correlation coefficient between the output and the quadratically correlated data.
![image](https://user-images.githubusercontent.com/5777644/141850312-991b8878-08a0-4249-bab8-abadcf6ff25c.png)

If we plot standard confidence, which should be 68%, we see that method 2 underestimates and methods 3 and 4 overestimate. Method 1 approaches the same value as method 2, but again requires too many bags.
![image](https://user-images.githubusercontent.com/5777644/141850496-b8cf1e13-4995-4c70-934e-b9193a1255ce.png)

The above results were all on prediction intervals, which incorporate noise. If we consider confidence intervals, which attempt to capture the true value, the jackknife variance estimate doesn't perform as well, and this shows through in the analysis of the estimated correlation coefficient. Methods 3 and 4 have a lower NLPD value, but I believe that is due to cancellation of errors. Method 2 is still better than method 1 (it's NLPD is lower and it's closer to the limiting value).
![image](https://user-images.githubusercontent.com/5777644/141850825-13bb5b54-a4a2-4920-80cd-21106f7e7e77.png)

*I set the allowed range to [-0.999, 0.999] instead of [-1, 1]. Although correlation values of +/- 1 are legitimate, they lead to degeneracies and numerical issues. And for all practical purposes, 0.999 is the same as 1.0 in this case.
**If the two outputs have variance `V_x` and `V_y`, then the covariance cannot exceed `sqrt(V_x * V_y)` in magnitude. Since `N` terms are summed together, we might expect to bound the magnitude of each term by `sqrt(V_x * V_y)/N`. But since methods 3 and 4 don't approach the correct limiting values, I conclude that it is expected and correct for some individual terms to be larger.