### PR TITLE
Reproducible training

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
-scala: 2.12.4
-jdk: openjdk8
+scala: 2.13.8
+jdk: openjdk11
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import Dependencies._
 
 ThisBuild / name := "lolo"
-ThisBuild / scalaVersion := "2.13.4"
-ThisBuild / crossScalaVersions := List("2.13.4", "2.12.4")
+ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / crossScalaVersions := List("2.13.8")
 ThisBuild / organization := "io.citrine"
 ThisBuild / organizationName := "Citrine Informatics"
 ThisBuild / homepage := Some(url("https://github.com/CitrineInformatics/lolo"))
@@ -25,15 +25,6 @@ ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 ThisBuild / pomIncludeRepository := { _ => false }
 
 ThisBuild / libraryDependencies ++= logging ++ loloDeps
-ThisBuild / libraryDependencies ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, major)) if major <= 12 =>
-      Seq()
-    case _ =>
-      Seq("org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion)
-  }
-}
-
 ThisBuild / Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
 
 // Assembly settings

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,6 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val thetaVersion = "1.1.5"
+  lazy val sprandomVersion = "0.1.0"
   lazy val breezeVersion = "2.0"
   lazy val junitVersion = "4.13.1"
   lazy val scalaTestVersion = "3.2.2"
@@ -17,11 +18,13 @@ object Dependencies {
   )
 
   lazy val loloDeps = Seq(
-    "io.citrine"      %% "theta"           % thetaVersion,
-    "org.scalanlp"    %% "breeze"          % breezeVersion,
-    "junit"            % "junit"           % junitVersion     % "test",
-    "org.scalatest"   %% "scalatest"       % scalaTestVersion % "test",
-    "com.github.sbt"   % "junit-interface" % "0.13.3"         % "test",
-    "org.knowm.xchart" % "xchart"          % "3.5.2"
+      "io.citrine"            %% "theta"                      % thetaVersion,
+    "io.citrine"              %% "sprandom"                   % sprandomVersion,
+    "org.scalanlp"            %% "breeze"                     % breezeVersion,
+    "org.scala-lang.modules"  %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
+    "junit"                    % "junit"                      % junitVersion     % "test",
+    "org.scalatest"           %% "scalatest"                  % scalaTestVersion % "test",
+    "com.github.sbt"           % "junit-interface"            % "0.13.3"         % "test",
+    "org.knowm.xchart"         % "xchart"                     % "3.5.2"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,12 +2,10 @@ import sbt._
 
 object Dependencies {
   lazy val thetaVersion = "1.1.5"
-  lazy val sprandomVersion = "0.1.0"
+  lazy val sprandomVersion = "0.1.1"
   lazy val breezeVersion = "2.0"
   lazy val junitVersion = "4.13.1"
   lazy val scalaTestVersion = "3.2.2"
-
-  // this is used in build.sbt so that it works with both 2.12 and 2.13
   lazy val scalaParallelCollectionsVersion = "1.0.0"
 
   lazy val logging = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   )
 
   lazy val loloDeps = Seq(
-      "io.citrine"            %% "theta"                      % thetaVersion,
+    "io.citrine"              %% "theta"                      % thetaVersion,
     "io.citrine"              %% "sprandom"                   % sprandomVersion,
     "org.scalanlp"            %% "breeze"                     % breezeVersion,
     "org.scala-lang.modules"  %% "scala-parallel-collections" % scalaParallelCollectionsVersion,

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -281,11 +281,11 @@ class BaseLoloClassifier(BaseLoloLearner, ClassifierMixin):
     Implements a modification to the fit operation that stores the number of classes
     and the predict/predict_proba methods"""
 
-    def fit(self, X, y, weights=None):
+    def fit(self, X, y, weights=None, random_seed=None):
         # Get the number of classes
         self.n_classes_ = len(set(y))
 
-        return super(BaseLoloClassifier, self).fit(X, y, weights)
+        return super(BaseLoloClassifier, self).fit(X, y, weights, random_seed)
 
     def predict(self, X):
         pred_result = self._get_prediction_result(X)

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -351,7 +351,7 @@ class RandomForestMixin(BaseLoloLearner):
         self.random_seed = random_seed
 
     def _make_learner(self):
-        rng = self.gateway.jvm.scala.util.Random(self.random_seed) if self.random_seed else self.gateway.jvm.scala.util.Random()
+        rng = self.gateway.jvm.io.citrine.random.Random(self.random_seed) if self.random_seed else self.gateway.jvm.io.citrine.random.Random()
 
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
         #  TODO: that ^^, please
@@ -430,9 +430,8 @@ class ExtraRandomTreesMixIn(BaseLoloLearner):
 
     def _make_learner(self):
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
-        #  TODO: that ^^, please
 
-        rng = self.gateway.jvm.scala.util.Random(self.random_seed) if self.random_seed else self.gateway.jvm.scala.util.Random()
+        rng = self.gateway.jvm.io.citrine.random.Random(self.random_seed) if self.random_seed else self.gateway.jvm.io.citrine.random.Random()
 
         learner = self.gateway.jvm.io.citrine.lolo.learners.ExtraRandomTrees(
             self.num_trees, self.use_jackknife,
@@ -496,7 +495,7 @@ class RegressionTreeLearner(BaseLoloRegressor):
             "$lessinit$greater$default$5"
         )()
 
-        rng = self.gateway.jvm.scala.util.Random() if self.random_seed is None else self.gateway.jvm.scala.util.Random(self.random_seed)
+        rng = self.gateway.jvm.io.citrine.random.Random() if self.random_seed is None else self.gateway.jvm.io.citrine.random.Random(self.random_seed)
 
         return self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner(
             self.num_features, self.max_depth, self.min_leaf_instances,

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -351,10 +351,10 @@ class RandomForestMixin(BaseLoloLearner):
         self.random_seed = random_seed
 
     def _make_learner(self):
-        rng = self.gateway.jvm.io.citrine.random.Random(self.random_seed) if self.random_seed else self.gateway.jvm.io.citrine.random.Random()
+        rng = self.gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(self.random_seed) if self.random_seed \
+            else self.gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng()
 
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
-        #  TODO: that ^^, please
         learner = self.gateway.jvm.io.citrine.lolo.learners.RandomForest(
             self.num_trees, self.use_jackknife,
             getattr(self.gateway.jvm.io.citrine.lolo.learners.RandomForest,
@@ -431,7 +431,8 @@ class ExtraRandomTreesMixIn(BaseLoloLearner):
     def _make_learner(self):
         #  TODO: Figure our a more succinct way of dealing with optional arguments/Option values
 
-        rng = self.gateway.jvm.io.citrine.random.Random(self.random_seed) if self.random_seed else self.gateway.jvm.io.citrine.random.Random()
+        rng = self.gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(self.random_seed) if self.random_seed \
+            else self.gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng()
 
         learner = self.gateway.jvm.io.citrine.lolo.learners.ExtraRandomTrees(
             self.num_trees, self.use_jackknife,
@@ -495,7 +496,8 @@ class RegressionTreeLearner(BaseLoloRegressor):
             "$lessinit$greater$default$5"
         )()
 
-        rng = self.gateway.jvm.io.citrine.random.Random() if self.random_seed is None else self.gateway.jvm.io.citrine.random.Random(self.random_seed)
+        rng = self.gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng() if self.random_seed is None \
+            else self.gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(self.random_seed)
 
         return self.gateway.jvm.io.citrine.lolo.trees.regression.RegressionTreeLearner(
             self.num_features, self.max_depth, self.min_leaf_instances,

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -8,7 +8,7 @@ from lolopy.utils import send_1D_array
 import numpy as np
 
 
-def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, **kwargs):
+def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, *args):
     """Call a metric from lolopy
     
     Args:
@@ -17,7 +17,7 @@ def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, 
         y_pred ([double]): Predicted values
         random_seed (int): for reproducibility (only used by some metrics)
         y_std ([double]): Prediction uncertainties (only used by some metrics)
-        *args (list): Any parameters to the constructor of the Metric
+        *args: Any parameters to the constructor of the Metric
     Returns:
         (double): Metric score
     """
@@ -32,8 +32,8 @@ def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, 
         else gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng()
     # Get the metric object
     metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
-    if len(kwargs) > 0:
-        metric = metric(*kwargs)
+    if len(args) > 0:
+        metric = metric(*args)
 
     # Convert the data arrays to Java
     y_true_java = send_1D_array(gateway, y_true, True)
@@ -86,7 +86,7 @@ def standard_error(y_true, y_pred, y_std, rescale=1.0):
         (double): standard error
     """
 
-    return _call_lolo_merit('StandardError', y_true, y_pred, y_std=y_std, rescale=float(rescale))
+    return _call_lolo_merit('StandardError', y_true, y_pred, None, y_std, float(rescale))
 
 
 def uncertainty_correlation(y_true, y_pred, y_std, random_seed=None):

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -27,7 +27,7 @@ def _call_lolo_merit(metric_name, y_true, y_pred, rng, y_std=None, *args):
 
     gateway = get_java_gateway()
     # Get default rng
-    rng = rng if rng else gateway.jvm.scala.util.Random()
+    rng = rng if rng else gateway.jvm.io.citrine.random.Random()
     # Get the metric object
     metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
     if len(args) > 0:

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -8,7 +8,7 @@ from lolopy.utils import send_1D_array
 import numpy as np
 
 
-def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, *args):
+def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, **kwargs):
     """Call a metric from lolopy
     
     Args:
@@ -32,8 +32,8 @@ def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, 
         else gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng()
     # Get the metric object
     metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
-    if len(args) > 0:
-        metric = metric(*args)
+    if len(kwargs) > 0:
+        metric = metric(**kwargs)
 
     # Convert the data arrays to Java
     y_true_java = send_1D_array(gateway, y_true, True)

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -8,14 +8,15 @@ from lolopy.utils import send_1D_array
 import numpy as np
 
 
-def _call_lolo_merit(metric_name, y_true, y_pred, rng, y_std=None, *args):
+def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, *args):
     """Call a metric from lolopy
     
     Args:
         metric_name (str): Name of a Merit class (e.g., UncertaintyCorrelation)
         y_true ([double]): True value
         y_pred ([double]): Predicted values
-        y_uncert ([double]): Prediction uncertainties
+        random_seed (int): for reproducibility (only used by some metrics)
+        y_std ([double]): Prediction uncertainties (only used by some metrics)
         *args (list): Any parameters to the constructor of the Metric
     Returns:
         (double): Metric score
@@ -27,7 +28,8 @@ def _call_lolo_merit(metric_name, y_true, y_pred, rng, y_std=None, *args):
 
     gateway = get_java_gateway()
     # Get default rng
-    rng = rng if rng else gateway.jvm.io.citrine.random.Random()
+    rng = gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(random_seed) if random_seed \
+        else gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng()
     # Get the metric object
     metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
     if len(args) > 0:
@@ -45,7 +47,7 @@ def _call_lolo_merit(metric_name, y_true, y_pred, rng, y_std=None, *args):
     return metric.evaluate(pred_result, y_true_java, rng)
 
 
-def root_mean_squared_error(y_true, y_pred, rng=None):
+def root_mean_squared_error(y_true, y_pred):
     """Compute the root mean squared error
     
     Args:
@@ -55,10 +57,10 @@ def root_mean_squared_error(y_true, y_pred, rng=None):
         (double): RMSE
     """
 
-    return _call_lolo_merit('RootMeanSquareError', y_true, y_pred, rng)
+    return _call_lolo_merit('RootMeanSquareError', y_true, y_pred)
 
 
-def standard_confidence(y_true, y_pred, y_std, rng=None):
+def standard_confidence(y_true, y_pred, y_std):
     """Fraction of entries that have errors within the predicted confidence interval. 
     
     Args:
@@ -69,10 +71,10 @@ def standard_confidence(y_true, y_pred, y_std, rng=None):
         (double): standard confidence
     """
 
-    return _call_lolo_merit('StandardConfidence', y_true, y_pred, rng, y_std)
+    return _call_lolo_merit('StandardConfidence', y_true, y_pred, y_std=y_std)
 
 
-def standard_error(y_true, y_pred, y_std, rng=None, rescale=1.0):
+def standard_error(y_true, y_pred, y_std, rescale=1.0):
     """Root mean square of the error divided by the predicted uncertainty 
     
     Args:
@@ -84,17 +86,18 @@ def standard_error(y_true, y_pred, y_std, rng=None, rescale=1.0):
         (double): standard error
     """
 
-    return _call_lolo_merit('StandardError', y_true, y_pred, rng, y_std, float(rescale))
+    return _call_lolo_merit('StandardError', y_true, y_pred, y_std=y_std, rescale=float(rescale))
 
 
-def uncertainty_correlation(y_true, y_pred, y_std, rng=None):
+def uncertainty_correlation(y_true, y_pred, y_std, random_seed=None):
     """Measure of the correlation between the predicted uncertainty and error magnitude
     
     Args:
         y_true ([double]): True value
         y_pred ([double]): Predicted values
         y_std ([double]): Predicted uncertainty
+        random_seed (int): for reproducibility
     Returns:
         (double):
     """
-    return _call_lolo_merit('UncertaintyCorrelation', y_true, y_pred, rng, y_std)
+    return _call_lolo_merit('UncertaintyCorrelation', y_true, y_pred, random_seed=random_seed, y_std=y_std)

--- a/python/lolopy/metrics.py
+++ b/python/lolopy/metrics.py
@@ -33,7 +33,7 @@ def _call_lolo_merit(metric_name, y_true, y_pred, random_seed=None, y_std=None, 
     # Get the metric object
     metric = getattr(gateway.jvm.io.citrine.lolo.validation, metric_name)
     if len(kwargs) > 0:
-        metric = metric(**kwargs)
+        metric = metric(*kwargs)
 
     # Convert the data arrays to Java
     y_true_java = send_1D_array(gateway, y_true, True)

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -32,7 +32,7 @@ def _make_linear_data():
 class TestRF(TestCase):
 
     def test_rf_regressor(self):
-        rf = RandomForestRegressor(random_seed = 31247895)
+        rf = RandomForestRegressor()
 
         # Train the model
         X, y = load_diabetes(return_X_y=True)
@@ -42,7 +42,7 @@ class TestRF(TestCase):
             rf.predict(X)
 
         # Fit the model
-        rf.fit(X, y)
+        rf.fit(X, y, random_seed=31247895)
 
         # Run some predictions
         y_pred = rf.predict(X)
@@ -79,13 +79,13 @@ class TestRF(TestCase):
         self.assertIsNone(rf.model_)
 
     def test_rf_multioutput_regressor(self):
-        rf = RandomForestRegressor(random_seed=810355)
+        rf = RandomForestRegressor()
         # A regression dataset with 3 outputs
         X, y = load_linnerud(return_X_y=True)
         num_data = len(X)
         num_outputs = y.shape[1]
 
-        rf.fit(X, y)
+        rf.fit(X, y, random_seed=810355)
         y_pred, y_std = rf.predict(X, return_std=True)
         _, y_cov = rf.predict(X, return_cov_matrix=True)
 
@@ -103,11 +103,11 @@ class TestRF(TestCase):
             rf.predict(X, return_std=True, return_cov_matrix=True)
 
     def test_classifier(self):
-        rf = RandomForestClassifier(random_seed = 34789)
+        rf = RandomForestClassifier()
 
         # Load in the iris dataset
         X, y = load_iris(return_X_y=True)
-        rf.fit(X, y)
+        rf.fit(X, y, random_seed=34789)
 
         # Predict the probability of membership in each class
         y_prob = rf.predict_proba(X)
@@ -126,7 +126,7 @@ class TestRF(TestCase):
         self.assertAlmostEqual(acc, 1)  # Given default settings, we should get perfect fitness to training data
 
     def test_serialization(self):
-        rf = RandomForestClassifier(random_seed = 234785)
+        rf = RandomForestClassifier()
 
         # Make sure this doesn't error without a model training
         data = pkl.dumps(rf)
@@ -134,7 +134,7 @@ class TestRF(TestCase):
 
         # Load in the iris dataset and train model
         X, y = load_iris(return_X_y=True)
-        rf.fit(X, y)
+        rf.fit(X, y, random_seed=234785)
 
         # Try saving and loading the model
         data = pkl.dumps(rf)
@@ -207,19 +207,19 @@ class TestRF(TestCase):
         self.assertAlmostEqual(1.0, r2_score(y, tree.predict(X)))  # Linear leaves means perfect fit
 
         # Test whether changing leaf learner does something
-        rf = RandomForestRegressor(leaf_learner=LinearRegression(), min_leaf_instances=16, random_seed = 23478)
-        rf.fit(X[:16, :], y[:16])  # Train only on a subset
+        rf = RandomForestRegressor(leaf_learner=LinearRegression(), min_leaf_instances=16)
+        rf.fit(X[:16, :], y[:16], random_seed=23478)  # Train only on a subset
         self.assertAlmostEqual(1.0, r2_score(y, rf.predict(X)))  # Should fit perfectly on whole dataset
 
-        rf = RandomForestRegressor(random_seed = 7834)
-        rf.fit(X[:16, :], y[:16])
+        rf = RandomForestRegressor()
+        rf.fit(X[:16, :], y[:16], random_seed=7834)
         self.assertLess(r2_score(y, rf.predict(X)), 1.0)  # Should not fit the whole dataset perfectly
 
 
 class TestExtraRandomTrees(TestCase):
 
     def test_extra_random_trees_regressor(self):
-        rf = ExtraRandomTreesRegressor(random_seed = 378456)
+        rf = ExtraRandomTreesRegressor()
 
         # Train the model
         X, y = load_diabetes(return_X_y=True)
@@ -229,7 +229,7 @@ class TestExtraRandomTrees(TestCase):
             rf.predict(X)
 
         # Fit the model
-        rf.fit(X, y)
+        rf.fit(X, y, random_seed=378456)
 
         # Run some predictions
         y_pred = rf.predict(X)
@@ -262,11 +262,11 @@ class TestExtraRandomTrees(TestCase):
         self.assertIsNone(rf.model_)
 
     def test_extra_random_trees_classifier(self):
-        rf = ExtraRandomTreesClassifier(random_seed = 378456)
+        rf = ExtraRandomTreesClassifier()
 
         # Load in the iris dataset
         X, y = load_iris(return_X_y=True)
-        rf.fit(X, y)
+        rf.fit(X, y, random_seed=378456)
 
         # Predict the probability of membership in each class
         y_prob = rf.predict_proba(X)
@@ -285,7 +285,7 @@ class TestExtraRandomTrees(TestCase):
         self.assertAlmostEqual(acc, 1)  # Given default settings, we should get perfect fitness to training data
 
     def test_serialization(self):
-        rf = ExtraRandomTreesClassifier(random_seed = 378945)
+        rf = ExtraRandomTreesClassifier()
 
         # Make sure this doesn't error without a model training
         data = pkl.dumps(rf)
@@ -293,7 +293,7 @@ class TestExtraRandomTrees(TestCase):
 
         # Load in the iris dataset and train model
         X, y = load_iris(return_X_y=True)
-        rf.fit(X, y)
+        rf.fit(X, y, random_seed=378945)
 
         # Try saving and loading the model
         data = pkl.dumps(rf)

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -273,6 +273,18 @@ class TestExtraRandomTrees(TestCase):
         rf.clear_model()
         self.assertIsNone(rf.model_)
 
+    def test_reproducibility(self):
+        seed = 378456
+        rf1 = ExtraRandomTreesRegressor()
+        rf2 = ExtraRandomTreesRegressor()
+        X, y = load_diabetes(return_X_y=True)
+
+        rf1.fit(X, y, random_seed=seed)
+        rf2.fit(X, y, random_seed=seed)
+        pred1 = rf1.predict(X)
+        pred2 = rf2.predict(X)
+        self.assertTrue((pred1 == pred2).all())
+
     def test_extra_random_trees_classifier(self):
         rf = ExtraRandomTreesClassifier()
 

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -78,6 +78,18 @@ class TestRF(TestCase):
         rf.clear_model()
         self.assertIsNone(rf.model_)
 
+    def test_reproducibility(self):
+        seed = 31247895
+        rf1 = RandomForestRegressor()
+        rf2 = RandomForestRegressor()
+        X, y = load_diabetes(return_X_y=True)
+
+        rf1.fit(X, y, random_seed=seed)
+        rf2.fit(X, y, random_seed=seed)
+        pred1 = rf1.predict(X)
+        pred2 = rf2.predict(X)
+        self.assertEqual(pred1, pred2)
+
     def test_rf_multioutput_regressor(self):
         rf = RandomForestRegressor()
         # A regression dataset with 3 outputs

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -88,7 +88,7 @@ class TestRF(TestCase):
         rf2.fit(X, y, random_seed=seed)
         pred1 = rf1.predict(X)
         pred2 = rf2.predict(X)
-        self.assertEqual(pred1, pred2)
+        self.assertTrue((pred1 == pred2).all())
 
     def test_rf_multioutput_regressor(self):
         rf = RandomForestRegressor()

--- a/python/lolopy/tests/test_metrics.py
+++ b/python/lolopy/tests/test_metrics.py
@@ -12,7 +12,7 @@ class TestMetrics(TestCase):
 
     def test_standard_confidene(self):
         gateway = get_java_gateway()
-        rng = gateway.jvm.io.citrine.random.Random(367894)
+        rng = gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(367894)
         self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 0.9]), 0.5, rng)
         self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 1.1]), 1, rng)
 
@@ -24,7 +24,7 @@ class TestMetrics(TestCase):
         seed(3893789455)
         sample_size = 2 ** 15
         gateway = get_java_gateway()
-        rng = gateway.jvm.io.citrine.random.Random(783245)
+        rng = gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(783245)
         for expected in [0, 0.75]:
             # Make the error distribution
             y_true = uniform(0, 1, sample_size)

--- a/python/lolopy/tests/test_metrics.py
+++ b/python/lolopy/tests/test_metrics.py
@@ -24,7 +24,7 @@ class TestMetrics(TestCase):
         seed(3893789455)
         sample_size = 2 ** 15
         gateway = get_java_gateway()
-        rng = gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(783245)
+        random_seed = 783245
         for expected in [0, 0.75]:
             # Make the error distribution
             y_true = uniform(0, 1, sample_size)
@@ -37,6 +37,6 @@ class TestMetrics(TestCase):
             y_std = [abs(d[1]) for d in draw]
 
             # Test with a very large tolerance for now
-            measured_corr = uncertainty_correlation(y_true, y_pred, y_std, rng = rng)
+            measured_corr = uncertainty_correlation(y_true, y_pred, y_std, random_seed=random_seed)
             corr_error = abs(measured_corr - expected)
             self.assertLess(corr_error, 0.25, 'Error for {:.2f}: {:.2f}'.format(expected, corr_error))

--- a/python/lolopy/tests/test_metrics.py
+++ b/python/lolopy/tests/test_metrics.py
@@ -11,10 +11,8 @@ class TestMetrics(TestCase):
         self.assertAlmostEqual(root_mean_squared_error([4, 5], [1, 2]), 3)
 
     def test_standard_confidene(self):
-        gateway = get_java_gateway()
-        rng = gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(367894)
-        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 0.9]), 0.5, rng)
-        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 1.1]), 1, rng)
+        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 0.9]), 0.5)
+        self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 1.1]), 1)
 
     def test_standard_error(self):
         self.assertAlmostEqual(standard_error([1, 2], [1, 2], [1, 1]), 0)
@@ -23,7 +21,6 @@ class TestMetrics(TestCase):
     def test_uncertainty_correlation(self):
         seed(3893789455)
         sample_size = 2 ** 15
-        gateway = get_java_gateway()
         random_seed = 783245
         for expected in [0, 0.75]:
             # Make the error distribution

--- a/python/lolopy/tests/test_metrics.py
+++ b/python/lolopy/tests/test_metrics.py
@@ -12,7 +12,7 @@ class TestMetrics(TestCase):
 
     def test_standard_confidene(self):
         gateway = get_java_gateway()
-        rng = gateway.jvm.scala.util.Random(367894)
+        rng = gateway.jvm.io.citrine.random.Random(367894)
         self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 0.9]), 0.5, rng)
         self.assertAlmostEqual(standard_confidence([1, 2], [2, 3], [1.5, 1.1]), 1, rng)
 
@@ -24,7 +24,7 @@ class TestMetrics(TestCase):
         seed(3893789455)
         sample_size = 2 ** 15
         gateway = get_java_gateway()
-        rng = gateway.jvm.scala.util.Random(783245)
+        rng = gateway.jvm.io.citrine.random.Random(783245)
         for expected in [0, 0.75]:
             # Make the error distribution
             y_true = uniform(0, 1, sample_size)

--- a/src/main/scala/io/citrine/lolo/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/Learner.scala
@@ -12,7 +12,11 @@ trait Learner extends Serializable {
     * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
-  def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]] = None, rng: Random = Random()): TrainingResult
+  def train(
+      trainingData: Seq[(Vector[Any], Any)],
+      weights: Option[Seq[Double]] = None,
+      rng: Random = Random()
+  ): TrainingResult
 
   /**
     * Train a model with weights
@@ -40,5 +44,9 @@ trait MultiTaskLearner extends Serializable {
     * @param rng          random number generator for reproducibility
     * @return A training result that encompasses model(s) for all labels.
     */
-  def train(trainingData: Seq[(Vector[Any], Vector[Any])], weights: Option[Seq[Double]] = None, rng: Random = Random()): MultiTaskTrainingResult
+  def train(
+      trainingData: Seq[(Vector[Any], Vector[Any])],
+      weights: Option[Seq[Double]] = None,
+      rng: Random = Random()
+  ): MultiTaskTrainingResult
 }

--- a/src/main/scala/io/citrine/lolo/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/Learner.scala
@@ -1,8 +1,7 @@
 package io.citrine.lolo
 
-/**
-  * Created by maxhutch on 11/14/16.
-  */
+import io.citrine.random.Random
+
 trait Learner extends Serializable {
 
   /**
@@ -10,18 +9,20 @@ trait Learner extends Serializable {
     *
     * @param trainingData to train on
     * @param weights      for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
-  def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]] = None): TrainingResult
+  def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]] = None, rng: Random = Random()): TrainingResult
 
   /**
     * Train a model with weights
     *
     * @param trainingData with weights in the form (features, label, weight)
+    * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
-  def train(trainingData: Seq[(Vector[Any], Any, Double)]): TrainingResult = {
-    train(trainingData.map(r => (r._1, r._2)), Some(trainingData.map(_._3)))
+  def train(trainingData: Seq[(Vector[Any], Any, Double)], rng: Random): TrainingResult = {
+    train(trainingData.map(r => (r._1, r._2)), Some(trainingData.map(_._3)), rng)
   }
 
 }
@@ -36,7 +37,8 @@ trait MultiTaskLearner extends Serializable {
     *
     * @param trainingData  to train on. Each entry is a tuple (vector of inputs, vector of labels)
     * @param weights for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return A training result that encompasses model(s) for all labels.
     */
-  def train(trainingData: Seq[(Vector[Any], Vector[Any])], weights: Option[Seq[Double]] = None): MultiTaskTrainingResult
+  def train(trainingData: Seq[(Vector[Any], Vector[Any])], weights: Option[Seq[Double]] = None, rng: Random = Random()): MultiTaskTrainingResult
 }

--- a/src/main/scala/io/citrine/lolo/Model.scala
+++ b/src/main/scala/io/citrine/lolo/Model.scala
@@ -2,9 +2,6 @@ package io.citrine.lolo
 
 import breeze.linalg.DenseMatrix
 
-/**
-  * Created by maxhutch on 11/14/16.
-  */
 trait Model[+T <: PredictionResult[Any]] extends Serializable {
 
   /**

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -126,7 +126,9 @@ case class Bagger(
     val helper = BaggerHelper(models, trainingData, Nib, useJackknife, uncertaintyCalibration)
     val biasModel = if (biasLearner.isDefined && helper.oobErrors.nonEmpty && helper.isRegression) {
       Async.canStop()
-      Some(biasLearner.get.train(helper.biasTraining).getModel().asInstanceOf[Model[PredictionResult[Double]]])
+      Some(
+        biasLearner.get.train(helper.biasTraining, rng = rng).getModel().asInstanceOf[Model[PredictionResult[Double]]]
+      )
     } else None
 
     if (helper.isRegression) {

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -90,7 +90,12 @@ case class MultiTaskBagger(
         val helper = BaggerHelper(thisLabelModels, thisTrainingData, Nib, useJackknife, uncertaintyCalibration)
         val biasModel = if (biasLearner.isDefined && isRegression) {
           Async.canStop()
-          Some(biasLearner.get.train(helper.biasTraining, rng = rng).getModel().asInstanceOf[Model[PredictionResult[Double]]])
+          Some(
+            biasLearner.get
+              .train(helper.biasTraining, rng = rng)
+              .getModel()
+              .asInstanceOf[Model[PredictionResult[Double]]]
+          )
         } else None
         (biasModel, helper.rescaleRatio)
       }

--- a/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.hypers
 
 import io.citrine.lolo.Learner
+import io.citrine.random.Random
 
 /**
   * Brute force search over the grid of hypers
@@ -19,7 +20,8 @@ case class GridHyperOptimizer() extends HyperOptimizer {
   override def optimize(
       trainingData: Seq[(Vector[Any], Any)],
       numIterations: Int = 1,
-      builder: Map[String, Any] => Learner
+      builder: Map[String, Any] => Learner,
+      rng: Random
   ): (Map[String, Any], Double) = {
     var best: Map[String, Any] = Map()
     var loss = Double.MaxValue

--- a/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
@@ -40,9 +40,9 @@ case class GridHyperOptimizer() extends HyperOptimizer {
           j = j / size
       }
 
-      /* Set up a learner with these parameters and compute the loss */
+      // Set up a learner with these parameters and compute the loss
       val testLearner = builder(testHypers)
-      val res = testLearner.train(trainingData)
+      val res = testLearner.train(trainingData, rng = rng)
       if (res.getLoss().isEmpty) {
         throw new IllegalArgumentException("Trying to optimize hyper-paramters for a learner without getLoss")
       }

--- a/src/main/scala/io/citrine/lolo/hypers/HyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/HyperOptimizer.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.hypers
 
 import io.citrine.lolo.Learner
+import io.citrine.random.Random
 
 /**
   * Base class for hyperparameter optimizers
@@ -35,6 +36,7 @@ abstract class HyperOptimizer() {
   def optimize(
       trainingData: Seq[(Vector[Any], Any)],
       numIterations: Int = 8,
-      builder: Map[String, Any] => Learner
+      builder: Map[String, Any] => Learner,
+      rng: Random = Random()
   ): (Map[String, Any], Double)
 }

--- a/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
@@ -38,7 +38,7 @@ class RandomHyperOptimizer() extends HyperOptimizer {
           n -> rng.shuffle(v).head
       }
       val testLearner = builder(testHypers)
-      val res = testLearner.train(trainingData)
+      val res = testLearner.train(trainingData, rng = rng)
       if (res.getLoss().isEmpty) {
         throw new IllegalArgumentException("Trying to optimize hyper-paramters for a learner without getLoss")
       }

--- a/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
@@ -1,8 +1,7 @@
 package io.citrine.lolo.hypers
 
 import io.citrine.lolo.Learner
-
-import scala.util.Random
+import io.citrine.random.Random
 
 /**
   * Search for hypers by randomly sampling the search space
@@ -11,7 +10,7 @@ import scala.util.Random
   * calls.
   * Created by maxhutch on 12/7/16.
   */
-class RandomHyperOptimizer(rng: Random = Random) extends HyperOptimizer {
+class RandomHyperOptimizer() extends HyperOptimizer {
 
   /** Keep track of the best hypers outside of the optimize call so it persists across calls */
   var best: Map[String, Any] = Map()
@@ -29,7 +28,8 @@ class RandomHyperOptimizer(rng: Random = Random) extends HyperOptimizer {
   override def optimize(
       trainingData: Seq[(Vector[Any], Any)],
       numIterations: Int,
-      builder: Map[String, Any] => Learner
+      builder: Map[String, Any] => Learner,
+      rng: Random
   ): (Map[String, Any], Double) = {
     /* Just draw numIteration times */
     (0 until numIterations).foreach { i =>

--- a/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
+++ b/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
@@ -49,7 +49,11 @@ case class ExtraRandomTrees(
     * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
-  override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]], rng: Random): TrainingResult = {
+  override def train(
+      trainingData: Seq[(Vector[Any], Any)],
+      weights: Option[Seq[Double]],
+      rng: Random
+  ): TrainingResult = {
     val repOutput = trainingData.head._2
     val isRegression = repOutput.isInstanceOf[Double]
     val numFeatures: Int = RandomForest.getNumFeatures(subsetStrategy, trainingData.head._1.size, isRegression)

--- a/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
+++ b/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
@@ -1,6 +1,5 @@
 package io.citrine.lolo.learners
 
-import breeze.stats.distributions.RandBasis
 import io.citrine.random.Random
 import io.citrine.lolo.bags.Bagger
 import io.citrine.lolo.transformers.FeatureRotator
@@ -8,7 +7,6 @@ import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import io.citrine.lolo.trees.splits.{ExtraRandomClassificationSplitter, ExtraRandomRegressionSplitter}
 import io.citrine.lolo.{Learner, TrainingResult}
-import org.apache.commons.math3.random.MersenneTwister
 
 /**
   * Extremely randomized tree ensemble
@@ -59,7 +57,7 @@ case class ExtraRandomTrees(
     val numFeatures: Int = RandomForest.getNumFeatures(subsetStrategy, trainingData.head._1.size, isRegression)
 
     repOutput match {
-      case _: Double => {
+      case _: Double =>
         val DTLearner = RegressionTreeLearner(
           leafLearner = leafLearner,
           numFeatures = numFeatures,
@@ -76,8 +74,7 @@ case class ExtraRandomTrees(
           disableBootstrap = disableBootstrap
         )
         bagger.train(trainingData, weights, rng)
-      }
-      case _: Any => {
+      case _: Any =>
         val DTLearner = ClassificationTreeLearner(
           leafLearner = leafLearner,
           numFeatures = numFeatures,
@@ -94,7 +91,6 @@ case class ExtraRandomTrees(
           disableBootstrap = disableBootstrap
         )
         bagger.train(trainingData, weights, rng)
-      }
     }
   }
 }

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -49,7 +49,11 @@ case class RandomForest(
     * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
-  override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]], rng: Random): TrainingResult = {
+  override def train(
+      trainingData: Seq[(Vector[Any], Any)],
+      weights: Option[Seq[Double]],
+      rng: Random
+  ): TrainingResult = {
     val repOutput = trainingData.head._2
     val isRegression = repOutput.isInstanceOf[Double] ||
       (repOutput.isInstanceOf[Seq[Any]] && repOutput.asInstanceOf[Seq[Any]].exists(_.isInstanceOf[Double]))

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -41,8 +41,10 @@ case class RandomForest(
   /**
     * Train a random forest model
     *
-    * If the training labels are Doubles, this is a regression forest; otherwise, a classification forest.
-    * Options like the number of trees are set via setHyper
+    * If the training label is a Double then this is a regression forest.
+    * If the training label is another primtiive then this is a classification forest.
+    * If the training label is a sequence then this is a multitask forest.
+    * Options like the number of trees are set via the constructor.
     *
     * @param trainingData to train on
     * @param weights      for the training rows, if applicable

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -1,26 +1,26 @@
 package io.citrine.lolo.linear
 
+import io.citrine.random.Random
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
-
-import scala.util.Random
 
 /**
   * Created by maxhutch on 11/15/16.
   */
-case class GuessTheMeanLearner(rng: Random = Random) extends Learner {
+case class GuessTheMeanLearner() extends Learner {
 
   /**
     * Train a model
     *
     * @param trainingData to train on
     * @param weights      for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
-  override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]]): TrainingResult = {
+  override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]], rng: Random): TrainingResult = {
     val data = trainingData.map(_._2).zip(weights.getOrElse(Seq.fill(trainingData.size)(1.0)))
     val mean = data.head._1 match {
-      case x: Double => data.asInstanceOf[Seq[(Double, Double)]].map(p => p._1 * p._2).sum / data.map(_._2).sum
-      case x: Any    => rng.shuffle(data.groupBy(_._1).mapValues(_.map(_._2).sum).toSeq).maxBy(_._2)._1
+      case _: Double => data.asInstanceOf[Seq[(Double, Double)]].map(p => p._1 * p._2).sum / data.map(_._2).sum
+      case _: Any    => rng.shuffle(data.groupBy(_._1).mapValues(_.map(_._2).sum).toSeq).maxBy(_._2)._1
     }
 
     new GuessTheMeanTrainingResult(new GuessTheMeanModel(mean))

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -16,7 +16,11 @@ case class GuessTheMeanLearner() extends Learner {
     * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
-  override def train(trainingData: Seq[(Vector[Any], Any)], weights: Option[Seq[Double]], rng: Random): TrainingResult = {
+  override def train(
+      trainingData: Seq[(Vector[Any], Any)],
+      weights: Option[Seq[Double]],
+      rng: Random
+  ): TrainingResult = {
     val data = trainingData.map(_._2).zip(weights.getOrElse(Seq.fill(trainingData.size)(1.0)))
     val mean = data.head._1 match {
       case _: Double => data.asInstanceOf[Seq[(Double, Double)]].map(p => p._1 * p._2).sum / data.map(_._2).sum

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -1,7 +1,8 @@
 package io.citrine.lolo.linear
 
-import breeze.linalg.{diag, sum, DenseMatrix, DenseVector}
+import breeze.linalg.{DenseMatrix, DenseVector, diag, sum}
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
+import io.citrine.random.Random
 import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Success, Try}
@@ -23,11 +24,13 @@ case class LinearRegressionLearner(
     *
     * @param trainingData to train on
     * @param weights      for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return a model
     */
   override def train(
       trainingData: Seq[(Vector[Any], Any)],
-      weights: Option[Seq[Double]]
+      weights: Option[Seq[Double]],
+      rng: Random
   ): LinearRegressionTrainingResult = {
     val lambda = regParam.getOrElse(0.0)
     val regularized = lambda > 0.0

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.linear
 
-import breeze.linalg.{DenseMatrix, DenseVector, diag, sum}
+import breeze.linalg.{diag, sum, DenseMatrix, DenseVector}
 import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult}
 import io.citrine.random.Random
 import org.slf4j.LoggerFactory

--- a/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
+++ b/src/main/scala/io/citrine/lolo/stats/StatsUtils.scala
@@ -1,5 +1,9 @@
 package io.citrine.lolo.stats
 
+import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
+import io.citrine.random.Random
+import org.apache.commons.math3.random.MersenneTwister
+
 object StatsUtils {
 
   /**
@@ -58,4 +62,7 @@ object StatsUtils {
     if (sigma2X == 0 || sigma2Y == 0) return 0.0
     covariance(X, Y, Some(actualWeights)) / math.sqrt(sigma2X * sigma2Y)
   }
+
+  def breezeRandBasis(rng: Random): RandBasis =
+    new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(rng.nextLong())))
 }

--- a/src/main/scala/io/citrine/lolo/stats/functions/Linear.scala
+++ b/src/main/scala/io/citrine/lolo/stats/functions/Linear.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.stats.functions
 
-import scala.util.Random
+import io.citrine.random.Random
 
 /**
   * Linear function, defined by its gradient
@@ -22,7 +22,7 @@ object Linear {
     * @param magnitude of the gradient (default: 1)
     * @return linear function with specified gradient magnitude in a random direction
     */
-  def randomDirection(nDim: Int, magnitude: Double = 1.0, rng: Random = Random): Linear = {
+  def randomDirection(nDim: Int, magnitude: Double = 1.0, rng: Random = Random()): Linear = {
     val gradient = {
       // Draw guassian so the direction is random rather than preferring corners
       val unnormalized = Seq.fill(nDim) { rng.nextGaussian() }

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.transformers
 
 import io.citrine.lolo._
+import io.citrine.random.Random
 import breeze.linalg.{diag, qr, DenseMatrix, DenseVector}
 import breeze.linalg.qr.QR
 import breeze.numerics.signum
@@ -22,11 +23,13 @@ case class FeatureRotator(baseLearner: Learner) extends Learner {
     *
     * @param trainingData to train on
     * @param weights      for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
   override def train(
       trainingData: Seq[(Vector[Any], Any)],
-      weights: Option[Seq[Double]]
+      weights: Option[Seq[Double]],
+      rng: Random
   ): RotatedFeatureTrainingResult = {
     val featuresToRotate = FeatureRotator.getDoubleFeatures(trainingData.head._1)
     val trans = FeatureRotator.getRandomRotation(featuresToRotate.length)
@@ -46,11 +49,13 @@ case class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiT
     *
     * @param trainingData  to train on
     * @param weights for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return a sequence of training results, one for each label
     */
   override def train(
       trainingData: Seq[(Vector[Any], Vector[Any])],
-      weights: Option[Seq[Double]]
+      weights: Option[Seq[Double]],
+      rng: Random
   ): MultiTaskRotatedFeatureTrainingResult = {
     val inputs = trainingData.map(_._1)
     val labels = trainingData.map(_._2)

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -36,7 +36,7 @@ case class FeatureRotator(baseLearner: Learner) extends Learner {
 
     val (inputs, labels) = trainingData.unzip
     val rotatedTrainingData = FeatureRotator.applyRotation(inputs, featuresToRotate, trans).zip(labels)
-    val baseTrainingResult = baseLearner.train(rotatedTrainingData, weights)
+    val baseTrainingResult = baseLearner.train(rotatedTrainingData, weights, rng)
 
     RotatedFeatureTrainingResult(baseTrainingResult, featuresToRotate, trans)
   }
@@ -62,7 +62,7 @@ case class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiT
     val featuresToRotate = FeatureRotator.getDoubleFeatures(inputs.head)
     val trans = FeatureRotator.getRandomRotation(inputs.head.length)
     val rotatedFeatures = FeatureRotator.applyRotation(inputs, featuresToRotate, trans)
-    val baseTrainingResult = baseLearner.train(rotatedFeatures.zip(labels), weights)
+    val baseTrainingResult = baseLearner.train(rotatedFeatures.zip(labels), weights, rng)
     MultiTaskRotatedFeatureTrainingResult(baseTrainingResult, featuresToRotate, trans)
   }
 }

--- a/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/FeatureRotator.scala
@@ -5,8 +5,8 @@ import io.citrine.random.Random
 import breeze.linalg.{diag, qr, DenseMatrix, DenseVector}
 import breeze.linalg.qr.QR
 import breeze.numerics.signum
-import breeze.stats.distributions.{Gaussian, RandBasis, ThreadLocalRandomGenerator}
-import org.apache.commons.math3.random.MersenneTwister
+import breeze.stats.distributions.Gaussian
+import io.citrine.lolo.stats.StatsUtils.breezeRandBasis
 
 /**
   * Rotate the training data before passing along to a base learner
@@ -209,7 +209,7 @@ object FeatureRotator {
     * @return unitary matrix
     */
   def getRandomRotation(dimension: Int, rng: Random = Random()): DenseMatrix[Double] = {
-    val randBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(rng.nextLong())))
+    val randBasis = breezeRandBasis(rng)
     val gaussian = Gaussian(0, 1)(randBasis)
     val X = DenseMatrix.rand(dimension, dimension, gaussian)
     val QR(_Q, _R) = qr(X)

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.transformers
 
 import io.citrine.lolo._
+import io.citrine.random.Random
 
 case class Standardization(shift: Double, scale: Double) {
   require(scale > 0 && scale < Double.PositiveInfinity)
@@ -26,11 +27,13 @@ case class Standardizer(baseLearner: Learner) extends Learner {
     *
     * @param trainingData to train on
     * @param weights      for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return training result containing a model
     */
   override def train(
       trainingData: Seq[(Vector[Any], Any)],
-      weights: Option[Seq[Double]]
+      weights: Option[Seq[Double]],
+      rng: Random
   ): StandardizerTrainingResult = {
     val inputTrans = Standardizer.getMultiStandardization(trainingData.map(_._1))
     val outputTrans = trainingData.head._2 match {
@@ -54,11 +57,13 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
     *
     * @param trainingData  to train on
     * @param weights for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
     * @return a sequence of training results, one for each label
     */
   override def train(
       trainingData: Seq[(Vector[Any], Vector[Any])],
-      weights: Option[Seq[Double]]
+      weights: Option[Seq[Double]],
+      rng: Random
   ): MultiTaskStandardizerTrainingResult = {
     val (inputs, labels) = trainingData.unzip
     val labelsTransposed = labels.transpose.toVector

--- a/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/Standardizer.scala
@@ -44,7 +44,7 @@ case class Standardizer(baseLearner: Learner) extends Learner {
     val (inputs, labels) = trainingData.unzip
     val standardTrainingData =
       Standardizer.applyStandardization(inputs, inputTrans).zip(Standardizer.applyStandardization(labels, outputTrans))
-    val baseTrainingResult = baseLearner.train(standardTrainingData, weights)
+    val baseTrainingResult = baseLearner.train(standardTrainingData, weights, rng)
 
     new StandardizerTrainingResult(baseTrainingResult, outputTrans, inputTrans)
   }
@@ -86,7 +86,7 @@ class MultiTaskStandardizer(baseLearner: MultiTaskLearner) extends MultiTaskLear
       }
       .transpose
 
-    val baseTrainingResult = baseLearner.train(standardInputs.zip(standardLabels), weights)
+    val baseTrainingResult = baseLearner.train(standardInputs.zip(standardLabels), weights, rng)
     new MultiTaskStandardizerTrainingResult(baseTrainingResult, outputTrans, inputTrans)
   }
 }

--- a/src/main/scala/io/citrine/lolo/trees/Nodes.scala
+++ b/src/main/scala/io/citrine/lolo/trees/Nodes.scala
@@ -3,12 +3,12 @@ package io.citrine.lolo.trees
 import breeze.linalg.DenseMatrix
 import io.citrine.lolo.trees.splits.Split
 import io.citrine.lolo.{Learner, Model, PredictionResult}
+import io.citrine.random.Random
 
 import scala.collection.mutable
 
 /**
   * Class to provide getNode interface for internal and leaf training nodes
-  * Created by maxhutch on 11/29/16.
   *
   * @param trainingData   that this node sees
   * @param remainingDepth to stop growing the node
@@ -189,7 +189,8 @@ class InternalModelNode[T <: PredictionResult[Any]](
 class TrainingLeaf[T](
     trainingData: Seq[(Vector[AnyVal], T, Double)],
     leafLearner: Learner,
-    depth: Int
+    depth: Int,
+    rng: Random
 ) extends TrainingNode(
       trainingData = trainingData,
       remainingDepth = 0
@@ -202,7 +203,7 @@ class TrainingLeaf[T](
     */
   def getNode(): ModelNode[PredictionResult[T]] = {
     new ModelLeaf(
-      leafLearner.train(trainingData).getModel().asInstanceOf[Model[PredictionResult[T]]],
+      leafLearner.train(trainingData, rng = rng).getModel().asInstanceOf[Model[PredictionResult[T]]],
       depth,
       trainingData.size.toDouble
     )

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
@@ -5,9 +5,9 @@ import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.trees.regression.RegressionTrainingLeaf
 import io.citrine.lolo.trees.splits.{MultiTaskSplitter, NoSplit}
 import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingLeaf}
+import io.citrine.random.Random
 
 import scala.collection.mutable
-import scala.util.Random
 
 /**
   * Node in a multi-task training tree, which can produce nodes for its model trees.
@@ -26,17 +26,18 @@ class MultiTaskTrainingNode(
     maxDepth: Int,
     minInstances: Int,
     randomizePivotLocation: Boolean = false,
-    rng: Random = Random
+    rng: Random
 ) {
 
   // Compute a split
   val (split, deltaImpurity) = if (maxDepth <= 0) {
     (new NoSplit, 0.0)
   } else {
-    MultiTaskSplitter(rng = rng, randomizePivotLocation = randomizePivotLocation).getBestSplit(
+    MultiTaskSplitter(randomizePivotLocation = randomizePivotLocation).getBestSplit(
       inputs,
       numFeatures,
-      minInstances
+      minInstances,
+      rng
     )
   }
 
@@ -53,7 +54,7 @@ class MultiTaskTrainingNode(
             maxDepth - 1,
             minInstances,
             randomizePivotLocation,
-            rng = rng
+            rng = rng.split()
           )
         ),
         Some(
@@ -63,7 +64,7 @@ class MultiTaskTrainingNode(
             maxDepth - 1,
             minInstances,
             randomizePivotLocation,
-            rng = rng
+            rng = rng.split()
           )
         )
       )
@@ -93,17 +94,20 @@ class MultiTaskTrainingNode(
       case (_, Some(theRightChild)) if right.nonEmpty =>
         theRightChild.getFeatureImportance(index)
       case (_, _) =>
+        // TODO (PLA-10388): get the rng in here somehow (right now it's instantiating a random rng)
         if (label.isInstanceOf[Double]) {
           new RegressionTrainingLeaf(
             reducedData.asInstanceOf[Seq[(Vector[AnyVal], Double, Double)]],
             GuessTheMeanLearner(),
-            1
+            1,
+            rng = Random()
           ).getFeatureImportance()
         } else {
           new TrainingLeaf[Char](
             reducedData.asInstanceOf[Seq[(Vector[AnyVal], Char, Double)]],
             GuessTheMeanLearner(),
-            1
+            1,
+            rng = Random()
           ).getFeatureImportance()
         }
     }
@@ -147,17 +151,20 @@ class MultiTaskTrainingNode(
       case (_, Some(theRightChild)) if right.nonEmpty =>
         theRightChild.getNode(index)
       case (_, _) =>
-        if (label.isInstanceOf[Double]) {
+        // TODO (PLA-10388): get the rng in here somehow (right now it's instantiating a random rng)
+      if (label.isInstanceOf[Double]) {
           new RegressionTrainingLeaf(
             reducedData.asInstanceOf[Seq[(Vector[AnyVal], Double, Double)]],
             GuessTheMeanLearner(),
-            1
+            1,
+            rng = Random()
           ).getNode()
         } else {
           new TrainingLeaf[Char](
             reducedData.asInstanceOf[Seq[(Vector[AnyVal], Char, Double)]],
             GuessTheMeanLearner(),
-            1
+            1,
+            rng = Random()
           ).getNode()
         }
     }

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
@@ -94,7 +94,7 @@ class MultiTaskTrainingNode(
       case (_, Some(theRightChild)) if right.nonEmpty =>
         theRightChild.getFeatureImportance(index)
       case (_, _) =>
-        // TODO (PLA-10388): get the rng in here somehow (right now it's instantiating a random rng)
+        // TODO (PLA-10415): get the rng in here somehow (right now it's instantiating a random rng)
         if (label.isInstanceOf[Double]) {
           new RegressionTrainingLeaf(
             reducedData.asInstanceOf[Seq[(Vector[AnyVal], Double, Double)]],
@@ -151,7 +151,7 @@ class MultiTaskTrainingNode(
       case (_, Some(theRightChild)) if right.nonEmpty =>
         theRightChild.getNode(index)
       case (_, _) =>
-        // TODO (PLA-10388): get the rng in here somehow (right now it's instantiating a random rng)
+        // TODO (PLA-10415): get the rng in here somehow (right now it's instantiating a random rng)
         if (label.isInstanceOf[Double]) {
           new RegressionTrainingLeaf(
             reducedData.asInstanceOf[Seq[(Vector[AnyVal], Double, Double)]],

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
@@ -152,7 +152,7 @@ class MultiTaskTrainingNode(
         theRightChild.getNode(index)
       case (_, _) =>
         // TODO (PLA-10388): get the rng in here somehow (right now it's instantiating a random rng)
-      if (label.isInstanceOf[Double]) {
+        if (label.isInstanceOf[Double]) {
           new RegressionTrainingLeaf(
             reducedData.asInstanceOf[Seq[(Vector[AnyVal], Double, Double)]],
             GuessTheMeanLearner(),

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -1,12 +1,11 @@
 package io.citrine.lolo.trees.multitask
 
+import io.citrine.random.Random
 import io.citrine.lolo.encoders.CategoricalEncoder
 import io.citrine.lolo.trees.ModelNode
 import io.citrine.lolo.trees.classification.ClassificationTree
 import io.citrine.lolo.trees.regression.RegressionTree
 import io.citrine.lolo.{Model, MultiTaskLearner, MultiTaskTrainingResult, ParallelModels, PredictionResult}
-
-import scala.util.Random
 
 /**
   * A tree learner that operates on multiple labels.
@@ -15,26 +14,26 @@ import scala.util.Random
   * @param maxDepth to grow the tree to
   * @param minLeafInstances minimum number of training instances per leaf
   * @param randomizePivotLocation whether to generate splits randomly between the data points
-  * @param rng random number generator, for reproducibility
   */
 case class MultiTaskTreeLearner(
     numFeatures: Int = -1,
     maxDepth: Int = 30,
     minLeafInstances: Int = 1,
-    randomizePivotLocation: Boolean = false,
-    rng: Random = Random
+    randomizePivotLocation: Boolean = false
 ) extends MultiTaskLearner {
 
   /**
     * Construct one regression or classification tree for each label.
     *
-    * @param trainingData   to train on
-    * @param weights  for the training rows, if applicable
-    * @return         sequence of models, one for each label
+    * @param trainingData to train on
+    * @param weights      for the training rows, if applicable
+    * @param rng          random number generator for reproducibility
+    * @return             sequence of models, one for each label
     */
   override def train(
       trainingData: Seq[(Vector[Any], Vector[Any])],
-      weights: Option[Seq[Double]]
+      weights: Option[Seq[Double]],
+      rng: Random
   ): MultiTaskTreeTrainingResult = {
     val (inputs, labels) = trainingData.unzip
     val repInput = inputs.head

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
@@ -2,17 +2,18 @@ package io.citrine.lolo.trees.regression
 
 import io.citrine.lolo.trees.{ModelLeaf, ModelNode, TrainingNode}
 import io.citrine.lolo.{Learner, Model, PredictionResult}
+import io.citrine.random.Random
 
 import scala.collection.mutable
 
 /**
   * Training leaf node for regression trees
-  * Created by maxhutch on 3/8/17.
   */
 class RegressionTrainingLeaf(
     trainingData: Seq[(Vector[AnyVal], Double, Double)],
     leafLearner: Learner,
-    depth: Int
+    depth: Int,
+    rng: Random
 ) extends TrainingNode(trainingData, depth) {
 
   /**
@@ -48,7 +49,7 @@ class RegressionTrainingLeaf(
   }
 
   /** Train the leaf learner on the training data */
-  val leafTrainingResult = leafLearner.train(trainingData)
+  val leafTrainingResult = leafLearner.train(trainingData, rng = rng)
 
   /** Pull out the model for future use */
   val model = leafTrainingResult.getModel().asInstanceOf[Model[PredictionResult[Double]]]

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
@@ -22,7 +22,7 @@ class RegressionTrainingLeaf(
     * @return lightweight prediction node
     */
   def getNode(): ModelNode[PredictionResult[Double]] = {
-    new ModelLeaf(model.asInstanceOf[Model[PredictionResult[Double]]], depth, trainingData.size.toDouble)
+    new ModelLeaf(model, depth, trainingData.size.toDouble)
   }
 
   /**

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
@@ -127,7 +127,7 @@ object RegressionTrainingNode {
         _._2 != trainingData.head._2
       )
     ) {
-      val (leftSplit, leftDelta) = splitter.getBestSplit(trainingData, numFeatures, minLeafInstances)
+      val (leftSplit, leftDelta) = splitter.getBestSplit(trainingData, numFeatures, minLeafInstances, rng = rng)
       if (!leftSplit.isInstanceOf[NoSplit]) {
         new RegressionTrainingNode(
           trainingData,

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
@@ -24,7 +24,7 @@ class RegressionTrainingNode(
       remainingDepth = remainingDepth
     ) {
 
-  // TODO (PLA-10388): see if there's a way to get the rng for this (and the other nodes) out of the constructor
+  // TODO (PLA-10415): see if there's a way to get the rng for this (and the other nodes) out of the constructor
   // val (split: Split, deltaImpurity: Double) = RegressionSplitter.getBestSplit(trainingData, numFeatures)
   assert(trainingData.size > 1, "If we are going to split, we need at least 2 training rows")
   assert(

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
@@ -3,6 +3,7 @@ package io.citrine.lolo.trees.regression
 import io.citrine.lolo.trees.splits.{NoSplit, Split, Splitter}
 import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingNode}
 import io.citrine.lolo.{Learner, PredictionResult}
+import io.citrine.random.Random
 
 /**
   * Created by maxhutch on 1/12/17.
@@ -16,18 +17,22 @@ class RegressionTrainingNode(
     numFeatures: Int,
     minLeafInstances: Int,
     remainingDepth: Int,
-    maxDepth: Int
+    maxDepth: Int,
+    rng: Random
 ) extends TrainingNode(
       trainingData = trainingData,
       remainingDepth = remainingDepth
     ) {
 
+  // TODO (PLA-10388): see if there's a way to get the rng for this (and the other nodes) out of the constructor
   // val (split: Split, deltaImpurity: Double) = RegressionSplitter.getBestSplit(trainingData, numFeatures)
   assert(trainingData.size > 1, "If we are going to split, we need at least 2 training rows")
   assert(
     !split.isInstanceOf[NoSplit],
     s"Empty split split for training data: \n${trainingData.map(_.toString() + "\n")}"
   )
+  private val leftRng = rng.split()
+  private val rightRng = rng.split()
 
   lazy val (leftTrain, rightTrain) = trainingData.partition(r => split.turnLeft(r._1))
   assert(
@@ -42,7 +47,8 @@ class RegressionTrainingNode(
     minLeafInstances,
     remainingDepth,
     maxDepth,
-    numFeatures
+    numFeatures,
+    leftRng
   )
   lazy val rightChild = RegressionTrainingNode.buildChild(
     rightTrain,
@@ -51,7 +57,8 @@ class RegressionTrainingNode(
     minLeafInstances,
     remainingDepth,
     maxDepth,
-    numFeatures
+    numFeatures,
+    rightRng
   )
 
   /**
@@ -102,6 +109,7 @@ object RegressionTrainingNode {
     * @param remainingDepth   the number of splits left
     * @param maxDepth         to compute depth via remainingDepth
     * @param numFeatures      to consider in the split
+    * @param rng              random number generator for reproducibility
     * @return the child node, either a RegressionTrainingNode or TrainingLeaf
     */
   def buildChild(
@@ -111,7 +119,8 @@ object RegressionTrainingNode {
       minLeafInstances: Int,
       remainingDepth: Int,
       maxDepth: Int,
-      numFeatures: Int
+      numFeatures: Int,
+      rng: Random
   ): TrainingNode[AnyVal, Double] = {
     if (
       trainingData.size >= 2 * minLeafInstances && remainingDepth > 0 && trainingData.exists(
@@ -129,13 +138,14 @@ object RegressionTrainingNode {
           numFeatures,
           minLeafInstances,
           remainingDepth - 1,
-          maxDepth
+          maxDepth,
+          rng
         )
       } else {
-        new RegressionTrainingLeaf(trainingData, leafLearner, maxDepth - remainingDepth)
+        new RegressionTrainingLeaf(trainingData, leafLearner, maxDepth - remainingDepth, rng)
       }
     } else {
-      new RegressionTrainingLeaf(trainingData, leafLearner, maxDepth - remainingDepth)
+      new RegressionTrainingLeaf(trainingData, leafLearner, maxDepth - remainingDepth, rng)
     }
   }
 }

--- a/src/main/scala/io/citrine/lolo/trees/splits/BoltzmannSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/BoltzmannSplitter.scala
@@ -1,10 +1,10 @@
 package io.citrine.lolo.trees.splits
 
+import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.VarianceCalculator
 import io.citrine.lolo.trees.splits.BoltzmannSplitter.SplitterResult
 
 import scala.collection.mutable
-import scala.util.Random
 
 /**
   * Find a split for a regression problem
@@ -30,7 +30,7 @@ import scala.util.Random
   * @param temperature used to control how sensitive the probability of a split is to its change in variance.
   *                    The temperature can be thought of as a hyperparameter.
   */
-case class BoltzmannSplitter(temperature: Double, rng: Random = Random) extends Splitter[Double] {
+case class BoltzmannSplitter(temperature: Double) extends Splitter[Double] {
   require(
     temperature >= Float.MinPositiveValue,
     s"Temperature must be >= ${Float.MinPositiveValue} to avoid numerical underflows"
@@ -43,12 +43,14 @@ case class BoltzmannSplitter(temperature: Double, rng: Random = Random) extends 
     * @param data         to split
     * @param numFeatures  to consider, randomly
     * @param minInstances minimum instances permitted in a post-split partition
+    * @param rng          random number generator for reproducibility
     * @return a split object that optimally divides data
     */
   def getBestSplit(
       data: Seq[(Vector[AnyVal], Double, Double)],
       numFeatures: Int,
-      minInstances: Int
+      minInstances: Int,
+      rng: Random
   ): (Split, Double) = {
     /* Pre-compute these for the variance calculation */
     val calculator = VarianceCalculator.build(data.map(_._2), data.map(_._3))

--- a/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
@@ -1,28 +1,30 @@
 package io.citrine.lolo.trees.splits
 
+import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.GiniCalculator
-
-import scala.util.Random
 
 /**
   * Find the best split for classification problems.
   *
   * Created by maxhutch on 12/2/16.
   */
-case class ClassificationSplitter(randomizedPivotLocation: Boolean = false, rng: Random = Random)
+case class ClassificationSplitter(randomizedPivotLocation: Boolean = false)
     extends Splitter[Char] {
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)
     *
-    * @param data        to split
-    * @param numFeatures to consider, randomly
+    * @param data         to split
+    * @param numFeatures  to consider, randomly
+    * @param minInstances minimum instances permitted in a post-split partition
+    * @param rng          random number generator for reproducibility
     * @return a split object that optimally divides data
     */
   def getBestSplit(
       data: Seq[(Vector[AnyVal], Char, Double)],
       numFeatures: Int,
-      minInstances: Int
+      minInstances: Int,
+      rng: Random
   ): (Split, Double) = {
     var bestSplit: Split = new NoSplit()
     var bestImpurity = Double.MaxValue

--- a/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
@@ -8,8 +8,7 @@ import io.citrine.lolo.trees.impurity.GiniCalculator
   *
   * Created by maxhutch on 12/2/16.
   */
-case class ClassificationSplitter(randomizedPivotLocation: Boolean = false)
-    extends Splitter[Char] {
+case class ClassificationSplitter(randomizedPivotLocation: Boolean = false) extends Splitter[Char] {
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)

--- a/src/main/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitter.scala
@@ -1,32 +1,30 @@
 package io.citrine.lolo.trees.splits
 
+import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.{ImpurityCalculator, VarianceCalculator}
-
-import scala.util.Random
 
 /**
   * A splitter that defines Extremely Randomized Trees
   *
   * This is based on Geurts, P., Ernst, D. & Wehenkel, L. Extremely randomized trees. Mach Learn 63, 3–42 (2006).
   * https://doi.org/10.1007/s10994-006-6226-1.
-  *
-  * @param rng random number generator
   */
-case class ExtraRandomRegressionSplitter(
-    rng: Random = Random
-) extends Splitter[Double] {
+case class ExtraRandomRegressionSplitter() extends Splitter[Double] {
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)
     *
     * @param data        to split
     * @param numFeatures to consider, randomly
+    * @param minInstances minimum instances permitted in a post-split partition
+    * @param rng          random number generator for reproducibility
     * @return a split object that optimally divides data
     */
   def getBestSplit(
       data: Seq[(Vector[AnyVal], Double, Double)],
       numFeatures: Int,
-      minInstances: Int
+      minInstances: Int,
+      rng: Random
   ): (Split, Double) = {
 
     val calculator = VarianceCalculator.build(data.map(_._2), data.map(_._3))
@@ -41,8 +39,8 @@ case class ExtraRandomRegressionSplitter(
     rng.shuffle(featureIndices.toVector).take(numFeatures).foreach { index =>
       /* Use different spliters for each type */
       val (possibleSplit, possibleVariance) = rep._1(index) match {
-        case _: Double => getBestRealSplit(data, calculator.copy(), index, minInstances)
-        case _: Char   => getBestCategoricalSplit(data, calculator.copy(), index, minInstances)
+        case _: Double => getBestRealSplit(data, calculator.copy(), index, minInstances, rng)
+        case _: Char   => getBestCategoricalSplit(data, calculator.copy(), index, minInstances, rng)
         case _: Any    => throw new IllegalArgumentException("Trying to split unknown feature type")
       }
 
@@ -66,13 +64,15 @@ case class ExtraRandomRegressionSplitter(
     * @param data  to split
     * @param index of the feature to split on
     * @param minCount minimum number of data points to allow in each of the resulting splits
+    * @param rng      random number generator, for reproducibility
     * @return the best split of this feature
     */
   def getBestRealSplit(
       data: Seq[(Vector[AnyVal], Double, Double)],
       calculator: ImpurityCalculator[Double],
       index: Int,
-      minCount: Int
+      minCount: Int,
+      rng: Random
   ): (RealSplit, Double) = {
     /* Pull out the feature that's considered here and sort by it */
     val axis: Seq[Double] = data.map(_._1(index).asInstanceOf[Double])
@@ -98,13 +98,16 @@ case class ExtraRandomRegressionSplitter(
     *
     * @param data  to split
     * @param index of the feature to split on
+    * @param minCount minimum number of data points to allow in each of the resulting splits
+    * @param rng      random number generator, for reproducibility
     * @return the best split of this feature
     */
   def getBestCategoricalSplit(
       data: Seq[(Vector[AnyVal], Double, Double)],
       calculator: ImpurityCalculator[Double],
       index: Int,
-      minCount: Int
+      minCount: Int,
+      rng: Random
   ): (Split, Double) = {
     /* Extract the features at the index */
     val thinData = data.map(dat => (dat._1(index).asInstanceOf[Char], dat._2, dat._3))

--- a/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
@@ -1,13 +1,9 @@
 package io.citrine.lolo.trees.splits
 
+import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.MultiImpurityCalculator
 
-import scala.util.Random
-
-/**
-  * Created by maxhutch on 11/29/16.
-  */
-case class MultiTaskSplitter(randomizePivotLocation: Boolean = false, rng: Random = Random)
+case class MultiTaskSplitter(randomizePivotLocation: Boolean = false)
     extends Splitter[Array[AnyVal]] {
 
   /**
@@ -15,13 +11,15 @@ case class MultiTaskSplitter(randomizePivotLocation: Boolean = false, rng: Rando
     *
     * @param data        to split
     * @param numFeatures to consider, randomly
-    * @param minInstances the minimum number of data points on a split node
+    * @param minInstances minimum instances permitted in a post-split partition
+    * @param rng          random number generator for reproducibility
     * @return a split object that optimally divides data
     */
   def getBestSplit(
       data: Seq[(Vector[AnyVal], Array[AnyVal], Double)],
       numFeatures: Int,
-      minInstances: Int
+      minInstances: Int,
+      rng: Random
   ): (Split, Double) = {
     var bestSplit: Split = new NoSplit()
     var bestImpurity = Double.MaxValue

--- a/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
@@ -3,8 +3,7 @@ package io.citrine.lolo.trees.splits
 import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.MultiImpurityCalculator
 
-case class MultiTaskSplitter(randomizePivotLocation: Boolean = false)
-    extends Splitter[Array[AnyVal]] {
+case class MultiTaskSplitter(randomizePivotLocation: Boolean = false) extends Splitter[Array[AnyVal]] {
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)

--- a/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
@@ -1,9 +1,9 @@
 package io.citrine.lolo.trees.splits
 
 import io.citrine.lolo.trees.impurity.VarianceCalculator
+import io.citrine.random.Random
 
 import scala.collection.immutable.BitSet
-import scala.util.Random
 
 /**
   * Find the best split for regression problems.
@@ -20,19 +20,22 @@ import scala.util.Random
   *
   * Created by maxhutch on 11/29/16.
   */
-case class RegressionSplitter(randomizePivotLocation: Boolean = false, rng: Random = Random) extends Splitter[Double] {
+case class RegressionSplitter(randomizePivotLocation: Boolean = false) extends Splitter[Double] {
 
   /**
     * Get the best split, considering numFeature random features (w/o replacement)
     *
     * @param data        to split
     * @param numFeatures to consider, randomly
+    * @param minInstances minimum instances permitted in a post-split partition
+    * @param rng          random number generator for reproducibility
     * @return a split object that optimally divides data
     */
   def getBestSplit(
       data: Seq[(Vector[AnyVal], Double, Double)],
       numFeatures: Int,
-      minInstances: Int
+      minInstances: Int,
+      rng: Random
   ): (Split, Double) = {
 
     val calculator = VarianceCalculator.build(data.map(_._2), data.map(_._3))

--- a/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
@@ -48,7 +48,7 @@ case class RegressionSplitter(randomizePivotLocation: Boolean = false) extends S
     /* Try every feature index */
     val featureIndices: Seq[Int] = rep._1.indices
     rng.shuffle(featureIndices).take(numFeatures).foreach { index =>
-      /* Use different spliters for each type */
+      /* Use different splitters for each type */
       val (possibleSplit, possibleVariance) = rep._1(index) match {
         case _: Double =>
           Splitter.getBestRealSplit[Double](data, calculator.copy(), index, minInstances, randomizePivotLocation, rng)

--- a/src/main/scala/io/citrine/lolo/trees/splits/Splitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/Splitter.scala
@@ -3,9 +3,13 @@ package io.citrine.lolo.trees.splits
 import io.citrine.lolo.trees.impurity.ImpurityCalculator
 import io.citrine.random.Random
 
-
 trait Splitter[T] {
-  def getBestSplit(data: Seq[(Vector[AnyVal], T, Double)], numFeatures: Int, minInstances: Int, rng: Random = Random()): (Split, Double)
+  def getBestSplit(
+      data: Seq[(Vector[AnyVal], T, Double)],
+      numFeatures: Int,
+      minInstances: Int,
+      rng: Random = Random()
+  ): (Split, Double)
 }
 
 object Splitter {

--- a/src/main/scala/io/citrine/lolo/trees/splits/Splitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/Splitter.scala
@@ -1,14 +1,11 @@
 package io.citrine.lolo.trees.splits
 
 import io.citrine.lolo.trees.impurity.ImpurityCalculator
+import io.citrine.random.Random
 
-import scala.util.Random
 
-/**
-  * Created by maxhutch on 7/5/17.
-  */
 trait Splitter[T] {
-  def getBestSplit(data: Seq[(Vector[AnyVal], T, Double)], numFeatures: Int, minInstances: Int): (Split, Double)
+  def getBestSplit(data: Seq[(Vector[AnyVal], T, Double)], numFeatures: Int, minInstances: Int, rng: Random = Random()): (Split, Double)
 }
 
 object Splitter {
@@ -32,6 +29,7 @@ object Splitter {
     * @param minCount minimum number of data points to allow in each of the resulting splits
     * @param randomizePivotLocation whether generate splits by drawing a random value uniformly between the two split points.
     *                               This can improve generalizability, particularly as part of an ensemble.
+    * @param rng  random number generator for reproducibility
     * @return the best split of this feature
     */
   def getBestRealSplit[T](
@@ -40,7 +38,7 @@ object Splitter {
       index: Int,
       minCount: Int,
       randomizePivotLocation: Boolean = false,
-      rng: Random = Random
+      rng: Random = Random()
   ): (Split, Double) = {
     /* Pull out the feature that's considered here and sort by it */
     val thinData = data.map(dat => (dat._1(index).asInstanceOf[Double], dat._2, dat._3)).sortBy(_._1)

--- a/src/main/scala/io/citrine/lolo/util/Async.scala
+++ b/src/main/scala/io/citrine/lolo/util/Async.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo.util
 
+// TODO (PLA-10416): Remove Async
 /**
   * Object containing utility functions for supporting interrupts
   * Created by maxhutch on 4/20/17.

--- a/src/main/scala/io/citrine/lolo/util/LoloPyRandom.scala
+++ b/src/main/scala/io/citrine/lolo/util/LoloPyRandom.scala
@@ -1,0 +1,12 @@
+package io.citrine.lolo.util
+
+import io.citrine.random.Random
+
+/** Tool used to generate Random() instances in LoloPy. */
+object LoloPyRandom {
+
+  def getRng(seed: Int): Random = Random(seed)
+
+  def getRng(): Random = Random()
+
+}

--- a/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
@@ -1,8 +1,7 @@
 package io.citrine.lolo.validation
 
+import io.citrine.random.Random
 import io.citrine.lolo.{Learner, PredictionResult}
-
-import scala.util.Random
 
 /**
   * Methods tha use cross-validation to calculate predicted-vs-actual data and metric estimates
@@ -27,7 +26,7 @@ case object CrossValidation {
       metrics: Map[String, Merit[T]],
       k: Int = 8,
       nTrial: Int = 1,
-      rng: Random = Random
+      rng: Random = Random()
   ): Map[String, (Double, Double)] = {
     Merit.estimateMerits(
       kFoldPvA(trainingData, learner, k, nTrial, rng).iterator,
@@ -51,7 +50,7 @@ case object CrossValidation {
       learner: Learner,
       k: Int = 8,
       nTrial: Int = 1,
-      rng: Random = Random
+      rng: Random = Random()
   ): Iterable[(PredictionResult[T], Seq[T])] = {
     val nTest: Int = Math.ceil(trainingData.size.toDouble / k).toInt
     (0 until nTrial).flatMap { _ =>
@@ -61,7 +60,7 @@ case object CrossValidation {
         val (testFolds, trainFolds) = folds.zipWithIndex.partition(_._2 == idx)
         val testData = testFolds.flatMap(_._1)
         val trainData = trainFolds.flatMap(_._1)
-        val model = learner.train(trainData).getModel()
+        val model = learner.train(trainData, rng = rng).getModel()
         val predictions: PredictionResult[T] = model.transform(testData.map(_._1)).asInstanceOf[PredictionResult[T]]
         (predictions, testData.map(_._2))
       }

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -3,10 +3,10 @@ package io.citrine.lolo.validation
 import java.util
 
 import io.citrine.lolo.PredictionResult
+import io.citrine.random.Random
 import org.knowm.xchart.XYChart
 
 import scala.collection.JavaConverters._
-import scala.util.Random
 
 /**
   * Real-valued figure of merit on predictions of type T
@@ -18,7 +18,7 @@ trait Merit[T] {
     *
     * @return the value of the figure of merit
     */
-  def evaluate(predictionResult: PredictionResult[T], actual: Seq[T], rng: Random = Random): Double
+  def evaluate(predictionResult: PredictionResult[T], actual: Seq[T], rng: Random = Random()): Double
 
   /**
     * Estimate the merit and the uncertainty in the merit over batches of predicted and ground-truth values
@@ -26,7 +26,7 @@ trait Merit[T] {
     * @param pva predicted-vs-actual data as an iterable over [[PredictionResult]] and ground-truth tuples
     * @return the estimate of the merit value and the uncertainty in that estimate
     */
-  def estimate(pva: Iterable[(PredictionResult[T], Seq[T])], rng: Random = Random): (Double, Double) = {
+  def estimate(pva: Iterable[(PredictionResult[T], Seq[T])], rng: Random = Random()): (Double, Double) = {
     val samples = pva.map { case (prediction, actual) => evaluate(prediction, actual, rng) }
     val mean: Double = samples.sum / samples.size
     val variance: Double =
@@ -42,7 +42,7 @@ case object RootMeanSquareError extends Merit[Double] {
   override def evaluate(
       predictionResult: PredictionResult[Double],
       actual: Seq[Double],
-      rng: Random = Random
+      rng: Random = Random()
   ): Double = {
     Math.sqrt(
       (predictionResult.getExpected(), actual).zipped.map {
@@ -59,7 +59,7 @@ case object CoefficientOfDetermination extends Merit[Double] {
   override def evaluate(
       predictionResult: PredictionResult[Double],
       actual: Seq[Double],
-      rng: Random = Random
+      rng: Random = Random()
   ): Double = {
     val averageActual = actual.sum / actual.size
     val sumOfSquares = actual.map(x => Math.pow(x - averageActual, 2)).sum
@@ -75,7 +75,7 @@ case object StandardConfidence extends Merit[Double] {
   override def evaluate(
       predictionResult: PredictionResult[Double],
       actual: Seq[Double],
-      rng: Random = Random
+      rng: Random = Random()
   ): Double = {
     if (predictionResult.getUncertainty().isEmpty) return 0.0
 
@@ -92,7 +92,7 @@ case class StandardError(rescale: Double = 1.0) extends Merit[Double] {
   override def evaluate(
       predictionResult: PredictionResult[Double],
       actual: Seq[Double],
-      rng: Random = Random
+      rng: Random = Random()
   ): Double = {
     if (predictionResult.getUncertainty().isEmpty) return Double.PositiveInfinity
     val standardized = (predictionResult.getExpected(), predictionResult.getUncertainty().get, actual).zipped.map {
@@ -117,7 +117,7 @@ case object UncertaintyCorrelation extends Merit[Double] {
   override def evaluate(
       predictionResult: PredictionResult[Double],
       actual: Seq[Double],
-      rng: Random = Random
+      rng: Random = Random()
   ): Double = {
     val predictedUncertaintyActual: Seq[(Double, Double, Double)] = (
       predictionResult.getExpected(),
@@ -168,7 +168,7 @@ object Merit {
   def estimateMerits[T](
       pva: Iterator[(PredictionResult[T], Seq[T])],
       merits: Map[String, Merit[T]],
-      rng: Random = Random
+      rng: Random = Random()
   ): Map[String, (Double, Double)] = {
 
     pva
@@ -206,7 +206,7 @@ object Merit {
       logScale: Boolean = false,
       yMin: Option[Double] = None,
       yMax: Option[Double] = None,
-      rng: Random = Random
+      rng: Random = Random()
   )(
       pvaBuilder: Double => Iterator[(PredictionResult[T], Seq[T])]
   ): XYChart = {

--- a/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
@@ -1,13 +1,12 @@
 package io.citrine.lolo.validation
 
 import io.citrine.lolo.{Learner, PredictionResult}
-
-import scala.util.Random
+import io.citrine.random.Random
 
 /**
   * Methods that draw data from a distribution and compute predicted-vs-actual data
   */
-case class StatisticalValidation(rng: Random = Random) {
+case class StatisticalValidation(rng: Random = Random()) {
 
   /**
     * Generate predicted-vs-actual data given a source of ground truth data and a learner

--- a/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
@@ -6,7 +6,7 @@ import io.citrine.random.Random
 /**
   * Methods that draw data from a distribution and compute predicted-vs-actual data
   */
-case class StatisticalValidation(rng: Random = Random()) {
+case class StatisticalValidation() {
 
   /**
     * Generate predicted-vs-actual data given a source of ground truth data and a learner
@@ -23,6 +23,7 @@ case class StatisticalValidation(rng: Random = Random()) {
     * @param nTrain  size of each training set
     * @param nTest   size of each test set
     * @param nRound  number of train/test sets to draw and evaluate
+    * @param rng     random number generator for reproducibility
     * @tparam T type of the model
     * @return predicted-vs-actual data that can be fed into a metric or visualization
     */
@@ -31,11 +32,12 @@ case class StatisticalValidation(rng: Random = Random()) {
       learner: Learner,
       nTrain: Int,
       nTest: Int,
-      nRound: Int
+      nRound: Int,
+      rng: Random
   ): Iterator[(PredictionResult[T], Seq[T])] = {
     Iterator.tabulate(nRound) { _ =>
       val trainingData: Seq[(Vector[Any], T)] = source.take(nTrain).toSeq
-      val model = learner.train(trainingData).getModel()
+      val model = learner.train(trainingData, rng = rng).getModel()
       val testData: Seq[(Vector[Any], T)] = source.take(nTest).toSeq
       val predictions: PredictionResult[T] = model.transform(testData.map(_._1)).asInstanceOf[PredictionResult[T]]
       (predictions, testData.map(_._2))
@@ -57,6 +59,7 @@ case class StatisticalValidation(rng: Random = Random()) {
     * @param nTrain  size of each training set
     * @param nTest   size of each test set
     * @param nRound  number of train/test sets to draw and evaluate
+    * @param rng     random number generator for reproducibility
     * @tparam T type of the model
     * @return predicted-vs-actual data that can be fed into a metric or visualization
     */
@@ -65,12 +68,13 @@ case class StatisticalValidation(rng: Random = Random()) {
       learner: Learner,
       nTrain: Int,
       nTest: Int,
-      nRound: Int
+      nRound: Int,
+      rng: Random
   ): Iterator[(PredictionResult[T], Seq[T])] = {
     Iterator.tabulate(nRound) { _ =>
       val subset = rng.shuffle(source).take(nTrain + nTest)
       val (trainingData: Seq[(Vector[Any], T)], testData: Seq[(Vector[Any], T)]) = subset.splitAt(nTrain)
-      val model = learner.train(trainingData).getModel()
+      val model = learner.train(trainingData, rng = rng).getModel()
       val predictions: PredictionResult[T] = model.transform(testData.map(_._1)).asInstanceOf[PredictionResult[T]]
       (predictions, testData.map(_._2))
     }

--- a/src/test/scala/io/citrine/lolo/AccuracyTest.scala
+++ b/src/test/scala/io/citrine/lolo/AccuracyTest.scala
@@ -29,58 +29,6 @@ class AccuracyTest extends SeedRandomMixIn {
     learner.train(trainingData, rng = rng).getLoss().get
   }
 
-  // TODO (PLA-10388): enable this test
-  // TODO (PLA-10388): make reproducibility tests for classification and multitask forests
-  /**
-    * Test that setting rng yields repeatable results.
-    */
-  /**
-    * DISABLED until implementing perfect reproducibility.
-    *  @Test
-    *  def testRepeatable(): Unit = {
-    *    val (errorsStandardTree, errorsAnnealingTree, errorsUnrandomizedTree) = (1 to 4).map { _ =>
-    *      val seed = 354128L
-    *      val rng = new Random(seed)
-    *      val errorStandardTree = {
-    *        val baseLearner = RegressionTreeLearner(
-    *          numFeatures = nFeat,
-    *          splitter = RegressionSplitter(randomizePivotLocation = true, rng = rng),
-    *          rng = rng
-    *        )
-    *        val learner = new Bagger(baseLearner, numBags = nRow * 8, randBasis = TestUtils.getBreezeRandBasis(rng))
-    *        computeMetrics(learner)
-    *      }
-    *      rng.setSeed(seed)
-    *      val errorAnnealingTree = {
-    *        val baseLearner = RegressionTreeLearner(
-    *          numFeatures = nFeat,
-    *          splitter = BoltzmannSplitter(temperature = Float.MinPositiveValue, rng = rng),
-    *          rng = rng
-    *        )
-    *        val learner = new Bagger(baseLearner, numBags = nRow * 8, randBasis = TestUtils.getBreezeRandBasis(rng))
-    *        computeMetrics(learner)
-    *      }
-    *      rng.setSeed(seed)
-    *      val randBasis = TestUtils.getBreezeRandBasis(rng)
-    *      val errorUnrandomizedTree = {
-    *        val baseLearner = RegressionTreeLearner(
-    *          numFeatures = nFeat,
-    *          splitter = RegressionSplitter(randomizePivotLocation = false, rng = rng),
-    *          rng = rng
-    *        )
-    *        val learner = new Bagger(baseLearner, numBags = nRow * 8, randBasis = randBasis)
-    *        computeMetrics(learner)
-    *      }
-    *      (errorStandardTree, errorAnnealingTree, errorUnrandomizedTree)
-    *    }.unzip3
-    *
-    *    val atol = 1e-12
-    *    assert(errorsStandardTree.forall{ e => Math.abs(e - errorsStandardTree.head) < atol })
-    *    assert(errorsAnnealingTree.forall{ e => Math.abs(e - errorsStandardTree.head) < atol })
-    *    assert(errorsUnrandomizedTree.forall{ e => Math.abs(e - errorsUnrandomizedTree.head) < atol })
-    *  }
-    */
-
   /**
     * Quick sanity check of the test setup
     */

--- a/src/test/scala/io/citrine/lolo/TestUtils.scala
+++ b/src/test/scala/io/citrine/lolo/TestUtils.scala
@@ -132,8 +132,6 @@ object TestUtils {
     }
   }
 
-  def getBreezeRandBasis(rng: Random = Random()): RandBasis =
-    new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(rng.nextLong())))
 }
 
 /**
@@ -142,9 +140,6 @@ object TestUtils {
 trait SeedRandomMixIn {
   // Reset random number generator.
   var rng: Random = Random(2348752L)
-
-  // Set global RNG also, as a hack to partially coerce internals to be more deterministic.
-  scala.util.Random.setSeed(rng.nextLong())
 
   @Before
   def initializeRandom(): Unit = {

--- a/src/test/scala/io/citrine/lolo/TestUtils.scala
+++ b/src/test/scala/io/citrine/lolo/TestUtils.scala
@@ -4,10 +4,11 @@ import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import io.citrine.lolo.linear.LinearRegressionLearner
 import io.citrine.lolo.stats.StatsUtils.variance
 import io.citrine.lolo.stats.functions.Friedman
+import io.citrine.random.Random
 import org.apache.commons.math3.random.MersenneTwister
 import org.junit.Before
 
-import scala.util.{Random, Try}
+import scala.util.Try
 
 /**
   * Created by maxhutch on 11/28/16.
@@ -47,7 +48,7 @@ object TestUtils {
       xscale: Double = 1.0,
       xoff: Double = 0.0,
       noise: Double = 0.0,
-      rng: Random = new Random()
+      rng: Random = Random()
   ): Vector[(Vector[Double], Double)] = {
     Vector.fill(rows) {
       val input = Vector.fill(cols)(xscale * rng.nextDouble() + xoff)
@@ -65,7 +66,7 @@ object TestUtils {
     * @param rng  random number generator
     * @return     sequence of values that have desired correlation with X
     */
-  def makeLinearCorrelatedData(X: Seq[Double], rho: Double, rng: Random = new Random()): Seq[Double] = {
+  def makeLinearCorrelatedData(X: Seq[Double], rho: Double, rng: Random = Random()): Seq[Double] = {
     require(rho >= -1.0 && rho <= 1.0, "correlation coefficient must be between -1.0 and 1.0")
     val Y = Seq.fill(X.length)(rng.nextGaussian())
     val linearLearner = LinearRegressionLearner()
@@ -83,7 +84,7 @@ object TestUtils {
       xscale: Double = 1.0,
       xoff: Double = 0.0,
       noise: Double = 0.0,
-      rng: Random = new Random()
+      rng: Random = Random()
   ): Iterator[(Vector[Double], Double)] = {
     Iterator.continually {
       val input = Vector.fill(cols)(xscale * rng.nextDouble() + xoff)
@@ -131,7 +132,7 @@ object TestUtils {
     }
   }
 
-  def getBreezeRandBasis(rng: Random = new Random()): RandBasis =
+  def getBreezeRandBasis(rng: Random = Random()): RandBasis =
     new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(rng.nextLong())))
 }
 
@@ -140,7 +141,7 @@ object TestUtils {
   */
 trait SeedRandomMixIn {
   // Reset random number generator.
-  var rng: Random = new Random(2348752L)
+  var rng: Random = Random(2348752L)
 
   // Set global RNG also, as a hack to partially coerce internals to be more deterministic.
   scala.util.Random.setSeed(rng.nextLong())
@@ -148,7 +149,6 @@ trait SeedRandomMixIn {
   @Before
   def initializeRandom(): Unit = {
     // Seeds must also be reset for each test so that incremental tests are as predictable as running the full case.
-    rng = new Random(2348752L)
-    scala.util.Random.setSeed(rng.nextLong())
+    rng = Random(2348752L)
   }
 }

--- a/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedResultTest.scala
@@ -17,8 +17,8 @@ class BaggedResultTest extends SeedRandomMixIn {
       inputBins = Seq((0, 8))
     )
 
-    val DTLearner = RegressionTreeLearner(numFeatures = 12, rng = rng)
-    val biasLearner = RegressionTreeLearner(maxDepth = 5, leafLearner = Some(GuessTheMeanLearner(rng = rng)))
+    val DTLearner = RegressionTreeLearner(numFeatures = 12)
+    val biasLearner = RegressionTreeLearner(maxDepth = 5, leafLearner = Some(GuessTheMeanLearner()))
 
     Array(
       Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = true),
@@ -38,7 +38,7 @@ class BaggedResultTest extends SeedRandomMixIn {
       ),
       Bagger(DTLearner, numBags = 64, biasLearner = None, uncertaintyCalibration = false, useJackknife = false)
     ).foreach { bagger =>
-      testConsistency(trainingData, bagger.train(trainingData).getModel())
+      testConsistency(trainingData, bagger.train(trainingData, rng = rng).getModel())
     }
   }
 
@@ -49,7 +49,7 @@ class BaggedResultTest extends SeedRandomMixIn {
   def testBaggedSingleResultGetUncertainty(): Unit = {
     val noiseLevel = 100.0
 
-    Seq(RegressionTreeLearner(), GuessTheMeanLearner(rng = rng)).foreach { baseLearner =>
+    Seq(RegressionTreeLearner(), GuessTheMeanLearner()).foreach { baseLearner =>
       // These are in Seqs as a convenience for repurposing this test as a diagnostic tool.
       Seq(128).foreach { nRows =>
         Seq(16).foreach { nCols =>
@@ -63,7 +63,7 @@ class BaggedResultTest extends SeedRandomMixIn {
                 TestUtils.generateTrainingData(nRows, nCols, noise = 0.0, function = _ => 0.0, rng = rng)
               val trainingData = trainingDataTmp.map { x => (x._1, x._2 + noiseLevel * rng.nextDouble()) }
               val baggedLearner = Bagger(baseLearner, numBags = nBags, uncertaintyCalibration = true)
-              val RFMeta = baggedLearner.train(trainingData)
+              val RFMeta = baggedLearner.train(trainingData, rng = rng)
               val RF = RFMeta.getModel()
               val results = RF.transform(trainingData.take(4).map(_._1))
 

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -31,10 +31,9 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
     val baggedLearner = MultiTaskBagger(
       DTLearner,
       numBags = trainingData.size,
-      randBasis = TestUtils.getBreezeRandBasis(rng),
       uncertaintyCalibration = true
     )
-    val RFMeta = baggedLearner.train(reshapedTrainingData)
+    val RFMeta = baggedLearner.train(reshapedTrainingData, rng = rng)
     val RF = RFMeta.getModels().head
 
     val results = RF.transform(trainingData.map(_._1))
@@ -73,10 +72,9 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
               val baggedLearner = MultiTaskBagger(
                 baseLearner,
                 numBags = nBags,
-                uncertaintyCalibration = true,
-                randBasis = TestUtils.getBreezeRandBasis(rng)
+                uncertaintyCalibration = true
               )
-              val RFMeta = baggedLearner.train(reshapedTrainingData)
+              val RFMeta = baggedLearner.train(reshapedTrainingData, rng = rng)
               val RF = RFMeta.getModels().head
               val results = RF.transform(trainingData.take(4).map(_._1))
 
@@ -173,8 +171,8 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
     val reshapedTrainingData = trainingData.map { case (input, label) => (input, Vector(label)) }
     val DTLearner = MultiTaskTreeLearner()
     val baggedLearner =
-      MultiTaskBagger(DTLearner, numBags = trainingData.size, randBasis = TestUtils.getBreezeRandBasis(rng))
-    val RFMeta = baggedLearner.train(reshapedTrainingData)
+      MultiTaskBagger(DTLearner, numBags = trainingData.size)
+    val RFMeta = baggedLearner.train(reshapedTrainingData, rng = rng)
     val RF = RFMeta.getModels().head
 
     /* Inspect the results */
@@ -212,10 +210,9 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
       learner,
       numBags = numBags,
       biasLearner = Some(RegressionTreeLearner(maxDepth = 2)),
-      randBasis = TestUtils.getBreezeRandBasis(rng),
       uncertaintyCalibration = true
     )
-    val RF = baggedLearner.train(inputs.zip(labels))
+    val RF = baggedLearner.train(inputs.zip(labels), rng = rng)
 
     val testInputs = inputs.take(numTest)
     val predictionResult = RF.getModel().transform(testInputs)
@@ -252,10 +249,9 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
     val baggedLearner = MultiTaskBagger(
       learner,
       numBags = numBags,
-      biasLearner = Some(RegressionTreeLearner(maxDepth = 2)),
-      randBasis = TestUtils.getBreezeRandBasis(rng)
+      biasLearner = Some(RegressionTreeLearner(maxDepth = 2))
     )
-    val RF = baggedLearner.train(inputs.zip(labels)).getModel()
+    val RF = baggedLearner.train(inputs.zip(labels), rng = rng).getModel()
 
     val testInputs =
       TestUtils.generateTrainingData(numTest, 12, function = Friedman.friedmanSilverman, rng = rng).map(_._1)
@@ -306,10 +302,9 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
     val baggedLearner = MultiTaskBagger(
       DTLearner,
       numBags = inputs.size,
-      biasLearner = Some(GuessTheMeanLearner(rng = rng)),
-      randBasis = TestUtils.getBreezeRandBasis(rng)
+      biasLearner = Some(GuessTheMeanLearner())
     )
-    val trainingResult = baggedLearner.train(inputs.zip(labels))
+    val trainingResult = baggedLearner.train(inputs.zip(labels), rng = rng)
     val RF = trainingResult.getModels().last
 
     val catResults = RF.transform(inputs).getExpected()
@@ -317,7 +312,7 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
     assert(realUncertainty.forall(!_.asInstanceOf[Double].isNaN), s"Some uncertainty values were NaN")
 
     val referenceModel = Bagger(ClassificationTreeLearner(), numBags = inputs.size)
-      .train(inputs.zip(sparseCat).filterNot(_._2 == null))
+      .train(inputs.zip(sparseCat).filterNot(_._2 == null), rng = rng)
     val reference = referenceModel
       .getModel()
       .transform(inputs)
@@ -361,10 +356,9 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
       val baggedLearner = MultiTaskBagger(
         MultiTaskTreeLearner(),
         numBags = inputs.size,
-        biasLearner = Some(GuessTheMeanLearner(rng = rng)),
-        randBasis = TestUtils.getBreezeRandBasis(rng)
+        biasLearner = Some(GuessTheMeanLearner())
       )
-      assert(baggedLearner.train(inputs.zip(labels)).getModels().size == 2)
+      assert(baggedLearner.train(inputs.zip(labels), rng = rng).getModels().size == 2)
     }
   }
 }

--- a/src/test/scala/io/citrine/lolo/learners/ExtraRandomTreesTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/ExtraRandomTreesTest.scala
@@ -3,6 +3,7 @@ package io.citrine.lolo.learners
 import breeze.stats.distributions.{Beta, RandBasis}
 import io.citrine.lolo.{SeedRandomMixIn, TestUtils}
 import io.citrine.lolo.stats.functions.Friedman
+import io.citrine.random.Random
 import org.junit.Test
 
 @Test
@@ -19,8 +20,8 @@ class ExtraRandomTreesTest extends SeedRandomMixIn {
     )
 
     Seq(true, false).foreach { randomlyRotateFeatures =>
-      val RFMeta = ExtraRandomTrees(randomlyRotateFeatures = randomlyRotateFeatures, rng = rng)
-        .train(trainingData)
+      val RFMeta = ExtraRandomTrees(randomlyRotateFeatures = randomlyRotateFeatures)
+        .train(trainingData, rng = rng)
       val RF = RFMeta.getModel()
 
       val loss = RFMeta.getLoss().get
@@ -69,15 +70,14 @@ class ExtraRandomTreesTest extends SeedRandomMixIn {
     Seq(true, false).foreach { randomlyRotateFeatures =>
       Seq(true, false).foreach { disableBootstrap =>
         Seq(1, 2).foreach { minLeafInstances =>
-          rng.setSeed(238834L)
+          rng = Random(238834L)
 
           val RFMeta = ExtraRandomTrees(
             numTrees = trainingData.size * 4,
             randomlyRotateFeatures = randomlyRotateFeatures,
             disableBootstrap = disableBootstrap,
-            rng = rng,
             minLeafInstances = minLeafInstances
-          ).train(trainingData)
+          ).train(trainingData, rng = rng)
           val RF = RFMeta.getModel()
 
           /* Inspect the results on the training set */
@@ -145,9 +145,9 @@ class ExtraRandomTreesTest extends SeedRandomMixIn {
         ) ++ mainTrainingData
 
         val RFSuffixed =
-          ExtraRandomTrees(numTrees = trainingDataSuffixed.size * 2, rng = rng).train(trainingDataSuffixed)
+          ExtraRandomTrees(numTrees = trainingDataSuffixed.size * 2).train(trainingDataSuffixed, rng = rng)
         val RFPrefixed =
-          ExtraRandomTrees(numTrees = trainingDataPrefixed.size * 2, rng = rng).train(trainingDataPrefixed)
+          ExtraRandomTrees(numTrees = trainingDataPrefixed.size * 2).train(trainingDataPrefixed, rng = rng)
         val predictedSuffixed = RFSuffixed.getModel().transform(testData.map(_._1))
         val predictedPrefixed = RFPrefixed.getModel().transform(testData.map(_._1))
         val extraLabelCountSuffixed = predictedSuffixed.getExpected().count { case p: String => p == dupeLabel }
@@ -184,12 +184,12 @@ class ExtraRandomTreesTest extends SeedRandomMixIn {
     */
   @Test
   def testWeightsWithSmallData(): Unit = {
-    val trainingData = TestUtils.generateTrainingData(8, 1, rng = rng)
+    val trainingData = TestUtils.generateTrainingData(8, 1)
     // the number of trees is the number of times we generate weights
     // so this has the effect of creating lots of different sets of weights
-    val learner = ExtraRandomTrees(numTrees = 16384, rng = rng)
+    val learner = ExtraRandomTrees(numTrees = 16384)
     // the test is that this training doesn't throw an exception
-    learner.train(trainingData).getModel()
+    learner.train(trainingData, rng = rng).getModel()
   }
 
 }

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -105,7 +105,7 @@ class RandomForestTest extends SeedRandomMixIn {
 
   /** Test that the same random seed leads to identical models */
   @Test
-  def testRepeatibility(): Unit = {
+  def testReproducibility(): Unit = {
     val numTrain = 50
     // Generate completely random training data
     val (inputs: Seq[Vector[Double]], realLabel: Seq[Double]) = TestUtils
@@ -114,20 +114,15 @@ class RandomForestTest extends SeedRandomMixIn {
     val catLabel: Seq[Boolean] = Seq.fill(numTrain)(rng.nextBoolean())
     val allLabels = Vector(realLabel, catLabel).transpose
 
+    // Generate test points
     val numTest = 25
     val testInputs = TestUtils.generateTrainingData(rows = numTest, cols = 12, function = _ => 0.0, rng = rng).map(_._1)
 
     val seed = 67852103L
-    val meta = RegressionTreeLearner(splitter = RegressionSplitter(randomizePivotLocation = true))
-    val model1 = meta.train(inputs.zip(realLabel), rng = Random(seed)).getModel()
-    val model2 = meta.train(inputs.zip(realLabel), rng = Random(seed)).getModel()
-    val pred1 = model1.transform(testInputs)
-    val pred2 = model2.transform(testInputs)
-    assert(pred1.getExpected() == pred2.getExpected())
     val RFMeta = RandomForest(
       biasLearner = Some(RegressionTreeLearner(maxDepth = 5)),
-      randomizePivotLocation = true
-//      randomlyRotateFeatures = true
+      randomizePivotLocation = true,
+      randomlyRotateFeatures = true
     )
     Vector(realLabel, catLabel, allLabels).foreach { labels =>
       val model1 = RFMeta.train(inputs.zip(labels), rng = Random(seed)).getModel()

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -229,7 +229,8 @@ class FeatureRotatorTest extends SeedRandomMixIn {
     val result = model.transform(classificationData.map(_._1)).getExpected()
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(classificationData, rng = rng).getModel().asInstanceOf[RotatedFeatureModel[String]]
+    val rotatedModel =
+      rotatedLearner.train(classificationData, rng = rng).getModel().asInstanceOf[RotatedFeatureModel[String]]
     var rotatedResult = rotatedModel.transform(classificationData.map(_._1)).getExpected()
 
     result.zip(rotatedResult).foreach {

--- a/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/FeatureRotatorTest.scala
@@ -98,7 +98,7 @@ class FeatureRotatorTest extends SeedRandomMixIn {
     */
   @Test
   def testPassthroughFunctions(): Unit = {
-    val rotatedTrainingResult = FeatureRotator(RegressionTreeLearner()).train(data)
+    val rotatedTrainingResult = FeatureRotator(RegressionTreeLearner()).train(data, rng = rng)
 
     assert(
       rotatedTrainingResult.getLoss() == rotatedTrainingResult.baseTrainingResult.getLoss(),
@@ -120,12 +120,12 @@ class FeatureRotatorTest extends SeedRandomMixIn {
     */
   @Test
   def testRotatedGTM(): Unit = {
-    val learner = GuessTheMeanLearner(rng = rng)
-    val model = learner.train(data).getModel()
+    val learner = GuessTheMeanLearner()
+    val model = learner.train(data, rng = rng).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
-    val rotatedLearner = FeatureRotator(GuessTheMeanLearner(rng = rng))
-    val rotatedModel = rotatedLearner.train(data).getModel()
+    val rotatedLearner = FeatureRotator(GuessTheMeanLearner())
+    val rotatedModel = rotatedLearner.train(data, rng = rng).getModel()
     val rotatedResult = rotatedModel.transform(data.map(_._1)).getExpected()
 
     result.zip(rotatedResult).foreach {
@@ -140,13 +140,13 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedLinear(): Unit = {
     val learner = LinearRegressionLearner()
-    val model = learner.train(data, Some(weights)).getModel()
+    val model = learner.train(data, Some(weights), rng).getModel()
     val result = model.transform(data.map(_._1))
     val expected = result.getExpected()
     val gradient = result.getGradient()
 
     val rotatedLearner = FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(data, Some(weights)).getModel()
+    val rotatedModel = rotatedLearner.train(data, Some(weights), rng).getModel()
     val rotatedResult = rotatedModel.transform(data.map(_._1))
     val rotatedExpected = rotatedResult.getExpected()
     val rotatedGradient = rotatedResult.getGradient()
@@ -169,11 +169,11 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedRidge(): Unit = {
     val learner = LinearRegressionLearner(regParam = Some(1.0))
-    val model = learner.train(data).getModel()
+    val model = learner.train(data, rng = rng).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(data).getModel()
+    val rotatedModel = rotatedLearner.train(data, rng = rng).getModel()
     val rotatedResult = rotatedModel.transform(data.map(_._1)).getExpected()
 
     result.zip(rotatedResult).foreach {
@@ -188,11 +188,11 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedRegressionTree(): Unit = {
     val learner = RegressionTreeLearner()
-    val model = learner.train(data).getModel()
+    val model = learner.train(data, rng = rng).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(data).getModel().asInstanceOf[RotatedFeatureModel[Double]]
+    val rotatedModel = rotatedLearner.train(data, rng = rng).getModel().asInstanceOf[RotatedFeatureModel[Double]]
     var rotatedResult = rotatedModel.transform(data.map(_._1)).getExpected()
     result.zip(rotatedResult).foreach {
       case (free: Double, rotated: Double) =>
@@ -225,11 +225,11 @@ class FeatureRotatorTest extends SeedRandomMixIn {
     )
 
     val learner = ClassificationTreeLearner()
-    val model = learner.train(classificationData).getModel()
+    val model = learner.train(classificationData, rng = rng).getModel()
     val result = model.transform(classificationData.map(_._1)).getExpected()
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(classificationData).getModel().asInstanceOf[RotatedFeatureModel[String]]
+    val rotatedModel = rotatedLearner.train(classificationData, rng = rng).getModel().asInstanceOf[RotatedFeatureModel[String]]
     var rotatedResult = rotatedModel.transform(classificationData.map(_._1)).getExpected()
 
     result.zip(rotatedResult).foreach {
@@ -273,7 +273,7 @@ class FeatureRotatorTest extends SeedRandomMixIn {
     val baseLearner = MultiTaskTreeLearner()
     val rotatedLearner = MultiTaskFeatureRotator(MultiTaskTreeLearner())
 
-    val baseTrainingResult = baseLearner.train(inputs.zip(labels))
+    val baseTrainingResult = baseLearner.train(inputs.zip(labels), rng = rng)
     val baseDoubleModel = baseTrainingResult.getModels().head
     val baseCatModel = baseTrainingResult.getModels().last
     val rotatedTrainingResult = rotatedLearner.train(inputs.zip(labels))

--- a/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/StandardizerTest.scala
@@ -52,12 +52,12 @@ class StandardizerTest extends SeedRandomMixIn {
     */
   @Test
   def testStandardGTM(): Unit = {
-    val learner = GuessTheMeanLearner(rng = rng)
-    val model = learner.train(data).getModel()
+    val learner = GuessTheMeanLearner()
+    val model = learner.train(data, rng = rng).getModel()
     val result = model.transform(data.map(_._1)).getExpected()
 
-    val standardLearner = Standardizer(GuessTheMeanLearner(rng = rng))
-    val standardModel = standardLearner.train(data).getModel()
+    val standardLearner = Standardizer(GuessTheMeanLearner())
+    val standardModel = standardLearner.train(data, rng = rng).getModel()
     val standardResult = standardModel.transform(data.map(_._1)).getExpected()
 
     result.zip(standardResult).foreach {

--- a/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
@@ -5,14 +5,10 @@ import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.trees.classification.{ClassificationTree, ClassificationTreeLearner}
 import io.citrine.lolo.trees.regression.RegressionTree
+import io.citrine.random.Random
 import org.junit.Test
 import org.scalatest.Assertions._
 
-import scala.util.Random
-
-/**
-  * Created by maxhutch on 11/29/16.
-  */
 @Test
 class MultiTaskTreeTest extends SeedRandomMixIn {
 
@@ -98,12 +94,12 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
   def testSingleModelEquality(): Unit = {
     // Train twice with the same seed, first outputting two models and then outputting a combined model.
     val seed = 817235L
-    val trainRng = new Random(seed)
-    val combinedModelRng = new Random(seed)
-    val learner = MultiTaskTreeLearner(rng = trainRng)
-    val combinedModelLearner = MultiTaskTreeLearner(rng = combinedModelRng)
-    val models = learner.train(inputs.zip(labels)).getModels()
-    val combinedModel = combinedModelLearner.train(inputs.zip(labels)).getModel()
+    val trainRng = Random(seed)
+    val combinedModelRng = Random(seed)
+    val learner = MultiTaskTreeLearner()
+    val combinedModelLearner = MultiTaskTreeLearner()
+    val models = learner.train(inputs.zip(labels), rng = trainRng).getModels()
+    val combinedModel = combinedModelLearner.train(inputs.zip(labels), rng = combinedModelRng).getModel()
 
     // Generate new inputs to test equality on.
     val testInputs = TestUtils
@@ -118,8 +114,8 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
   /** Test that feature importance correctly identifies the 1st feature as the most important for Friedman-Silverman. */
   @Test
   def testFeatureImportance(): Unit = {
-    val multiTaskLearner = MultiTaskTreeLearner(rng = rng)
-    val multiTaskTrainingResult = multiTaskLearner.train(inputs.zip(labels))
+    val multiTaskLearner = MultiTaskTreeLearner()
+    val multiTaskTrainingResult = multiTaskLearner.train(inputs.zip(labels), rng = rng)
     val importances = multiTaskTrainingResult.getFeatureImportance().get
     assert(importances(1) == importances.max)
   }

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -9,9 +9,6 @@ import io.citrine.lolo.trees.splits.{BoltzmannSplitter, RegressionSplitter}
 import org.junit.Test
 import org.scalatest.Assertions._
 
-/**
-  * Created by maxhutch on 11/29/16.
-  */
 @Test
 class RegressionTreeTest extends SeedRandomMixIn {
 
@@ -243,8 +240,8 @@ class RegressionTreeTest extends SeedRandomMixIn {
   def testSimpleBoltzmannTree(): Unit = {
     val csv = TestUtils.readCsv("double_example.csv")
     val trainingData = csv.map(vec => (vec.init, vec.last.asInstanceOf[Double]))
-    val DTLearner = RegressionTreeLearner(splitter = BoltzmannSplitter(1e-4), rng = rng)
-    val DT = DTLearner.train(trainingData).getModel()
+    val DTLearner = RegressionTreeLearner(splitter = BoltzmannSplitter(1e-4))
+    val DT = DTLearner.train(trainingData, rng = rng).getModel()
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_._1))

--- a/src/test/scala/io/citrine/lolo/trees/splits/BoltzmannSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/BoltzmannSplitterTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.splits
 
 import io.citrine.lolo.SeedRandomMixIn
+import io.citrine.random.Random
 import org.junit.Test
 
 class BoltzmannSplitterTest extends SeedRandomMixIn {
@@ -10,7 +11,7 @@ class BoltzmannSplitterTest extends SeedRandomMixIn {
     */
   @Test
   def testZeroVariance(): Unit = {
-    val splitter = BoltzmannSplitter(1.0e-9, rng = rng)
+    val splitter = BoltzmannSplitter(1.0e-9)
     val testData = Seq.fill(64) {
       val x = rng.nextDouble()
       val y = 1.0
@@ -31,7 +32,7 @@ class BoltzmannSplitterTest extends SeedRandomMixIn {
     */
   @Test
   def testLowVariance(): Unit = {
-    val splitter = BoltzmannSplitter(1.0e-18, rng = rng)
+    val splitter = BoltzmannSplitter(1.0e-18)
     val testData = Seq.fill(256) {
       val x = rng.nextDouble()
       val y = rng.nextGaussian() * 1.0e-9 + 1.0
@@ -39,7 +40,7 @@ class BoltzmannSplitterTest extends SeedRandomMixIn {
       (Vector(x), y, weight)
     }
 
-    splitter.getBestSplit(testData, 1, 1)
+    splitter.getBestSplit(testData, 1, 1, rng = rng)
   }
 
 }

--- a/src/test/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitterTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.splits
 
 import io.citrine.lolo.{SeedRandomMixIn, TestUtils}
+import io.citrine.random.Random
 import org.junit.Test
 
 class ExtraRandomRegressionSplitterTest extends SeedRandomMixIn {
@@ -10,7 +11,7 @@ class ExtraRandomRegressionSplitterTest extends SeedRandomMixIn {
     */
   @Test
   def testZeroVariance(): Unit = {
-    val splitter = ExtraRandomRegressionSplitter(rng)
+    val splitter = ExtraRandomRegressionSplitter()
     val testData = Seq.fill(64) {
       val x = rng.nextDouble()
       val y = 1.0
@@ -31,7 +32,7 @@ class ExtraRandomRegressionSplitterTest extends SeedRandomMixIn {
     */
   @Test
   def testLowVariance(): Unit = {
-    val splitter = ExtraRandomRegressionSplitter(rng)
+    val splitter = ExtraRandomRegressionSplitter()
     val testData = Seq.fill(256) {
       val x = rng.nextDouble()
       val y = rng.nextGaussian() * 1.0e-9 + 1.0
@@ -39,7 +40,7 @@ class ExtraRandomRegressionSplitterTest extends SeedRandomMixIn {
       (Vector(x), y, weight)
     }
 
-    splitter.getBestSplit(testData, 1, 1)
+    splitter.getBestSplit(testData, 1, 1, rng = rng)
   }
 
   /**
@@ -74,7 +75,7 @@ class ExtraRandomRegressionSplitterTest extends SeedRandomMixIn {
 
             // Determine exactly what shuffle() and nextDouble() will return within getBestSplit by resetting rng to a common rng seed.
             val sharedSeed = 238745L + repetitionNumber
-            rng.setSeed(sharedSeed)
+            rng = Random(sharedSeed)
             // This is the set of shuffled indices to return when getBestSplit calls the RNG's shuffle method.
             val shuffledFeatureIndices = rng.shuffle(featureIndices)
             // Precompute the sequence of numbers returned when getBestSplit calls the RNG's nextDouble method to select cut points.
@@ -119,10 +120,10 @@ class ExtraRandomRegressionSplitterTest extends SeedRandomMixIn {
               ._1
 
             // Instantiate the splitter to test, passing in the random number generator that is reset to its former state used above.
-            rng.setSeed(sharedSeed)
-            val splitter = ExtraRandomRegressionSplitter(rng)
+            rng = Random(sharedSeed)
+            val splitter = ExtraRandomRegressionSplitter()
             // Ask the splitter what it chose as a split.
-            val bestSplit = splitter.getBestSplit(trainingData, numFeaturesToConsider, 1)
+            val bestSplit = splitter.getBestSplit(trainingData, numFeaturesToConsider, 1, rng = rng)
 
             // Finally, we can ensure that the index on which we split is correct...
             val testCaveatMessage = "NOTE: this test may inaccurately fail due to changes in the sequence of rng calls."

--- a/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
@@ -23,8 +23,8 @@ class MultiTaskSplitterTest extends SeedRandomMixIn {
     )
     val calculator = MultiImpurityCalculator.build(data.map(_._2), data.map(_._3))
 
-    val splitter = MultiTaskSplitter(rng = rng)
-    val (pivot, impurity) = Splitter.getBestRealSplit(data, calculator, 0, 1)
+    val splitter = MultiTaskSplitter()
+    val (pivot, impurity) = Splitter.getBestRealSplit(data, calculator, 0, 1, rng = rng)
     val turns = data.map(x => pivot.turnLeft(x._1))
     assert(turns == Seq(true, false, false, false))
     assert(impurity == 0.5)
@@ -43,7 +43,7 @@ class MultiTaskSplitterTest extends SeedRandomMixIn {
     )
     val calculator = MultiImpurityCalculator.build(data.map(_._2), data.map(_._3))
 
-    val splitter = MultiTaskSplitter(rng = rng)
+    val splitter = MultiTaskSplitter()
     val (pivot, impurity) = splitter.getBestCategoricalSplit(data, calculator, 0, 1)
     val turns = data.map(x => pivot.turnLeft(x._1)).take(3)
     println(turns)
@@ -65,8 +65,8 @@ class MultiTaskSplitterTest extends SeedRandomMixIn {
     val data = inputs.indices.map { i =>
       (inputs(i), labels(i).asInstanceOf[Array[AnyVal]], weights(i))
     }
-    val splitter = MultiTaskSplitter(rng = rng)
-    val (pivot, _) = splitter.getBestSplit(data, data.head._1.size, 1)
+    val splitter = MultiTaskSplitter()
+    val (pivot, _) = splitter.getBestSplit(data, data.head._1.size, 1, rng = rng)
     assert(!pivot.isInstanceOf[NoSplit])
   }
 }

--- a/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
@@ -80,8 +80,8 @@ object CalibrationStudy extends SeedRandomMixIn {
           useJackknife = true,
           uncertaintyCalibration = false
         )
-        StatisticalValidation(rng = rng)
-          .generativeValidation[Double](data, learner, nTrain = nTrain.toInt, nTest = 256, nRound = 32)
+        StatisticalValidation()
+          .generativeValidation[Double](data, learner, nTrain = nTrain.toInt, nTest = 256, nRound = 32, rng = rng)
       }
       BitmapEncoder.saveBitmap(chart, s"./scan-ratio.${ratio}", BitmapFormat.PNG)
     }
@@ -116,8 +116,8 @@ object CalibrationStudy extends SeedRandomMixIn {
           useJackknife = true,
           uncertaintyCalibration = calibrated
         )
-        StatisticalValidation(rng = rng)
-          .generativeValidation[Double](data, learner, nTrain = nTrain.toInt, nTest = 256, nRound = 32)
+        StatisticalValidation()
+          .generativeValidation[Double](data, learner, nTrain = nTrain.toInt, nTest = 256, nRound = 32, rng = rng)
       }
       val fname = if (calibrated) {
         s"./scan-nTrain.${nTrain}-nTree-cal"
@@ -159,8 +159,8 @@ object CalibrationStudy extends SeedRandomMixIn {
           useJackknife = true,
           uncertaintyCalibration = calibrated
         )
-        StatisticalValidation(rng = rng)
-          .generativeValidation[Double](data, learner, nTrain = nTrain.toInt, nTest = 256, nRound = 32)
+        StatisticalValidation()
+          .generativeValidation[Double](data, learner, nTrain = nTrain.toInt, nTest = 256, nRound = 32, rng = rng)
       }
       val fname = if (calibrated) {
         s"./scan-${funcName}-nTrain-nTree.${nTree}-cal"
@@ -194,13 +194,14 @@ object CalibrationStudy extends SeedRandomMixIn {
       biasLearner = None // Some(RegressionTreeLearner(maxDepth = (Math.log(nTrain) / Math.log(2) / 2).toInt))
     )
 
-    val fullStream = StatisticalValidation(rng = rng)
+    val fullStream = StatisticalValidation()
       .generativeValidation[Double](
         data,
         learner,
         nTrain,
         32,
-        512
+        512,
+        rng = rng
       )
       .toIterable
 
@@ -208,13 +209,14 @@ object CalibrationStudy extends SeedRandomMixIn {
       generativeHistogram(fullStream, learner, plotNormal = true, plotCauchy = true, calibrate = true, range = range)
     BitmapEncoder.saveBitmap(chart, s"./stdres_${funcName}-nTrain.${nTrain}-nTree.${nTree}", BitmapFormat.PNG)
 
-    val dataStream = StatisticalValidation(rng = rng)
+    val dataStream = StatisticalValidation()
       .generativeValidation[Double](
         data,
         learner,
         nTrain,
         32,
-        2
+        2,
+        rng = rng
       )
       .toIterable
     val pva = PredictedVsActual().visualize(dataStream)
@@ -320,8 +322,15 @@ object CalibrationStudy extends SeedRandomMixIn {
           useJackknife = true,
           uncertaintyCalibration = calibrated
         )
-        StatisticalValidation(rng = rng)
-          .generativeValidation[Double](trainingData, learner, nTrain = nTrain.toInt, nTest = 256, nRound = 32)
+        StatisticalValidation()
+          .generativeValidation[Double](
+            trainingData,
+            learner,
+            nTrain = nTrain.toInt,
+            nTest = 256,
+            nRound = 32,
+            rng = rng
+          )
       }
       val fname = if (calibrated) {
         s"./scan-hcep-nTrain-nTree.${nTree}-cal"
@@ -351,13 +360,14 @@ object CalibrationStudy extends SeedRandomMixIn {
       uncertaintyCalibration = false
     )
 
-    val fullStream = StatisticalValidation(rng = rng)
+    val fullStream = StatisticalValidation()
       .generativeValidation[Double](
         trainingData,
         learner,
         nTrain,
         32,
-        512
+        512,
+        rng = rng
       )
       .toIterable
 
@@ -365,13 +375,14 @@ object CalibrationStudy extends SeedRandomMixIn {
       generativeHistogram(fullStream, learner, plotNormal = true, plotCauchy = true, calibrate = true, range = range)
     BitmapEncoder.saveBitmap(chart, s"./stdres_hcep-nTrain.${nTrain}-nTree.${nTree}", BitmapFormat.PNG)
 
-    val dataStream = StatisticalValidation(rng = rng)
+    val dataStream = StatisticalValidation()
       .generativeValidation[Double](
         trainingData,
         learner,
         nTrain,
         32,
-        2
+        2,
+        rng = rng
       )
       .toIterable
     val pva = PredictedVsActual().visualize(dataStream)

--- a/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
@@ -1,12 +1,13 @@
 package io.citrine.lolo.validation
 
+import io.citrine.random.Random
 import io.citrine.lolo.{PredictionResult, SeedRandomMixIn}
 import org.apache.commons.math3.distribution.MultivariateNormalDistribution
 import org.apache.commons.math3.random.MersenneTwister
 import org.junit.Test
 import org.scalatest.Assertions._
 
-import scala.util.{Random, Try}
+import scala.util.Try
 
 class MeritTest extends SeedRandomMixIn {
 

--- a/src/test/scala/io/citrine/lolo/validation/StatisticalValidationTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/StatisticalValidationTest.scala
@@ -18,7 +18,7 @@ class StatisticalValidationTest extends SeedRandomMixIn {
       CrossValidation.kFoldCrossvalidation(dataSet, learner, metrics, k = 4, nTrial = 4)("rmse")
 
     val (rmseFromStats, uncertaintyFromStats) = Merit.estimateMerits(
-      StatisticalValidation(rng = rng).generativeValidation(dataGenerator, learner, 96, 32, 16),
+      StatisticalValidation().generativeValidation(dataGenerator, learner, 96, 32, 16, rng = rng),
       metrics
     )("rmse")
 


### PR DESCRIPTION
The intention of this PR is to allow complete reproducibility in Lolo. Given the same training data and the same configuration, we should be able to produce identical models when starting from the same random seed. The biggest change made to accomplish this goal is to **move random seeds from objects to methods**. Currently, a random seed can be specified when the user creates a `RandomForest` object. This is the same pattern as scikit-learn, but I have changed the random seed to be an argument of the `RandomForest`'s `train` method. There are several reasons.

1. Locality makes debugging easier. Putting the random seed on the function makes each function call reproducible, independent of global state. This allows us to drill down into the behavior of a specific piece of code when trying to understand an error.
2. It's more flexible. The same persisted configuration can be retrained with a specific random seed if we need to reproducible an earlier result. But it can also be retrained with an arbitrary seed.
3. It facilitates determinism in a multi-threaded environment. Logic can be fanned out to parallel processes and as long as each function call gets the same random seed, the result is deterministic. If the seed is on the objects then we need to construct a new object holding that seed in order to pass to each parallel process.

The clearest user-facing change is that learners, like `RandomForest` no longer have a random seed and the `train` method does have a random seed. But there are several internal methods that now have a random seed:
* getting the best split
* hyperparameter optimization
* running cross-validation and other model quality tests
* randomly rotating features

I'm submitting this PR as-is because it accomplishes the goal and is quite large already. But there are a few things to change in follow-on PRs.
* Currently, a multi-task RF is not able to pass the random seed all the way down to training the individual leaf learners. It's not an issue in practice because the leaf learners are deterministic, but it's still a potential bug. We'll need to re-architect the multi-task node creation structure to make this possible.
* Similarly, the regression and classification node structure leads to random seeds in some object constructors. These are internal objects that are created as part of training and expose no methods to the outside, so it's not an immediate issue. But it would be better to change how they are structured.

I also removed Scala 2.12 and upgraded the Travis build file from using jdk8 to jdk11