### PR TITLE
expose NiB and models in BaggedModel

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -303,8 +303,10 @@ class BaggedModel[+T: ClassTag](
     Some(scale * ensembleShapley.reduce(sumReducer).get)
   }
 
-  // Accessor useful for testing.
-  private[bags] def getModels(): ParSeq[Model[PredictionResult[T]]] = models
+  // Accessors useful for testing and benchmarking.
+   def getModels(): ParSeq[Model[PredictionResult[T]]] = models
+
+  def getNib(): Vector[Vector[Int]] = Nib
 }
 
 object Bagger {


### PR DESCRIPTION
These are useful for examining the out-of-bag predictions in benchmarking