### PR TITLE
Configure recalibration for multitask bagger

### DIFF
--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -114,7 +114,8 @@ case class Bagger(
       .reduce(Bagger.combineImportance)
       .map(_.map(_ / importances.size))
 
-    val helper = BaggerHelper(models, trainingData, Nib, useJackknife, uncertaintyCalibration)
+    val uncertaintyCalibrationLevel = if (uncertaintyCalibration) Some(0.683) else None
+    val helper = BaggerHelper(models, trainingData, Nib, useJackknife, uncertaintyCalibrationLevel)
     val biasModel = if (biasLearner.isDefined && helper.oobErrors.nonEmpty && helper.isRegression) {
       Async.canStop()
       Some(biasLearner.get.train(helper.biasTraining).getModel().asInstanceOf[Model[PredictionResult[Double]]])

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -27,6 +27,13 @@ case class MultiTaskBagger(
                             randBasis: RandBasis = Rand
                           ) extends MultiTaskLearner {
 
+    if (uncertaintyCalibrationLevel.isDefined) {
+      val p = uncertaintyCalibrationLevel.get
+      if (p <= 0.0 || p >= 1.0) {
+        throw new IllegalArgumentException(s"Uncertainty calibration level must be between 0 and 1, exclusive. Got $p.")
+      }
+    }
+
   override def train(inputs: Seq[Vector[Any]], labels: Seq[Seq[Any]], weights: Option[Seq[Double]] = None): MultiTaskBaggedTrainingResult = {
     /* Make sure the training data are the same size */
     assert(inputs.forall(inputs.head.size == _.size))

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -33,7 +33,7 @@ class MultiTaskBaggerTest {
     val inputs = trainingData.map(_._1)
     val labels = trainingData.map(_._2)
     val DTLearner = MultiTaskTreeLearner()
-    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size, randBasis = TestUtils.getBreezeRandBasis(10478L), uncertaintyCalibration = true)
+    val baggedLearner = MultiTaskBagger(DTLearner, numBags = trainingData.size, randBasis = TestUtils.getBreezeRandBasis(10478L), uncertaintyCalibrationLevel = Some(0.683))
     val RFMeta = baggedLearner.train(inputs, Seq(labels))
     val RF = RFMeta.getModels().head
 
@@ -68,7 +68,7 @@ class MultiTaskBaggerTest {
               val trainingData = trainingDataTmp.map { x => (x._1, x._2 + noiseLevel * rng.nextDouble()) }
               val inputs = trainingData.map(_._1)
               val labels = trainingData.map(_._2)
-              val baggedLearner = MultiTaskBagger(baseLearner, numBags = nBags, uncertaintyCalibration = true, randBasis = TestUtils.getBreezeRandBasis(7835178L))
+              val baggedLearner = MultiTaskBagger(baseLearner, numBags = nBags, uncertaintyCalibrationLevel = Some(0.683), randBasis = TestUtils.getBreezeRandBasis(7835178L))
               val RFMeta = baggedLearner.train(inputs, Seq(labels))
               val RF = RFMeta.getModels().head
               val results = RF.transform(trainingData.take(4).map(_._1))
@@ -185,7 +185,7 @@ class MultiTaskBaggerTest {
       numBags = numBags,
       biasLearner = Some(RegressionTreeLearner(maxDepth = 2)),
       randBasis = TestUtils.getBreezeRandBasis(78495L),
-      uncertaintyCalibration = true
+      uncertaintyCalibrationLevel = Some(0.683)
     )
     val RF = baggedLearner.train(inputs, Seq(realLabel, catLabel))
 


### PR DESCRIPTION
In order to allow running SL simulations using a variety of confidence level parameters, we expose an uncertainty level parameter. Instead of specifying whether they want to do uncertainty recalibration using a Boolean, users can specify the level of `p` (between 0 and 1).

This option is only exposed in `MultiTaskBagger`. In `Bagger`, a value of `true` maps to 0.683.