### PR TITLE
Allow observational option for more Merits

### DIFF
--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -62,11 +62,11 @@ case object CoefficientOfDetermination extends Merit[Double] {
 /**
   * The fraction of predictions that fall within the predicted uncertainty
   */
-case object StandardConfidence extends Merit[Double] {
+case class StandardConfidence(observational: Boolean = true) extends Merit[Double] {
   override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
-    if (predictionResult.getUncertainty().isEmpty) return 0.0
+    if (predictionResult.getUncertainty(observational).isEmpty) return 0.0
 
-    (predictionResult.getExpected(), predictionResult.getUncertainty().get, actual).zipped.count {
+    (predictionResult.getExpected(), predictionResult.getUncertainty(observational).get, actual).zipped.count {
       case (x, sigma: Double, y) => Math.abs(x - y) < sigma
     } / predictionResult.getExpected().size.toDouble
   }
@@ -75,10 +75,10 @@ case object StandardConfidence extends Merit[Double] {
 /**
   * Root mean square of (the error divided by the predicted uncertainty)
   */
-case class StandardError(rescale: Double = 1.0) extends Merit[Double] {
+case class StandardError(rescale: Double = 1.0, observational: Boolean = true) extends Merit[Double] {
   override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
-    if (predictionResult.getUncertainty().isEmpty) return Double.PositiveInfinity
-    val standardized = (predictionResult.getExpected(), predictionResult.getUncertainty().get, actual).zipped.map {
+    if (predictionResult.getUncertainty(observational).isEmpty) return Double.PositiveInfinity
+    val standardized = (predictionResult.getExpected(), predictionResult.getUncertainty(observational).get, actual).zipped.map {
       case (x, sigma: Double, y) => (x - y) / sigma
     }
     rescale * Math.sqrt(standardized.map(Math.pow(_, 2.0)).sum / standardized.size)
@@ -96,11 +96,11 @@ case class StandardError(rescale: Double = 1.0) extends Merit[Double] {
   * In the absence of a closed form for that coefficient, it is model empirically by drawing from N(0, x) to produce
   * an "ideal" error series from which the correlation coefficient can be estimated.
   */
-case object UncertaintyCorrelation extends Merit[Double] {
+case class UncertaintyCorrelation(observational: Boolean = true) extends Merit[Double] {
   override def evaluate(predictionResult: PredictionResult[Double], actual: Seq[Double], rng: Random = Random): Double = {
     val predictedUncertaintyActual: Seq[(Double, Double, Double)] = (
       predictionResult.getExpected(),
-      predictionResult.getUncertainty().get.asInstanceOf[Seq[Double]],
+      predictionResult.getUncertainty(observational).get.asInstanceOf[Seq[Double]],
       actual
     ).zipped.toSeq
 

--- a/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
@@ -55,7 +55,7 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of training rows",
         Seq(16, 32, 64, 128, 256, 512),
-        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
         logScale = true,
         yMin = Some(0.0),
         yMax = Some(1.0),
@@ -91,7 +91,7 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of trees",
         Seq(16, 32, 64, 128, 256, 512, 1024, 2048, 4096),
-        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
         logScale = true,
         yMin = Some(0.0),
         yMax = Some(1.0),
@@ -133,7 +133,7 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of training points",
         Seq(16, 32, 64, 128, 256, 512, 1024),
-        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
         logScale = true,
         yMin = Some(0.0),
         yMax = Some(1.0),
@@ -212,7 +212,7 @@ object CalibrationStudy {
     BitmapEncoder.saveBitmap(pva, s"./pva_${funcName}-nTrain.${nTrain}-nTree.${nTree}", BitmapFormat.PNG)
     Merit.estimateMerits(
       dataStream.iterator,
-      Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+      Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence(), "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
       rng = rng
     )
   }
@@ -284,7 +284,7 @@ object CalibrationStudy {
       val chart = Merit.plotMeritScan(
         "Number of training points",
         Seq(16, 32, 64, 128, 256, 512, 1024),
-        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+        Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence(), "standard error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
         logScale = true,
         yMin = Some(0.0),
         yMax = Some(1.0),
@@ -358,7 +358,7 @@ object CalibrationStudy {
     BitmapEncoder.saveBitmap(pva, s"./pva_hcep-nTrain.${nTrain}-nTree.${nTree}", BitmapFormat.PNG)
     Merit.estimateMerits(
       dataStream.iterator,
-      Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence, "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation),
+      Map("R2" -> CoefficientOfDetermination, "confidence" -> StandardConfidence(), "error / 4" -> StandardError(0.25), "sigmaCorr" -> UncertaintyCorrelation()),
       rng = rng
     )
   }

--- a/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
@@ -92,7 +92,7 @@ class MeritTest {
     val rng = new Random(34578L)
     val pva = getNormalPVA(uncertaintyCorrelation = 1.0, batchSize = 256, numBatch = 32, rng = rng)
     val expected = 0.68
-    val (confidence, uncertainty) = StandardConfidence.estimate(pva, rng = rng)
+    val (confidence, uncertainty) = StandardConfidence().estimate(pva, rng = rng)
     assert(Math.abs(confidence - expected) < 3 * uncertainty, "Confidence estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Confidence estimate was not precise enough")
   }
@@ -119,7 +119,7 @@ class MeritTest {
     val rng = new Random(34578L)
     val pva = getNormalPVA(noiseScale = 0.01, uncertaintyCorrelation = 1.0, batchSize = 256, numBatch = 32, rng = rng)
     val expected = 1.0
-    val (corr, uncertainty) = UncertaintyCorrelation.estimate(pva, rng = rng)
+    val (corr, uncertainty) = UncertaintyCorrelation().estimate(pva, rng = rng)
     assert(Math.abs(corr - expected) < 3 * uncertainty, "Uncertainty correlation estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Uncertainty correlation estimate was not precise enough")
   }
@@ -132,7 +132,7 @@ class MeritTest {
     val rng = new Random(34578L)
     val pva = getNormalPVA(noiseScale = 0.01, uncertaintyCorrelation = 0.0, batchSize = 256, numBatch = 32, rng = rng)
     val expected = 0.0
-    val (corr, uncertainty) = UncertaintyCorrelation.estimate(pva, rng = rng)
+    val (corr, uncertainty) = UncertaintyCorrelation().estimate(pva, rng = rng)
     assert(Math.abs(corr - expected) < 3 * uncertainty, "Uncertainty correlation estimate was not accurate enough")
     assert(uncertainty < 0.05, s"Uncertainty correlation estimate was not precise enough")
   }


### PR DESCRIPTION
For `StandardConfidence`, `StandardError`, and `UncertaintyCorrelation`, allow the calling code to specify whether the uncertainties should be observational or not (default is observational).