### PR TITLE
Unify learner train interface

### DIFF
--- a/src/main/scala/io/citrine/lolo/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/Learner.scala
@@ -34,10 +34,9 @@ trait MultiTaskLearner extends Serializable {
   /**
     * Train a model
     *
-    * @param inputs  to train on
-    * @param labels  sequence of sequences of labels, with shape (# labels) x (# training rows)
+    * @param trainingData  to train on. Each entry is a tuple (vector of inputs, sequence of labels)
     * @param weights for the training rows, if applicable
     * @return A training result that encompasses model(s) for all labels.
     */
-  def train(inputs: Seq[Vector[Any]], labels: Seq[Seq[Any]], weights: Option[Seq[Double]] = None): MultiTaskTrainingResult
+  def train(trainingData: Seq[(Vector[Any], Vector[Any])], weights: Option[Seq[Double]] = None): MultiTaskTrainingResult
 }

--- a/src/main/scala/io/citrine/lolo/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/Learner.scala
@@ -34,7 +34,7 @@ trait MultiTaskLearner extends Serializable {
   /**
     * Train a model
     *
-    * @param trainingData  to train on. Each entry is a tuple (vector of inputs, sequence of labels)
+    * @param trainingData  to train on. Each entry is a tuple (vector of inputs, vector of labels)
     * @param weights for the training rows, if applicable
     * @return A training result that encompasses model(s) for all labels.
     */

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -403,9 +403,7 @@ case class MultiPredictionBaggedResult(
 case class MultiTaskBaggedResult(
                                   baggedPredictions: Seq[BaggedResult[Any]],
                                   realLabels: Seq[Boolean],
-                                  NibIn: Vector[Vector[Int]],
-                                  trainingLabels: Seq[Seq[Any]],
-                                  trainingWeights: Seq[Double]
+                                  NibIn: Vector[Vector[Int]]
                                 ) extends BaggedResult[Seq[Any]] with MultiTaskModelPredictionResult {
 
   /* transpose to be (# training) x (# models) */

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -28,9 +28,8 @@ case class MultiTaskBagger(
                           ) extends MultiTaskLearner {
 
   override def train(trainingData: Seq[(Vector[Any], Vector[Any])], weights: Option[Seq[Double]] = None): MultiTaskBaggedTrainingResult = {
-    val inputs = trainingData.map(_._1)
+    val (inputs, labels) = trainingData.unzip
     val repInput = inputs.head
-    val labels = trainingData.map(_._2)
     val repOutput = labels.head
     /* Make sure the training data are the same size */
     assert(inputs.forall(repInput.size == _.size))

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -43,20 +43,20 @@ case class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiT
   /**
     * Create linear transformations for continuous features and labels & pass data through to learner
     *
-    * @param inputs  to train on
-    * @param labels  sequence of sequences of labels
+    * @param trainingData  to train on
     * @param weights for the training rows, if applicable
     * @return a sequence of training results, one for each label
     */
   override def train(
-                     inputs: Seq[Vector[Any]],
-                     labels: Seq[Seq[Any]],
-                     weights: Option[Seq[Double]]
+                      trainingData: Seq[(Vector[Any], Vector[Any])],
+                      weights: Option[Seq[Double]]
                     ): MultiTaskRotatedFeatureTrainingResult = {
+    val inputs = trainingData.map(_._1)
+    val labels = trainingData.map(_._2)
     val featuresToRotate = FeatureRotator.getDoubleFeatures(inputs.head)
     val trans = FeatureRotator.getRandomRotation(inputs.head.length)
     val rotatedFeatures = FeatureRotator.applyRotation(inputs, featuresToRotate, trans)
-    val baseTrainingResult = baseLearner.train(rotatedFeatures, labels, weights)
+    val baseTrainingResult = baseLearner.train(rotatedFeatures.zip(labels), weights)
     MultiTaskRotatedFeatureTrainingResult(baseTrainingResult, featuresToRotate, trans)
   }
 }

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -48,12 +48,12 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
   /**
     * Train a model
     *
-    * @param inputs  to train on
-    * @param labels  sequence of sequences of labels
+    * @param trainingData  to train on
     * @param weights for the training rows, if applicable
     * @return a sequence of training results, one for each label
     */
-  override def train(inputs: Seq[Vector[Any]], labels: Seq[Seq[Any]], weights: Option[Seq[Double]]): MultiTaskStandardizerTrainingResult = {
+  override def train(trainingData: Seq[(Vector[Any], Vector[Any])], weights: Option[Seq[Double]]): MultiTaskStandardizerTrainingResult = {
+    val (inputs, labels) = trainingData.unzip
     val inputTrans = Standardizer.getMultiStandardization(inputs)
     val outputTrans: Seq[Option[Standardization]] = labels.map { labelSeq =>
       if (labelSeq.head != null && labelSeq.head.isInstanceOf[Double]) {
@@ -64,10 +64,10 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
     }
     val standardInputs = Standardizer.applyStandardization(inputs, inputTrans)
     val standardLabels = labels.zip(outputTrans).map { case (labelSeq, trans) =>
-      Standardizer.applyStandardization(labelSeq, trans)
+      Standardizer.applyStandardization(labelSeq, trans).toVector
     }
 
-    val baseTrainingResult = baseLearner.train(standardInputs, standardLabels, weights)
+    val baseTrainingResult = baseLearner.train(standardInputs.zip(standardLabels), weights)
     new MultiTaskStandardizerTrainingResult(baseTrainingResult, outputTrans, inputTrans)
   }
 }

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -22,9 +22,8 @@ case class MultiTaskTreeLearner(
     * @return         sequence of models, one for each label
     */
   override def train(trainingData: Seq[(Vector[Any], Vector[Any])], weights: Option[Seq[Double]]): MultiTaskTreeTrainingResult = {
-    val inputs = trainingData.map(_._1)
+    val (inputs, labels) = trainingData.unzip
     val repInput = inputs.head
-    val labels = trainingData.map(_._2)
     val repOutput = labels.head
     val labelIndices = repOutput.indices
 
@@ -43,7 +42,7 @@ case class MultiTaskTreeLearner(
       if (v.isInstanceOf[Double]) {
         None
       } else {
-        Some(CategoricalEncoder.buildEncoder(labels(i).filterNot(_ == null)))
+        Some(CategoricalEncoder.buildEncoder(labels.map(_ (i)).filterNot(_ == null)))
       }
     }
     val encodedLabels = labels.map(CategoricalEncoder.encodeInput(_, outputEncoders))

--- a/src/test/scala/io/citrine/lolo/PerformanceTest.scala
+++ b/src/test/scala/io/citrine/lolo/PerformanceTest.scala
@@ -91,17 +91,17 @@ class PerformanceTest {
 
   def testMultitaskOverhead(N: Int): (Double, Double) = {
     val subset = trainingData.take(N)
-    val inputs = subset.map(_._1)
-    val realLabels = subset.map(_._2)
+    val (inputs, realLabels) = subset.unzip
     val catLabels = realLabels.map(_ > realLabels.sum / realLabels.size)
+    val labels = Vector(realLabels, catLabels).transpose
 
     val trainSingle: Double = Stopwatch.time({
-      new Bagger(new RegressionTreeLearner()).train(inputs.zip(realLabels)).getLoss()
-      new Bagger(new ClassificationTreeLearner()).train(inputs.zip(catLabels)).getLoss()
+      new Bagger(RegressionTreeLearner()).train(inputs.zip(realLabels)).getLoss()
+      new Bagger(ClassificationTreeLearner()).train(inputs.zip(catLabels)).getLoss()
     }, minRun = 1, maxRun = 1)
 
     val trainMulti: Double = Stopwatch.time({
-      new MultiTaskBagger(new MultiTaskTreeLearner()).train(inputs, Seq(realLabels, catLabels)).getLoss()
+      MultiTaskBagger(MultiTaskTreeLearner()).train(inputs.zip(labels)).getLoss()
     }, minRun = 1, maxRun = 1)
 
     (trainMulti, trainSingle)

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -248,15 +248,16 @@ class FeatureRotatorTest {
 
     // Sparsify the categorical labels
     val sparseCatLabel = catLabel.map(x => if (rng.nextBoolean()) x else null)
+    val labels = Vector(doubleLabel, sparseCatLabel).transpose
 
     // Train and evaluate rotated models on original and rotated features
-    val baseLearner = new MultiTaskTreeLearner()
-    val rotatedLearner = new MultiTaskFeatureRotator(MultiTaskTreeLearner())
+    val baseLearner = MultiTaskTreeLearner()
+    val rotatedLearner = MultiTaskFeatureRotator(MultiTaskTreeLearner())
 
-    val baseTrainingResult = baseLearner.train(inputs, Seq(doubleLabel, sparseCatLabel))
+    val baseTrainingResult = baseLearner.train(inputs.zip(labels))
     val baseDoubleModel = baseTrainingResult.getModels().head
     val baseCatModel = baseTrainingResult.getModels().last
-    val rotatedTrainingResult = rotatedLearner.train(inputs, Seq(doubleLabel, sparseCatLabel))
+    val rotatedTrainingResult = rotatedLearner.train(inputs.zip(labels))
     val rotatedDoubleModel = rotatedTrainingResult.getModels().head.asInstanceOf[RotatedFeatureModel[Double]]
     val rotatedCatModel = rotatedTrainingResult.getModels().last.asInstanceOf[RotatedFeatureModel[Boolean]]
 

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -179,15 +179,17 @@ class StandardizerTest {
 
     // Sparsify the categorical labels
     val sparseCatLabel = catLabel.map(x => if (rng.nextBoolean()) x else null)
+    val labels = Vector(doubleLabel, sparseCatLabel).transpose
 
     // Screw up the scale of the double labels
     val scale = 10000.0
     val rescaledLabel = doubleLabel.map(_ * scale)
+    val rescaledLabels = rescaledLabel.zip(sparseCatLabel).map { case (r, c) => Vector(r, c) }
 
     // Train and evaluate standard models on original and rescaled labels
     val standardizer = new MultiTaskStandardizer(MultiTaskTreeLearner())
-    val baseRes = standardizer.train(inputs, Seq(doubleLabel, sparseCatLabel)).getModels().last.transform(inputs).getExpected()
-    val standardRes = standardizer.train(inputs, Seq(rescaledLabel, sparseCatLabel)).getModels().last.transform(inputs).getExpected()
+    val baseRes = standardizer.train(inputs.zip(labels)).getModels().last.transform(inputs).getExpected()
+    val standardRes = standardizer.train(inputs.zip(rescaledLabels)).getModels().last.transform(inputs).getExpected()
     // Train and evaluate unstandardized model on rescaled labels
 
     // Compute metrics for each of the models


### PR DESCRIPTION
PLA-8798

`Learner` implements a method `train` that acts on a sequence of training data points, each of the form `(vector of inputs, label)`. But `MultiTaskLearner` implements `train` with a different interface: it takes one argument for the `inputs` and one argument for the `labels`. To make matters more confusing, the two arguments have different orientations. `inputs` has shape `(# training) x (# input dimensions)` while `labels` has shape `(# output dimensions) x (# training)`. This was undocumented and, at least to me, counter-intuitive.

In the context of Lolo it's not a big deal. But when I tried to implement the multi-task RF in Lolopy, I found that having these two different paradigms would lead to a lot of boilerplate, redundant code. So I decided to unify the interfaces, since I'm in here breaking things anyway.

`MultiTaskLearner` now implements train with a sequence of training data points, each of the form `(vector of inputs, vector of labels)`.