### PR TITLE
Publish to new sonatype infrastructure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,18 @@
 import Dependencies._
 
-name               := "lolo"
-scalaVersion       := "2.13.4"
-crossScalaVersions := List("2.13.4", "2.12.4")
-organization       := "io.citrine"
-organizationName   := "Citrine Informatics"
-homepage           := Some(url("https://github.com/CitrineInformatics/lolo"))
-developers         := List(Developer(id="maxhutch", name="Max Hutchinson", email="maxhutch@citrine.io", url=url("https://github.com/maxhutch")))
-description        := "A random forest-centered machine learning library in Scala."
-licenses           += "Apache-2.0" ->  url("http://www.apache.org/licenses/LICENSE-2.0.txt")
-scmInfo            := Some(ScmInfo(url("https://github.com/CitrineInformatics/lolo"), "scm:git@github.com:CitrineInformatics/lolo.git"))
+name                   := "lolo"
+scalaVersion           := "2.13.4"
+crossScalaVersions     := List("2.13.4", "2.12.4")
+organization           := "io.citrine"
+organizationName       := "Citrine Informatics"
+homepage               := Some(url("https://github.com/CitrineInformatics/lolo"))
+developers             := List(Developer(id="maxhutch", name="Max Hutchinson", email="maxhutch@citrine.io", url=url("https://github.com/maxhutch")))
+description            := "A random forest-centered machine learning library in Scala."
+licenses               += "Apache-2.0" ->  url("http://www.apache.org/licenses/LICENSE-2.0.txt")
+scmInfo                := Some(ScmInfo(url("https://github.com/CitrineInformatics/lolo"), "scm:git@github.com:CitrineInformatics/lolo.git"))
+sonatypeCredentialHost := "s01.oss.sonatype.org"
+sonatypeRepository     := "https://s01.oss.sonatype.org/service/local"
+
 
 pomIncludeRepository := { _ => false }
 test in assembly := {}


### PR DESCRIPTION
In [this Sonatype support request](https://issues.sonatype.org/browse/OSSRH-76297) we migrated Lolo and Theta to be published under the new Sonatype infrastructure. This PR configures the sbt ci-release plugin to use the new infrastructure url.

NB: This is my first time editing sbt config and I have no idea what I'm doing. Changes seem pretty straightforward but please double check I'm not making some beginner mistake.
