### PR TITLE
Uncertainty calibration default true

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -28,7 +28,7 @@ case class Bagger(
                    numBags: Int = -1,
                    useJackknife: Boolean = true,
                    biasLearner: Option[Learner] = None,
-                   uncertaintyCalibration: Boolean = false,
+                   uncertaintyCalibration: Boolean = true,
                    disableBootstrap: Boolean = false,
                    randBasis: RandBasis = Rand
                  ) extends Learner {

--- a/src/main/scala/io/citrine/lolo/bags/BaggerUtil.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggerUtil.scala
@@ -56,11 +56,12 @@ protected case class BaggerHelper(
     */
   val ratio = if (uncertaintyCalibration && isRegression && useJackknife) {
     Async.canStop()
-    oobErrors.map {
+    val oneSigmaRatio = oobErrors.map {
       case (_, 0.0, 0.0) => 1.0
       case (_, _, 0.0) => Double.PositiveInfinity
       case (_, error, uncertainty) => Math.abs(error / uncertainty)
     }.sorted.drop((oobErrors.size * 0.68).toInt).head
+    if (oneSigmaRatio.isPosInfinity) 1.0 else oneSigmaRatio
   } else {
     1.0
   }

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -23,7 +23,7 @@ case class MultiTaskBagger(
                             numBags: Int = -1,
                             useJackknife: Boolean = true,
                             biasLearner: Option[Learner] = None,
-                            uncertaintyCalibration: Boolean = false,
+                            uncertaintyCalibration: Boolean = true,
                             randBasis: RandBasis = Rand
                           ) extends MultiTaskLearner {
 

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -38,7 +38,7 @@ case class RandomForest(
                          subsetStrategy: Any = "auto",
                          minLeafInstances: Int = 1,
                          maxDepth: Int = Integer.MAX_VALUE,
-                         uncertaintyCalibration: Boolean = false,
+                         uncertaintyCalibration: Boolean = true,
                          randomizePivotLocation: Boolean = false,
                          randomlyRotateFeatures: Boolean = false,
                          rng: Random = Random


### PR DESCRIPTION
Sets `uncertaintyCalibration` to have a default value of true for `RandomForest`, `Bagger`, and `MultiTaskBagger`*. This is because the default uncertainty for the resulting predictions is observational uncertainty, which makes the most sense as a recalibrated bootstrap standard deviation, but that recalibration is not done if `uncertaintyCalibration = false`. Therefore, our defaults led to nonintuitive behavior.

The rescale ratio can sometimes be Infinity if the number of training data and bags are small. Since we have two tests that run thousands of trials and check that sigma is positive, now that `uncertaintyCalibration` is true it sometimes runs into that situation and throws an error. I have made is so that `ratio` is set to 1.0 in this scenario.

Since I was changing the rescale ratio logic, I took the opportunity to consolidate the `BaggerHelper` code, which was duplicated in `Bagger. This resolves #212.

*The default is still false for `ExtraRandomTrees`, since this learner disables the bootstrap by default.