### PR TITLE
Pass rng to splitters in RandomForest

### DIFF
--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -90,7 +90,7 @@ case class RandomForest(
           maxDepth = maxDepth,
           minLeafInstances = minLeafInstances,
           randomizePivotLocation = randomizePivotLocation,
-          rng = new Random(rng.nextLong())
+          rng = rng
         ))
         val bagger = MultiTaskBagger(
            if (randomlyRotateFeatures) MultiTaskFeatureRotator(DTLearner) else DTLearner,

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -68,8 +68,8 @@ case class RandomForest(
           numFeatures = numFeatures,
           minLeafInstances = minLeafInstances,
           maxDepth = maxDepth,
-          splitter = RegressionSplitter(randomizePivotLocation, rng = new Random(rng.nextLong())),
-          rng = new Random(rng.nextLong())
+          splitter = RegressionSplitter(randomizePivotLocation, rng = rng),
+          rng =rng
         )
 
         val bagger = Bagger(
@@ -107,8 +107,8 @@ case class RandomForest(
           numFeatures = numFeatures,
           minLeafInstances = minLeafInstances,
           maxDepth = maxDepth,
-          splitter = ClassificationSplitter(randomizePivotLocation, rng = new Random(rng.nextLong())),
-          rng = new Random(rng.nextLong())
+          splitter = ClassificationSplitter(randomizePivotLocation, rng = rng),
+          rng = rng
         )
         val bagger = Bagger(
           if (randomlyRotateFeatures) FeatureRotator(DTLearner) else DTLearner,

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -68,8 +68,8 @@ case class RandomForest(
           numFeatures = numFeatures,
           minLeafInstances = minLeafInstances,
           maxDepth = maxDepth,
-          splitter = RegressionSplitter(randomizePivotLocation),
-          rng = rng
+          splitter = RegressionSplitter(randomizePivotLocation, rng = new Random(rng.nextLong())),
+          rng = new Random(rng.nextLong())
         )
 
         val bagger = Bagger(
@@ -90,7 +90,7 @@ case class RandomForest(
           maxDepth = maxDepth,
           minLeafInstances = minLeafInstances,
           randomizePivotLocation = randomizePivotLocation,
-          rng = rng
+          rng = new Random(rng.nextLong())
         ))
         val bagger = MultiTaskBagger(
            if (randomlyRotateFeatures) MultiTaskFeatureRotator(DTLearner) else DTLearner,
@@ -107,8 +107,8 @@ case class RandomForest(
           numFeatures = numFeatures,
           minLeafInstances = minLeafInstances,
           maxDepth = maxDepth,
-          splitter = ClassificationSplitter(randomizePivotLocation),
-          rng = rng
+          splitter = ClassificationSplitter(randomizePivotLocation, rng = new Random(rng.nextLong())),
+          rng = new Random(rng.nextLong())
         )
         val bagger = Bagger(
           if (randomlyRotateFeatures) FeatureRotator(DTLearner) else DTLearner,

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -69,7 +69,7 @@ case class RandomForest(
           minLeafInstances = minLeafInstances,
           maxDepth = maxDepth,
           splitter = RegressionSplitter(randomizePivotLocation, rng = rng),
-          rng =rng
+          rng = rng
         )
 
         val bagger = Bagger(

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -209,7 +209,7 @@ class RandomForestTest {
     */
   @Test
   def testShapley(): Unit = {
-    rng.setSeed(3751L)
+    rng.setSeed(3753L)
 
     // Example from Lundberg paper (https://arxiv.org/pdf/1802.03888.pdf)
     val trainingData1 = Seq(


### PR DESCRIPTION
When training a typical random forest model, there are two primary sources of randomness: bagging and selecting features to consider at each split. Previously we did not pass the `rng` to the splitter, so the latter was not reproducible. This PR fixes that.