### PR TITLE
Update PyPi docs during Python release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ jobs:
     install:
       - cd python
       - make
-      - pip install pypandoc
       - pip install --only-binary=numpy,scipy -r requirements.txt
     script: true
     deploy:

--- a/python/README.md
+++ b/python/README.md
@@ -64,7 +64,7 @@ Our performance for model training is comparable to scikit-learn, as shown in th
 The blue-shaded region in the figure represents the time required to pass training data to the JVM.
 We note that training times are equivalent between using the Scala interface to Lolo and `lolopy` for training set sizes above 100.
 
-![training performance](./examples/profile/training-performance.png)
+![training performance](https://raw.githubusercontent.com/CitrineInformatics/lolo/main/python/examples/profile/training-performance.png)
  
 Lolopy and lolo are currently slower than scikit-learn for model evaluation, as shown in the figure below.
 The model timings are evaluated on a dataset size of 1000 with 145 features.
@@ -72,6 +72,6 @@ The decrease in model performance with training set size is an effect of the num
 Lolopy and lolo have similar performance for models with training set sizes of above 100.
 Below a training set size of 100, the cost of sending data limits the performance of `lolopy`. 
 
-![evaluation performance](./examples/profile/evaluation-performance.png)
+![evaluation performance](https://raw.githubusercontent.com/CitrineInformatics/lolo/main/python/examples/profile/evaluation-performance.png)
 
 For more details, see the [benchmarking notebook](./examples/profile/scaling-test.ipynb).

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup
 from glob import glob
 import shutil
-import sys
 import os
 
 # single source of truth for package version
@@ -24,18 +23,8 @@ if os.path.isdir(jar_path):
 os.mkdir(jar_path)
 shutil.copy(JAR_FILE[0], os.path.join(jar_path, 'lolo-jar-with-dependencies.jar'))
 
-# Convert the README.md file to rst (rst is rendered by PyPi not MD)
-#  Taken from: https://github.com/apache/spark/blob/master/python/setup.py
-# Parse the README markdown file into rst for PyPI
-long_description = "!!!!! missing pandoc do not upload to PyPI !!!!"
-try:
-    import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
-except ImportError:
-    print("Could not import pypandoc - required to package PySpark", file=sys.stderr)
-except OSError:
-    print("Could not convert - pandoc is not installed", file=sys.stderr)
-
+with open('README.md') as f:
+    long_description = f.read()
 
 # Make the installation
 setup(
@@ -53,4 +42,5 @@ setup(
     install_requires=['scikit-learn', 'py4j'],
     description='Python wrapper for the Lolo machine learning library',
     long_description=long_description,
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
I was able to figure out why the PyPi release stage of my recent jobs were failing. `pypandoc` released a new version, which [removed the deprecated method `pypandoc.convert` that we were calling](https://github.com/NicklasTegner/pypandoc/pull/257).

As it turns out, we no longer need to use this package. `pypandoc` is used to convert a `.md` file to an `.rst` file, which was previously being used to convert out README to a PyPi display format. As of March 2018 PyPi can natively accept `.md` files in the description, so we no longer need a conversion (see notes [here](https://stackoverflow.com/questions/26737222/how-to-make-pypi-description-markdown-work), and `pyspark` example setup file [here](https://github.com/apache/spark/blob/master/python/setup.py)). I have updated the Python setup file to just use the standard markdown in the README.

I was able to verify that the display format is correct following the steps [here](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#:~:text=You%20can%20check%20your%20README%20for%20markup%20errors%20before%20uploading%20as%20follows%3A).

I have also gone into our python README and updated the image links to the full Github asset URL, which will allow the images to be displayed in the PyPi docs (see guide [here](https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github)).