### PR TITLE
Return None if ensemble doesn't return Shapley values.

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -278,17 +278,18 @@ class BaggedModel[+T: ClassTag](
     */
   override def shapley(input: Vector[Any], omitFeatures: Set[Int] = Set()): Option[DenseMatrix[Double]] = {
     val ensembleShapley = models.map(model => model.shapley(input, omitFeatures))
-    if (!ensembleShapley.head.isDefined) {
+    if (ensembleShapley.head.isEmpty) {
       None
-    }
-    assert(ensembleShapley.forall(x => x.isDefined))
+    } else {
+      assert(ensembleShapley.forall(x => x.isDefined))
 
-    def sumReducer(a: Option[DenseMatrix[Double]], b: Option[DenseMatrix[Double]]): Option[DenseMatrix[Double]] = {
-      Some(a.get + b.get)
-    }
-    val scale = 1.0 / ensembleShapley.length
+      def sumReducer(a: Option[DenseMatrix[Double]], b: Option[DenseMatrix[Double]]): Option[DenseMatrix[Double]] = {
+        Some(a.get + b.get)
+      }
+      val scale = 1.0 / ensembleShapley.length
 
-    Some(scale * ensembleShapley.reduce(sumReducer).get)
+      Some(scale * ensembleShapley.reduce(sumReducer).get)
+    }
   }
 
   // Accessor useful for testing.

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -420,7 +420,7 @@ class BaggerTest {
       function = Friedman.friedmanSilverman,
       seed = rng.nextLong()
     )
-    val DTLearner = FeatureRotator(RegressionTreeLearner(numFeatures = nCols, rng = rng))
+    val DTLearner = RegressionTreeLearner(numFeatures = nCols, rng = rng)
     val model = Bagger(DTLearner, randBasis = TestUtils.getBreezeRandBasis(rng.nextLong()))
       .train(trainingData)
       .getModel()


### PR DESCRIPTION
Minor bugfix to return `None` if the ensemble doesn't return Shapley values.