### PR TITLE
Expose multitask random forest in Lolopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         - ./miniconda.sh -b
         - export PATH=/home/travis/miniconda3/bin:$PATH
         - conda update --yes conda
-        - conda create --yes -n condaenv python=3.6
+        - conda create --yes -n condaenv python=3.7
         - conda install --yes -n condaenv pip
         - source activate condaenv
     install:
@@ -57,7 +57,7 @@ jobs:
       - ./miniconda.sh -b
       - export PATH=/home/travis/miniconda3/bin:$PATH
       - conda update --yes conda
-      - conda create --yes -n condaenv python=3.6
+      - conda create --yes -n condaenv python=3.7
       - conda install --yes -n condaenv pip
       - source activate condaenv
     install:

--- a/python/README.md
+++ b/python/README.md
@@ -19,7 +19,7 @@ Lolo is a Scala library that contains a variety of machine learning algorithms, 
 
 ### Development 
 
-Lolopy requires Python >= 3.6, Java JDK >= 1.8, and sbt to be installed on your system when developing lolopy.  
+Lolopy requires Python >= 3.7, Java JDK >= 1.8, and sbt to be installed on your system when developing lolopy.
 
 Before developing `lolopy`, compile `lolo` on your system using sbt.
 We have provided a `Makefile` that contains the needed operations.

--- a/python/README.md
+++ b/python/README.md
@@ -21,7 +21,7 @@ Lolo is a Scala library that contains a variety of machine learning algorithms, 
 
 Lolopy requires Python >= 3.6, Java JDK >= 1.8, and sbt to be installed on your system when developing lolopy.  
 
-Before developing `lolopy`, compile `lolo` on your system using Maven.
+Before developing `lolopy`, compile `lolo` on your system using sbt.
 We have provided a `Makefile` that contains the needed operations.
 To build and install `lolopy` call `make` in this directory.
 

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -71,9 +71,10 @@ class BaseLoloLearner(BaseEstimator, metaclass=ABCMeta):
         learner = self._make_learner()
 
         # Determine the number of outputs
-        if len(y.shape) == 1:
+        y_shape = np.asarray(y).shape
+        if len(y_shape) == 1:
             self._num_outputs = 1
-        elif len(y.shape) == 2:
+        elif len(y_shape) == 2:
             self._num_outputs = y.shape[1]
         else:
             raise ValueError("Output array must be either 1- or 2-dimensional")

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -3,7 +3,6 @@ from abc import abstractmethod, ABCMeta
 import numpy as np
 from lolopy.loloserver import get_java_gateway
 from lolopy.utils import send_feature_array, send_1D_array
-import random
 from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin, is_regressor
 from sklearn.exceptions import NotFittedError
 
@@ -205,7 +204,6 @@ class BaseLoloRegressor(BaseLoloLearner, RegressorMixin):
         # If desired, return the uncertainty too
         if return_std:
             # TODO: This part fails on Windows because the NativeSystemBLAS is not found. Fix that
-            # TODO: This is only valid for regression models. Perhaps make a "LoloRegressor" class
             y_std_bytes = self.gateway.jvm.io.citrine.lolo.util.LoloPyDataLoader.getRegressionUncertainty(pred_result)
             y_std = np.frombuffer(y_std_bytes, 'float')
             return y_pred, y_std

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -8,7 +8,7 @@ from lolopy.learners import (
 )
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import r2_score, accuracy_score, log_loss
-from sklearn.datasets import load_boston, load_iris
+from sklearn.datasets import load_iris, load_diabetes
 from unittest import TestCase, main
 import pickle as pkl
 import numpy as np
@@ -35,7 +35,7 @@ class TestRF(TestCase):
         rf = RandomForestRegressor(random_seed = 31247895)
 
         # Train the model
-        X, y = load_boston(True)
+        X, y = load_diabetes(return_X_y=True)
 
         # Make sure we get a NotFittedError
         with self.assertRaises(NotFittedError):
@@ -52,10 +52,10 @@ class TestRF(TestCase):
         y_import = rf.get_importance_scores(X[:100, :])
         self.assertEqual((100, len(X)), y_import.shape)
 
-        # Basic test for functionality. R^2 above 0.98 was measured on 27Dec18
+        # Basic test for functionality. R^2 above 0.88 was measured on 2021-12-09
         score = r2_score(y_pred, y)
         print('R^2:', score)
-        self.assertGreater(score, 0.98)
+        self.assertGreater(score, 0.88)
 
         # Test with weights (make sure it doesn't crash)
         rf.fit(X, y, [2.0]*len(y))
@@ -78,7 +78,7 @@ class TestRF(TestCase):
         rf = RandomForestClassifier(random_seed = 34789)
 
         # Load in the iris dataset
-        X, y = load_iris(True)
+        X, y = load_iris(return_X_y=True)
         rf.fit(X, y)
 
         # Predict the probability of membership in each class
@@ -105,7 +105,7 @@ class TestRF(TestCase):
         rf2 = pkl.loads(data)
 
         # Load in the iris dataset and train model
-        X, y = load_iris(True)
+        X, y = load_iris(return_X_y=True)
         rf.fit(X, y)
 
         # Try saving and loading the model
@@ -121,7 +121,7 @@ class TestRF(TestCase):
         tree = RegressionTreeLearner()
 
         # Make sure it trains and predicts properly
-        X, y = load_boston(True)
+        X, y = load_diabetes(return_X_y=True)
         tree.fit(X, y)
 
         # Make sure the prediction works
@@ -134,7 +134,7 @@ class TestRF(TestCase):
         tree.max_depth = 2
         tree.fit(X, y)
         y_pred = tree.predict(X)
-        self.assertAlmostEqual(0.695574477, r2_score(y, y_pred))  # Result is deterministic
+        self.assertAlmostEqual(0.433370098, r2_score(y, y_pred))  # Result is deterministic
 
         # Constrain the tree to a single node, using minimum count per split
         tree = RegressionTreeLearner(min_leaf_instances=1000)
@@ -194,7 +194,7 @@ class TestExtraRandomTrees(TestCase):
         rf = ExtraRandomTreesRegressor(random_seed = 378456)
 
         # Train the model
-        X, y = load_boston(True)
+        X, y = load_diabetes(return_X_y=True)
 
         # Make sure we get a NotFittedError
         with self.assertRaises(NotFittedError):
@@ -211,10 +211,10 @@ class TestExtraRandomTrees(TestCase):
         y_import = rf.get_importance_scores(X[:100, :])
         self.assertEqual((100, len(X)), y_import.shape)
 
-        # Basic test for functionality. R^2 above 0.98 was measured on 2020-04-06
+        # Basic test for functionality. R^2 above 0.88 was measured on 2021-12-09
         score = r2_score(y_pred, y)
         print("R2: ", score)
-        self.assertGreater(score, 0.98)
+        self.assertGreater(score, 0.88)
 
         # Test with weights (make sure it doesn't crash)
         rf.fit(X, y, [2.0]*len(y))

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -8,7 +8,7 @@ from lolopy.learners import (
 )
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import r2_score, accuracy_score, log_loss
-from sklearn.datasets import load_iris, load_diabetes
+from sklearn.datasets import load_iris, load_diabetes, load_linnerud
 from unittest import TestCase, main
 import pickle as pkl
 import numpy as np
@@ -73,6 +73,14 @@ class TestRF(TestCase):
         # Make sure the detach operation functions
         rf.clear_model()
         self.assertIsNone(rf.model_)
+
+    def test_rf_multioutput_regressor(self):
+        rf = RandomForestRegressor(random_seed=810355)
+        # A regression dataset with 3 outputs
+        X, y = load_linnerud(return_X_y=True)
+
+        rf.fit(X, y)
+        y_pred = rf.predict(X, return_std=True)
 
     def test_classifier(self):
         rf = RandomForestClassifier(random_seed = 34789)

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -265,7 +265,7 @@ class TestExtraRandomTrees(TestCase):
         rf = ExtraRandomTreesClassifier(random_seed = 378456)
 
         # Load in the iris dataset
-        X, y = load_iris(True)
+        X, y = load_iris(return_X_y=True)
         rf.fit(X, y)
 
         # Predict the probability of membership in each class
@@ -292,7 +292,7 @@ class TestExtraRandomTrees(TestCase):
         rf2 = pkl.loads(data)
 
         # Load in the iris dataset and train model
-        X, y = load_iris(True)
+        X, y = load_iris(return_X_y=True)
         rf.fit(X, y)
 
         # Try saving and loading the model

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn==0.20.0
+scikit-learn==1.0.1
 py4j==0.10.8.1

--- a/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedResult.scala
@@ -418,12 +418,12 @@ case class MultiTaskBaggedResult(
     .transpose
     .map(x => new ParallelModelsPredictionResult(x.transpose))
 
-  // For each prediction, the uncertainty is a sequence of optional entries, one for each label.
-  override def getUncertainty(observational: Boolean = true): Option[Seq[Seq[Option[Any]]]] = {
+  // For each prediction, the uncertainty is a sequence of entries for each label. Missing uncertainty values are reported as NaN
+  override def getUncertainty(observational: Boolean = true): Option[Seq[Seq[Any]]] = {
     Some(baggedPredictions.map { predictionResult =>
       predictionResult.getUncertainty(observational) match {
-        case Some(value) => value.map(Some(_))
-        case None => Seq.fill(numPredictions)(None)
+        case Some(value) => value
+        case None => Seq.fill(numPredictions)(Double.NaN)
       }
     }.transpose)
   }

--- a/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
+++ b/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
@@ -52,23 +52,12 @@ case class ExtraRandomTrees(
     */
   override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]]): TrainingResult = {
     val breezeRandBasis: RandBasis = new RandBasis(new MersenneTwister(rng.nextLong()))
+    val repOutput = trainingData.head._2
+    val isRegression = repOutput.isInstanceOf[Double]
+    val numFeatures: Int = RandomForest.getNumFeatures(subsetStrategy, trainingData.head._1.size, isRegression)
 
-    trainingData.head._2 match {
+    repOutput match {
       case _: Double => {
-        val numFeatures: Int = subsetStrategy match {
-          case x: String => {
-            x match {
-              case "auto" => trainingData.head._1.size
-              case "sqrt" => Math.ceil(Math.sqrt(trainingData.head._1.size)).toInt
-              case "log2" => Math.ceil(Math.log(trainingData.head._1.size) / Math.log(2)).toInt
-              case x: String =>
-                println(s"Unrecognized subsetStrategy ${x}; using auto")
-                trainingData.head._1.size
-            }
-          }
-          case x: Int => x
-          case x: Double => (trainingData.head._1.size * x).toInt
-        }
         val DTLearner = RegressionTreeLearner(
           leafLearner = leafLearner,
           numFeatures = numFeatures,
@@ -88,20 +77,6 @@ case class ExtraRandomTrees(
         bagger.train(trainingData, weights)
       }
       case _: Any => {
-        val numFeatures: Int = subsetStrategy match {
-          case x: String => {
-            x match {
-              case "auto" => Math.ceil(Math.sqrt(trainingData.head._1.size)).toInt
-              case "sqrt" => Math.ceil(Math.sqrt(trainingData.head._1.size)).toInt
-              case "log2" => Math.ceil(Math.log(trainingData.head._1.size) / Math.log(2)).toInt
-              case x: String =>
-                println(s"Unrecognized subsetStrategy ${x}; using auto")
-                trainingData.head._1.size
-            }
-          }
-          case x: Int => x
-          case x: Double => (trainingData.head._1.size * x).toInt
-        }
         val DTLearner = ClassificationTreeLearner(
           leafLearner = leafLearner,
           numFeatures = numFeatures,

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -25,7 +25,7 @@ import scala.util.Random
   * @param minLeafInstances minimum number of instances per leave in each tree
   * @param maxDepth       maximum depth of each tree in the forest (default: unlimited)
   * @param uncertaintyCalibration whether to empirically recalibrate the predicted uncertainties (default: false)
-  * @param randomizePivotLocation whether generate splits randomly between the data points (default: false)
+  * @param randomizePivotLocation whether to generate splits randomly between the data points (default: false)
   * @param randomlyRotateFeatures whether to randomly rotate real features for each tree in the forest (default: false)
   * @param rng            random number generator to use for stochastic functionality
   */
@@ -81,8 +81,16 @@ case class RandomForest(
         )
         bagger.train(trainingData, weights)
       case _: Seq[Any] =>
-        // TODO: incorporate numFeatures, minLeafInstances, and maxDepth (maybe throw a warning if leafLearner is defined)
-        val DTLearner = new MultiTaskStandardizer(MultiTaskTreeLearner(randomizePivotLocation = randomizePivotLocation, rng = rng))
+        if (leafLearner.isDefined) {
+          println("'leafLearner' cannot be configured for multitask random forest at this time. Defaulting to a Guess The Mean learner.")
+        }
+        val DTLearner = new MultiTaskStandardizer(MultiTaskTreeLearner(
+          numFeatures = numFeatures,
+          maxDepth = maxDepth,
+          minLeafInstances = minLeafInstances,
+          randomizePivotLocation = randomizePivotLocation,
+          rng = rng
+        ))
         val bagger = MultiTaskBagger(
            if (randomlyRotateFeatures) MultiTaskFeatureRotator(DTLearner) else DTLearner,
           numBags = numTrees,

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -2,7 +2,8 @@ package io.citrine.lolo.learners
 
 import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import io.citrine.lolo.bags.{Bagger, MultiTaskBagger}
-import io.citrine.lolo.transformers.{FeatureRotator, MultiTaskStandardizer, MultiTaskFeatureRotator}
+import io.citrine.lolo.linear.GuessTheMeanLearner
+import io.citrine.lolo.transformers.{FeatureRotator, MultiTaskFeatureRotator, MultiTaskStandardizer}
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
@@ -81,8 +82,9 @@ case class RandomForest(
         )
         bagger.train(trainingData, weights)
       case _: Seq[Any] =>
-        if (leafLearner.isDefined) {
-          println("'leafLearner' cannot be configured for multitask random forest at this time. Defaulting to a Guess The Mean learner.")
+        leafLearner match {
+          case Some(learner) if !learner.isInstanceOf[GuessTheMeanLearner] =>
+            throw new IllegalArgumentException("Multitask random forest does not support leaf learners other than guess-the-mean")
         }
         val DTLearner = new MultiTaskStandardizer(MultiTaskTreeLearner(
           numFeatures = numFeatures,

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -82,9 +82,8 @@ case class RandomForest(
         )
         bagger.train(trainingData, weights)
       case _: Seq[Any] =>
-        leafLearner match {
-          case Some(learner) if !learner.isInstanceOf[GuessTheMeanLearner] =>
-            throw new IllegalArgumentException("Multitask random forest does not support leaf learners other than guess-the-mean")
+        if (leafLearner.isDefined && !leafLearner.get.isInstanceOf[GuessTheMeanLearner]) {
+          throw new IllegalArgumentException("Multitask random forest does not support leaf learners other than guess-the-mean")
         }
         val DTLearner = new MultiTaskStandardizer(MultiTaskTreeLearner(
           numFeatures = numFeatures,

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -16,8 +16,10 @@ import scala.util.Random
   *
   * @param numFeatures to randomly select from at each split (default: all)
   * @param maxDepth    to grow the tree to
+  * @param minLeafInstances minimum number of training instances per leaf
   * @param leafLearner learner to train the leaves with
-  * @param minLeafInstances minimum number of instances per leaf
+  * @param splitter to determine the best split of the node data
+  * @param rng random number generator, for reproducibility
   */
 case class RegressionTreeLearner(
                                   numFeatures: Int = -1,

--- a/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
@@ -15,6 +15,7 @@ case class MultiTaskSplitter(randomizePivotLocation: Boolean = false, rng: Rando
     *
     * @param data        to split
     * @param numFeatures to consider, randomly
+    * @param minInstances the minimum number of data points on a split node
     * @return a split object that optimally divides data
     */
   def getBestSplit(

--- a/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
+++ b/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
@@ -21,7 +21,7 @@ object LoloPyDataLoader {
     * @param bigEndian Whether the numbers are is big-endian or not
     * @return The array as a Scala array
     */
-  def getFeatureArray(input: Array[Byte], numAttributes : Integer, bigEndian: Boolean) : Seq[Vector[Double]] = {
+  def getFeatureArray(input: Array[Byte], numAttributes: Integer, bigEndian: Boolean) : Seq[Vector[Double]] = {
     // Get ordering
     val ordering = if (bigEndian) ByteOrder.BIG_ENDIAN else ByteOrder.LITTLE_ENDIAN
 

--- a/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
+++ b/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
@@ -4,8 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.zip._
-
-import io.citrine.lolo.PredictionResult
+import io.citrine.lolo.{MultiTaskModelPredictionResult, PredictionResult}
 
 /**
   * Tool used to transfer data from LoloPy to the JVM
@@ -83,6 +82,16 @@ object LoloPyDataLoader {
   }
 
   /**
+    * Generate the results of a multitask regression model, which are assumed to be all doubles
+    * @param predictionResult result of predicting on a multitask model
+    * @return Byte array of doubles in native system order (the caller must then reshape the result into a 2d array)
+    */
+  def getMultiRegressionExpected(predictionResult: MultiTaskModelPredictionResult): Array[Byte] = {
+    val predResults = predictionResult.getExpected().asInstanceOf[Seq[Seq[Double]]].flatten
+    send1DArray(predResults)
+  }
+
+  /**
     * Send the training entry importance scores to the Python client
     * @param predictionResult Prediction result object
     * @return Byte of array of doubles in native system order
@@ -99,6 +108,31 @@ object LoloPyDataLoader {
   def getRegressionUncertainty(predictionResult: PredictionResult[Any]): Array[Byte] = {
     val predResults : Seq[Double] = predictionResult.getUncertainty().get.asInstanceOf[Seq[Double]]
     send1DArray(predResults)
+  }
+
+  /**
+    * Get the uncertainties of a multitask regression model, which are assumed to be all doubles
+    * @param predictionResult result of predicting on a multitask model
+    * @return Byte array of doubles in native system order (the caller must then reshape the result into a 2d array)
+    */
+  def getMultiRegressionUncertainty(predictionResult: MultiTaskModelPredictionResult): Array[Byte] = {
+    val uncertaintyResults = predictionResult.getUncertainty().get.asInstanceOf[Seq[Seq[Double]]].flatten
+    send1DArray(uncertaintyResults)
+  }
+
+  /**
+    * Get the correlation coefficients between the uncertainties of a multitask regression model.
+    * By calling this method for all (i, j) pairs, one can construct a correlation matrix.
+    * Combined with getMultiRegressionUncertainty, one can construct the covariance matrix.
+    *
+    * @param predictionResult result of predicting on a multitask model
+    * @param i index of the first output
+    * @param j index of the second output
+    * @return Byte array of doubles in native system order
+    */
+  def getRegressionCorrelation(predictionResult: MultiTaskModelPredictionResult, i: Int, j: Int): Array[Byte] = {
+    val correlationResults = predictionResult.getUncertaintyCorrelation(i, j).get
+    send1DArray(correlationResults)
   }
 
   /**


### PR DESCRIPTION
PLA-8731

Makes it so that the `RandomForestRegressor` model in Lolopy can be trained on 2-dimensional label data, `y`. The model then returns predictions as a 2-dimensional array. This brings its behavior more in line with scikit-learn's random forest regressor, which can also operate on multiple labels. The following changes were made to enable this feature:
* The `RandomForest` learner in Lolo now checks to see if the output data is a `Seq` (previously it only checked whether or not it was a `Double`). If it's a `Seq`, then it produces a `MultiTaskBagger` around a standardized `MultiTaskTreeLearner`.
* The top-level `fit` method of `BaseLoloLearner` inspects the shape of the training labels `y`, and if it's a 2-d array then it gets sent to Java as an array instead of as a vector
* The `predict` method of `BaseLoloRegressor` changes the way it expects to receive predictions and uncertainties from Java, depending on the number of labels (for >1 labels, it reshapes the stream into a 2-dimensional array).
* The `predict` method now has a `return_cov_matrix` option in addition to the `return_std` option. Only one can be requested. `return_cov_matrix` returns an array of covariance matrices for each prediction.
* `MultiTaskTree`'s interface is expanded to include arguments for `minLeafInstances`, `maxDepth`, and `numFeatures`. 
* Although the random forest interface also includes a `leafLearner` argument, that one is not piped through to `MultiTaskTree`. If it is specified, then we print a message warning the user that it is being ignored. At this time, nothing except a guess-the-mean learner is sensible.

There are a few other small changes:
* I decided to upgrade scikit-learn to the recently-released version 1, on the belief that stable releases are better than unstable releases.
* This requires bumping the minimum python version from 3.6 to 3.7. Version 3.7 has been available since mid-2018.
* Scikit-learn v1 deprecates the boston housing dataset, so I replaced its use in tests with the diabetes dataset.
* The uncertainty for a multitask bagged model has been changed from `Option[Seq[Seq[Option[Any]]]]` to `Option[Seq[Seq[Any]]]`. The former was too clunky and it also made it more difficult to send the uncertainties over the wire. So what do we do if the uncertainty for a given label isn't defined? I decided to use `NaN`. This does have precedent in Lolo, which uses `NaN` and `null` to indicate missing labels in training data.

Despite many of the changes to Lolopy being at an abstract level, this PR does not enable any multitask models in Lolopy besides `RandomForestRegressor`.
* The linear regressor model in Lolo only accepts a single label
* The Extra Random forest model in Lolo makes use of customized extra-random regression/classification splitters, and those are not generalized to multitask models
* Lolopy makes a distinction between regression and classification learners, and so even though Lolo can train a mixed regression-classification multitask tree, that doesn't map onto Lolopy
* `RandomForestClassifier` would be the easiest to generalized to a multitask model. It would require modifying the `BaseLoloClassifier`'s `predict` and `proba` methods to handle the more complex data shape. This is a good follow-up candidate, especially since it would bring Lolpy more in line with sklearn, but it didn't seem high priority enough to delay the release.