### PR TITLE
Scala naming conventions and syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ For example, you can use Random Forest with:
 import io.citrine.lolo.learners.RandomForest
 val trainingData: Seq[(Vector[Any], Any)] = features.zip(labels)
 val model = new RandomForest().train(trainingData).getModel()
-val predictions: Seq[Any] = model.transform(testInputs).getExpected()
+val predictions: Seq[Any] = model.transform(testInputs).expected
 ```
 
 # Performance
 Lolo prioritizes functionality over performance, but it is still quite fast.  In its _random forest_ use case, the complexity scales as:
 
 | Time complexity | Training rows | Features | Trees |
-|-------|--------|-------|-------|
-| `train` | O(n log n) | O(n) | O(n) |
-| `getLoss` | O(n log n) | O(n) | O(n) |
-| `getExpected` | O(log n) | O(1) | O(n) |
-| `getUncertainty` | O(n) | O(1) | O(n) |
+|-----------------|--------|-------|-------|
+| `train`         | O(n log n) | O(n) | O(n) |
+| `loss`          | O(n log n) | O(n) | O(n) |
+| `expected`      | O(log n) | O(1) | O(n) |
+| `uncertainty`   | O(n) | O(1) | O(n) |
 
 On an [Ivy Bridge](http://ark.intel.com/products/77780/Intel-Core-i7-4930K-Processor-12M-Cache-up-to-3_90-GHz) test platform, the (1024 row, 1024 tree, 8 feature) [performance test](src/test/scala/io/citrine/lolo/PerformanceTest.scala) took 1.4 sec to train and 2.3 ms per prediction with uncertainty.
 

--- a/python/examples/profile/scala-benchmark.scala
+++ b/python/examples/profile/scala-benchmark.scala
@@ -18,12 +18,12 @@ def timedTest(trainingData: Seq[(Vector[Any], Double)], evalData: Seq[(Vector[An
   // Do dry timining run with 8 runs
   val model = baggedLearner.train(trainingData).getModel()
   Stopwatch.time({baggedLearner.train(trainingData).getModel()}, benchmark = "None", minRun = 8, maxRun = 8)
-  Stopwatch.time({model.transform(inputs).getExpected()}, benchmark = "None", minRun = 8, maxRun = 8)
+  Stopwatch.time({model.transform(inputs).expected}, benchmark = "None", minRun = 8, maxRun = 8)
   Stopwatch.time({model.transform(inputs).getUncertainty()}, benchmark = "None", minRun = 8, maxRun = 8)
 
   // Time it for real
   val timeTraining = Stopwatch.time({baggedLearner.train(trainingData).getModel()}, benchmark = "None", minRun = 16, targetError = 0.1, maxRun = 32)
-  val timePredicting = Stopwatch.time({model.transform(inputs).getExpected()}, benchmark = "None", minRun = 16, targetError = 0.1, maxRun = 32)
+  val timePredicting = Stopwatch.time({model.transform(inputs).expected}, benchmark = "None", minRun = 16, targetError = 0.1, maxRun = 32)
   val timeUncertainty = Stopwatch.time({model.transform(inputs).getUncertainty()}, benchmark = "None", minRun = 16, targetError = 0.1, maxRun = 32)
 
   (timeTraining, timePredicting, timeUncertainty)

--- a/python/examples/profile/scaling-test.ipynb
+++ b/python/examples/profile/scaling-test.ipynb
@@ -451,7 +451,7 @@
     "    r['lolopy_apply_wuncert'] = np.mean(time_function(model.predict, 16, X, return_std=True))\n",
     "    r['lolopy_apply_transfer'] = np.mean(time_function(model._convert_run_data, 16, X))\n",
     "    \n",
-    "    model.clear_model  # To save memory\n",
+    "    model.clear_model()  # To save memory\n",
     "    \n",
     "    # Time using RF\n",
     "    sk_model = SKRFRegressor(n_estimators=n)\n",

--- a/python/examples/profile/scaling-test.ipynb
+++ b/python/examples/profile/scaling-test.ipynb
@@ -451,7 +451,7 @@
     "    r['lolopy_apply_wuncert'] = np.mean(time_function(model.predict, 16, X, return_std=True))\n",
     "    r['lolopy_apply_transfer'] = np.mean(time_function(model._convert_run_data, 16, X))\n",
     "    \n",
-    "    model.clear_model()  # To save memory\n",
+    "    model.clear_model  # To save memory\n",
     "    \n",
     "    # Time using RF\n",
     "    sk_model = SKRFRegressor(n_estimators=n)\n",

--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -105,10 +105,10 @@ class BaseLoloLearner(BaseEstimator, metaclass=ABCMeta):
         self.gateway.detach(train_rows)
 
         # Get the model out
-        self.model_ = result.getModel()
+        self.model_ = result.model()
 
         # Store the feature importances
-        feature_importances_java = result.getFeatureImportance().get()
+        feature_importances_java = result.featureImportance().get()
         feature_importances_bytes = self.gateway.jvm.io.citrine.lolo.util.LoloPyDataLoader.send1DArray(feature_importances_java)
         self.feature_importances_ = np.frombuffer(feature_importances_bytes, 'float')
 

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -79,7 +79,7 @@ class TestRF(TestCase):
         assert np.all(y_cov.flatten() == y_std ** 2)
 
         # Make sure the detach operation functions
-        rf.clear_model
+        rf.clear_model()
         self.assertIsNone(rf.model_)
 
     def test_reproducibility(self):
@@ -276,7 +276,7 @@ class TestExtraRandomTrees(TestCase):
         self.assertGreater(np.std(y_std), 0)  # Must have a variety of values
 
         # Make sure the detach operation functions
-        rf.clear_model
+        rf.clear_model()
         self.assertIsNone(rf.model_)
 
     def test_reproducibility(self):

--- a/python/lolopy/tests/test_learners.py
+++ b/python/lolopy/tests/test_learners.py
@@ -79,7 +79,7 @@ class TestRF(TestCase):
         assert np.all(y_cov.flatten() == y_std ** 2)
 
         # Make sure the detach operation functions
-        rf.clear_model()
+        rf.clear_model
         self.assertIsNone(rf.model_)
 
     def test_reproducibility(self):
@@ -276,7 +276,7 @@ class TestExtraRandomTrees(TestCase):
         self.assertGreater(np.std(y_std), 0)  # Must have a variety of values
 
         # Make sure the detach operation functions
-        rf.clear_model()
+        rf.clear_model
         self.assertIsNone(rf.model_)
 
     def test_reproducibility(self):

--- a/src/main/scala/io/citrine/lolo/Model.scala
+++ b/src/main/scala/io/citrine/lolo/Model.scala
@@ -28,13 +28,13 @@ trait Model[+T] extends Serializable {
 trait MultiTaskModel extends Model[Vector[Any]] {
 
   /** The number of labels. Every prediction must have this length. */
-  val numLabels: Int
+  def numLabels: Int
 
   /** A boolean sequence indicating which labels are real-valued. Its length must be equal to `numLabels`. */
-  def getRealLabels: Seq[Boolean]
+  def realLabels: Seq[Boolean]
 
   /** Individual models corresponding to each label */
-  def getModels: Seq[Model[Any]]
+  def models: Seq[Model[Any]]
 
   override def transform(inputs: Seq[Vector[Any]]): MultiTaskModelPredictionResult
 
@@ -46,15 +46,11 @@ trait MultiTaskModel extends Model[Vector[Any]] {
   * @param models     sequence of models, one for each label
   * @param realLabels boolean sequence indicating which labels are real-valued
   */
-class ParallelModels(models: Seq[Model[Any]], realLabels: Seq[Boolean]) extends MultiTaskModel {
-  override val numLabels: Int = models.length
-
-  override def getRealLabels: Seq[Boolean] = realLabels
-
-  override def getModels: Seq[Model[Any]] = models
+case class ParallelModels(models: Seq[Model[Any]], realLabels: Seq[Boolean]) extends MultiTaskModel {
+  override def numLabels: Int = models.length
 
   override def transform(inputs: Seq[Vector[Any]]): ParallelModelsPredictionResult = {
-    val predictions = models.map(_.transform(inputs).getExpected()).toVector.transpose
-    new ParallelModelsPredictionResult(predictions)
+    val predictions = models.map(_.transform(inputs).expected).toVector.transpose
+    ParallelModelsPredictionResult(predictions)
   }
 }

--- a/src/main/scala/io/citrine/lolo/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/PredictionResult.scala
@@ -12,7 +12,7 @@ trait PredictionResult[+T] {
     *
     * @return expected value of each prediction
     */
-  def getExpected(): Seq[T]
+  def expected: Seq[T]
 
   /**
     * Get the "uncertainty" of the prediction
@@ -22,14 +22,14 @@ trait PredictionResult[+T] {
     * @param observational whether the uncertainty should account for observational uncertainty
     * @return uncertainty of each prediction
     */
-  def getUncertainty(observational: Boolean = true): Option[Seq[Any]] = None
+  def uncertainty(observational: Boolean = true): Option[Seq[Any]] = None
 
   /**
     * Get the training row scores for each prediction
     *
     * @return sequence (over predictions) of sequence (over training rows) of importances
     */
-  def getImportanceScores(): Option[Seq[Seq[Double]]] = None
+  def importanceScores: Option[Seq[Seq[Double]]] = None
 
   /**
     * Get the improvement (positive) or damage (negative) due to each training row on a prediction
@@ -37,14 +37,14 @@ trait PredictionResult[+T] {
     * @param actuals to assess the improvement or damage against
     * @return Sequence (over predictions) of sequence (over training rows) of influence
     */
-  def getInfluenceScores(actuals: Seq[Any]): Option[Seq[Seq[Double]]] = None
+  def influenceScores(actuals: Seq[Any]): Option[Seq[Seq[Double]]] = None
 
   /**
     * Get the gradient or sensitivity of each prediction
     *
     * @return a vector of doubles for each prediction
     */
-  def getGradient(): Option[Seq[Vector[Double]]] = None
+  def gradient: Option[Seq[Vector[Double]]] = None
 }
 
 /**
@@ -69,7 +69,7 @@ trait RegressionResult extends PredictionResult[Double] {
     * This statistic is related to the https://en.wikipedia.org/wiki/Prediction_interval
     * It does not include estimated bias, even if the regression result contains a bias estimate.
     */
-  def getStdDevObs(): Option[Seq[Double]] = None
+  def stdDevObs: Option[Seq[Double]] = None
 
   /**
     * Get the expected error of the observations, if possible
@@ -78,7 +78,7 @@ trait RegressionResult extends PredictionResult[Double] {
     * This statistic includes the contribution of the estimated bias.  E.g., for a normal distribution of predicted
     * means, the total error is sqrt(bias**2 + variance).
     */
-  def getTotalErrorObs(): Option[Seq[Double]] = None
+  def totalErrorObs: Option[Seq[Double]] = None
 
   /**
     * Get a quantile from the distribution of predicted observations, if possible
@@ -90,7 +90,7 @@ trait RegressionResult extends PredictionResult[Double] {
     *
     * @param quantile to get, taken between 0.0 and 1.0 (i.e. not a percentile)
     */
-  def getTotalErrorQuantileObs(quantile: Double): Option[Seq[Double]] = None
+  def totalErrorQuantileObs(quantile: Double): Option[Seq[Double]] = None
 
   /**
     * Get the expected error of the predicted mean observations, if possible
@@ -101,7 +101,7 @@ trait RegressionResult extends PredictionResult[Double] {
     * This statistic includes the contribution of the estimated bias.  E.g., for a normal distribution of predicted
     * means, the total error is sqrt(bias**2 + variance)
     */
-  def getTotalError(): Option[Seq[Double]] = None
+  def totalError: Option[Seq[Double]] = None
 
   /**
     * Get a quantile from the distribution of predicted means, if possible
@@ -110,7 +110,7 @@ trait RegressionResult extends PredictionResult[Double] {
     * corrected.
     * @param quantile to get, taken between 0.0 and 1.0 (i.e. not a percentile)
     */
-  def getTotalErrorQuantile(quantile: Double): Option[Seq[Double]] = None
+  def totalErrorQuantile(quantile: Double): Option[Seq[Double]] = None
 
   /**
     * Get the standard deviation of the distribution of predicted mean observations, if possible
@@ -120,7 +120,7 @@ trait RegressionResult extends PredictionResult[Double] {
     * This statistic is related to the variance in the bias-variance trade-off
     * https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
     */
-  def getStdDevMean(): Option[Seq[Double]] = None
+  def stdDevMean: Option[Seq[Double]] = None
 
   /**
     * Get a quantile from the distribution of predicted means, if possible
@@ -128,18 +128,15 @@ trait RegressionResult extends PredictionResult[Double] {
     * The distribution for which these quantiles are computed should have zero-mean (i.e. no bias)
     * @param quantile to get, taken between 0.0 and 1.0 (i.e. not a percentile)
     */
-  def getQuantileMean(quantile: Double): Option[Seq[Double]] = None
+  def quantileMean(quantile: Double): Option[Seq[Double]] = None
 
   /**
-    * **EXPERIMENTAL** Get the estimated bias of each prediction, if possible
+    * Get the estimated bias of each prediction, if possible.
     *
     * The bias is signed and can be subtracted from the prediction to improve accuracy.
     * See https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
-    *
-    * It is unclear if this method will be a stable member of the interface.  It should be reviewed
-    * before the next formal release.
     */
-  def getBias(): Option[Seq[Double]] = None
+  def bias: Option[Seq[Double]] = None
 
   /**
     * Get the "uncertainty", which is the TotalError if non-observational and the StdDevObs if observational
@@ -147,19 +144,19 @@ trait RegressionResult extends PredictionResult[Double] {
     * @param observational whether the uncertainty should account for observational uncertainty
     * @return uncertainty of each prediction
     */
-  override def getUncertainty(observational: Boolean = true): Option[Seq[Any]] = {
+  override def uncertainty(observational: Boolean = true): Option[Seq[Any]] = {
     if (observational) {
-      getTotalErrorObs()
+      totalErrorObs
     } else {
-      getTotalError()
+      totalError
     }
   }
 
-  def getQuantile(quantile: Double, observational: Boolean = true): Option[Seq[Double]] = {
+  def quantile(quantile: Double, observational: Boolean = true): Option[Seq[Double]] = {
     if (observational) {
-      getTotalErrorQuantileObs(quantile)
+      totalErrorQuantileObs(quantile)
     } else {
-      getTotalErrorQuantile(quantile)
+      totalErrorQuantile(quantile)
     }
   }
 }
@@ -167,7 +164,7 @@ trait RegressionResult extends PredictionResult[Double] {
 /** Container for predictions made on multiple labels simultaneously. */
 trait MultiTaskModelPredictionResult extends PredictionResult[Vector[Any]] {
 
-  override def getUncertainty(observational: Boolean = true): Option[Seq[Seq[Any]]] = None
+  override def uncertainty(observational: Boolean = true): Option[Seq[Seq[Any]]] = None
 
   /**
     * Get the correlation coefficients between the predictions made on two labels.
@@ -179,10 +176,8 @@ trait MultiTaskModelPredictionResult extends PredictionResult[Vector[Any]] {
     * @param observational whether the uncertainty correlation should take observational noise into account
     * @return optional sequence of correlation coefficients between specified labels for each prediction
     */
-  def getUncertaintyCorrelation(i: Int, j: Int, observational: Boolean = true): Option[Seq[Double]] = None
+  def uncertaintyCorrelation(i: Int, j: Int, observational: Boolean = true): Option[Seq[Double]] = None
 }
 
 /** A container that holds the predictions of several parallel models for multiple labels. */
-case class ParallelModelsPredictionResult(predictions: Seq[Vector[Any]]) extends MultiTaskModelPredictionResult {
-  override def getExpected(): Seq[Vector[Any]] = predictions
-}
+case class ParallelModelsPredictionResult(expected: Seq[Vector[Any]]) extends MultiTaskModelPredictionResult

--- a/src/main/scala/io/citrine/lolo/TrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/TrainingResult.scala
@@ -7,34 +7,35 @@ trait TrainingResult[+T] extends Serializable {
     *
     * @return the model
     */
-  def getModel(): Model[T]
+  def model: Model[T]
 
   /**
     * Get a measure of the importance of the model features
     *
     * @return feature influences as an array of doubles
     */
-  def getFeatureImportance(): Option[Vector[Double]] = None
+  def featureImportance: Option[Vector[Double]] = None
 
   /**
     * Get a measure of the loss of the model, e.g. RMS OOB error
     *
     * @return
     */
-  def getLoss(): Option[Double] = None
+  def loss: Option[Double] = None
 
   /**
     * Get the predicted vs actual values, e.g. from OOB
     *
     * @return seq of (feature vector, predicted value, and actual value)
     */
-  def getPredictedVsActual(): Option[Seq[(Vector[Any], T, T)]] = None
+  def predictedVsActual: Option[Seq[(Vector[Any], T, T)]] = None
 }
 
 trait MultiTaskTrainingResult extends TrainingResult[Vector[Any]] {
-  override def getModel(): MultiTaskModel
 
-  def getModels(): Seq[Model[Any]]
+  def models: Seq[Model[Any]]
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Vector[Option[Any]], Vector[Option[Any]])]] = None
+  override def model: MultiTaskModel
+
+  override def predictedVsActual: Option[Seq[(Vector[Any], Vector[Option[Any]], Vector[Option[Any]])]] = None
 }

--- a/src/main/scala/io/citrine/lolo/bags/BaggedModel.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedModel.scala
@@ -41,7 +41,7 @@ case class BaggedRegressionModel(
   override def transform(inputs: Seq[Vector[Any]]): BaggedRegressionPrediction = {
     assert(inputs.forall(_.size == inputs.head.size))
 
-    val bias = biasModel.map(_.transform(inputs).getExpected())
+    val bias = biasModel.map(_.transform(inputs).expected)
     val ensemblePredictions = ensembleModels.map(model => model.transform(inputs)).seq
 
     if (inputs.size == 1) {

--- a/src/main/scala/io/citrine/lolo/bags/BaggedPrediction.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedPrediction.scala
@@ -184,17 +184,17 @@ case class MultiPointBaggedPrediction(
 
   override lazy val stdDevObs: Option[Seq[Double]] = Option.when(!disableBootstrap)(varObs.map(math.sqrt))
 
-  override lazy val stdDevMean: Option[Seq[Double]] = {
-    if (disableBootstrap) {
+  override lazy val stdDevMean: Option[Seq[Double]] = Option
+    .when(disableBootstrap) {
       // If bootstrap is disabled, rescale is unity and treeVariance is our only option for UQ.
       // Since it's not recalibrated, it's best considered to be a confidence interval of the underlying weak learner.
       assert(rescaleRatio == 1.0)
-      Some(varObs.map(math.sqrt))
-    } else {
+      varObs.map(math.sqrt)
+    }
+    .orElse {
       val std = variance(rawExpected.toVector, expectedMatrix, NibJMat, NibIJMat).map(math.sqrt)
       Some(std)
     }
-  }
 
   /**
     * Return IJ scores

--- a/src/main/scala/io/citrine/lolo/bags/BaggedTrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedTrainingResult.scala
@@ -8,7 +8,7 @@ import scala.collection.parallel.immutable.ParSeq
 /** The result of training a [[Bagger]] to produce a [[BaggedModel]]. */
 sealed trait BaggedTrainingResult[+T] extends TrainingResult[T] {
 
-  override def getModel(): BaggedModel[T]
+  override def model: BaggedModel[T]
 }
 
 case class RegressionBaggerTrainingResult(
@@ -35,20 +35,20 @@ case class RegressionBaggerTrainingResult(
       if (oob.isEmpty || l.isNaN) {
         Seq.empty
       } else {
-        val predicted = oob.map(_._1.transform(Seq(f)).getExpected().head).sum / oob.size
+        val predicted = oob.map(_._1.transform(Seq(f)).expected.head).sum / oob.size
         Seq((f, predicted, l))
       }
   }
 
   lazy val loss: Double = RegressionMetrics.RMSE(predictedVsActual)
 
-  override def getFeatureImportance(): Option[Vector[Double]] = featureImportance
+  override def featureImportance: Option[Vector[Double]] = featureImportance
 
-  override def getModel(): BaggedRegressionModel = model
+  override def model: BaggedRegressionModel = model
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Double, Double)]] = Some(predictedVsActual)
+  override def predictedVsActual: Option[Seq[(Vector[Any], Double, Double)]] = Some(predictedVsActual)
 
-  override def getLoss(): Option[Double] = {
+  override def loss: Option[Double] = {
     if (predictedVsActual.nonEmpty) {
       Some(loss)
     } else {
@@ -78,20 +78,20 @@ case class ClassificationBaggerTrainingResult[T](
       if (oob.isEmpty || l == null) {
         Seq()
       } else {
-        val predicted = oob.map(_._1.transform(Seq(f)).getExpected().head).groupBy(identity).maxBy(_._2.size)._1
+        val predicted = oob.map(_._1.transform(Seq(f)).expected.head).groupBy(identity).maxBy(_._2.size)._1
         Seq((f, predicted, l))
       }
   }
 
   lazy val loss: Double = ClassificationMetrics.loss(predictedVsActual)
 
-  override def getFeatureImportance(): Option[Vector[Double]] = featureImportance
+  override def featureImportance: Option[Vector[Double]] = featureImportance
 
-  override def getModel(): BaggedClassificationModel[T] = model
+  override def model: BaggedClassificationModel[T] = model
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], T, T)]] = Some(predictedVsActual)
+  override def predictedVsActual: Option[Seq[(Vector[Any], T, T)]] = Some(predictedVsActual)
 
-  override def getLoss(): Option[Double] = {
+  override def loss: Option[Double] = {
     if (predictedVsActual.nonEmpty) {
       Some(loss)
     } else {

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -64,7 +64,7 @@ sealed trait Bagger[T] extends Learner[T] {
             case (count, row) => row.mapWeight(_ * count.toDouble)
           }
           val meta = baseLearner.train(weightedTrainingData, thisRng)
-          (meta.getModel(), meta.getFeatureImportance())
+          (meta.model, meta.featureImportance)
       }
       .unzip
 
@@ -139,7 +139,7 @@ case class RegressionBagger(
     val helper = BaggerHelper(ensemble.models, trainingData, ensemble.Nib, useJackknife, uncertaintyCalibration)
     val biasModel = biasLearner.collect {
       case learner if helper.oobErrors.nonEmpty =>
-        learner.train(helper.biasTraining, rng = rng).getModel()
+        learner.train(helper.biasTraining, rng = rng).model
     }
 
     RegressionBaggerTrainingResult(

--- a/src/main/scala/io/citrine/lolo/bags/BaggerHelper.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggerHelper.scala
@@ -34,8 +34,8 @@ protected[bags] case class BaggerHelper(
     } else {
       val model = BaggedRegressionModel(oobModels, Nib.filter { _(idx) == 0 })
       val predicted = model.transform(Seq(trainingData(idx).inputs))
-      val error = predicted.getExpected().head - trainingData(idx).label
-      val uncertainty = predicted.getStdDevObs().get.head
+      val error = predicted.expected.head - trainingData(idx).label
+      val uncertainty = predicted.stdDevObs.get.head
       Some(trainingData(idx).inputs, error, uncertainty)
     }
   }

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -246,7 +246,7 @@ case class MultiTaskBaggedModel(
 
   override val numLabels: Int = ensembleModels.head.numLabels
 
-  lazy val groupedModels: Vector[BaggedModel[Any]] = Vector.tabulate(numLabels) { i =>
+  override lazy val models: Vector[BaggedModel[Any]] = Vector.tabulate(numLabels) { i =>
     val thisLabelsModels = ensembleModels.map(_.models(i))
     if (realLabels(i)) {
       BaggedRegressionModel(
@@ -261,11 +261,9 @@ case class MultiTaskBaggedModel(
   }
 
   override def transform(inputs: Seq[Vector[Any]]): MultiTaskBaggedPrediction =
-    MultiTaskBaggedPrediction(groupedModels.map(_.transform(inputs)), realLabels)
+    MultiTaskBaggedPrediction(models.map(_.transform(inputs)), realLabels)
 
   override def realLabels: Seq[Boolean] = ensembleModels.head.realLabels
-
-  override def models: Seq[BaggedModel[Any]] = groupedModels
 }
 
 /**

--- a/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
@@ -39,10 +39,10 @@ case class GridHyperOptimizer() extends HyperOptimizer {
       // Set up a learner with these parameters and compute the loss
       val testLearner = builder(testHypers)
       val res = testLearner.train(trainingData, rng = rng)
-      if (res.getLoss().isEmpty) {
+      if (res.loss.isEmpty) {
         throw new IllegalArgumentException("Trying to optimize hyper-parameters for a learner without getLoss")
       }
-      val thisLoss = res.getLoss().get
+      val thisLoss = res.loss.get
 
       /* Save if it is an improvement */
       if (thisLoss < loss) {

--- a/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
@@ -38,10 +38,10 @@ class RandomHyperOptimizer() extends HyperOptimizer {
       }
       val testLearner = builder(testHypers)
       val res = testLearner.train(trainingData, rng = rng)
-      if (res.getLoss().isEmpty) {
+      if (res.loss.isEmpty) {
         throw new IllegalArgumentException("Trying to optimize hyper-paramters for a learner without getLoss")
       }
-      val thisLoss = res.getLoss().get
+      val thisLoss = res.loss.get
       /* Keep track of the best */
       if (thisLoss < loss) {
         best = testHypers

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -12,23 +12,12 @@ case class GuessTheMeanLearner() extends Learner[Double] {
   }
 }
 
-case class GuessTheMeanTrainingResult(model: GuessTheMeanModel) extends TrainingResult[Double] {
-  override def getModel(): GuessTheMeanModel = model
-}
+case class GuessTheMeanTrainingResult(model: GuessTheMeanModel) extends TrainingResult[Double]
 
 case class GuessTheMeanModel(mean: Double) extends Model[Double] {
-
   def transform(inputs: Seq[Vector[Any]]): GuessTheMeanResult = {
     GuessTheMeanResult(Seq.fill(inputs.size)(mean))
   }
 }
 
-case class GuessTheMeanResult(result: Seq[Double]) extends PredictionResult[Double] {
-
-  /**
-    * Get the expected values for this prediction
-    *
-    * @return expected value of each prediction
-    */
-  override def getExpected(): Seq[Double] = result
-}
+case class GuessTheMeanResult(expected: Seq[Double]) extends PredictionResult[Double]

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMode.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMode.scala
@@ -14,23 +14,12 @@ case class GuessTheModeLearner[T]() extends Learner[T] {
   }
 }
 
-case class GuessTheModeTrainingResult[T](model: GuessTheModeModel[T]) extends TrainingResult[T] {
-  override def getModel(): Model[T] = model
-}
+case class GuessTheModeTrainingResult[T](model: GuessTheModeModel[T]) extends TrainingResult[T]
 
 case class GuessTheModeModel[T](mean: T) extends Model[T] {
-
   def transform(inputs: Seq[Vector[Any]]): GuessTheModeResult[T] = {
     GuessTheModeResult(Seq.fill(inputs.size)(mean))
   }
 }
 
-case class GuessTheModeResult[T](result: Seq[T]) extends PredictionResult[T] {
-
-  /**
-    * Get the expected values for this prediction
-    *
-    * @return expected value of each prediction
-    */
-  override def getExpected(): Seq[T] = result
-}
+case class GuessTheModeResult[T](expected: Seq[T]) extends PredictionResult[T]

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -114,14 +114,14 @@ case class LinearRegressionLearner(
   */
 case class LinearRegressionTrainingResult(model: LinearRegressionModel) extends TrainingResult[Double] {
 
-  override def getModel(): LinearRegressionModel = model
+  override def model: LinearRegressionModel = model
 
   /**
     * Get a measure of the importance of the model features
     *
     * @return feature influences as an array of doubles
     */
-  override def getFeatureImportance(): Option[Vector[Double]] = {
+  override def featureImportance: Option[Vector[Double]] = {
     val beta: Vector[Double] = model.getBeta().map(Math.abs)
     val renorm: Double = 1.0 / beta.sum
     Some(beta.map(_ * renorm))
@@ -190,12 +190,12 @@ case class LinearRegressionResult(values: Seq[Double], grad: Vector[Double]) ext
     *
     * @return expected value of each prediction
     */
-  override def getExpected(): Seq[Double] = values
+  override def expected: Seq[Double] = values
 
   /**
     * Get the gradient, which is uniform
     *
     * @return a vector of doubles for each prediction
     */
-  override def getGradient(): Option[Seq[Vector[Double]]] = Some(Seq.fill(values.size)(grad))
+  override def gradient: Option[Seq[Vector[Double]]] = Some(Seq.fill(values.size)(grad))
 }

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -120,9 +120,9 @@ case class LinearRegressionTrainingResult(model: LinearRegressionModel) extends 
     * @return feature influences as an array of doubles
     */
   override def featureImportance: Option[Vector[Double]] = {
-    val beta = model.beta.map(math.abs)
-    val renorm = 1.0 / beta.sum
-    Some(beta.map(_ * renorm))
+    val importance = model.beta.map(math.abs)
+    val renorm = 1.0 / importance.sum
+    Some(importance.map(_ * renorm))
   }
 }
 

--- a/src/main/scala/io/citrine/lolo/transformers/rotator/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/rotator/FeatureRotator.scala
@@ -51,14 +51,12 @@ case class RotatedFeatureTrainingResult[T](
     trans: DenseMatrix[Double]
 ) extends TrainingResult[T] {
 
-  override def getModel(): Model[T] = {
-    RotatedFeatureModel(baseTrainingResult.getModel(), rotatedFeatures, trans)
-  }
+  override def model: Model[T] = RotatedFeatureModel(baseTrainingResult.model, rotatedFeatures, trans)
 
-  override def getLoss(): Option[Double] = baseTrainingResult.getLoss()
+  override def loss: Option[Double] = baseTrainingResult.loss
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], T, T)]] = {
-    baseTrainingResult.getPredictedVsActual().map { x =>
+  override def predictedVsActual: Option[Seq[(Vector[Any], T, T)]] = {
+    baseTrainingResult.predictedVsActual.map { x =>
       x.map {
         case (v, e, a) => (FeatureRotator.applyOneRotation(v, rotatedFeatures, trans), e, a)
       }
@@ -111,17 +109,17 @@ case class RotatedFeaturePrediction[T](
     *
     * @return expected value of each prediction
     */
-  override def getExpected(): Seq[T] = baseResult.getExpected()
+  override def expected: Seq[T] = baseResult.expected
 
   /**
     * Get the uncertainty of the prediction by delegating to baseResult.
     *
     * @return uncertainty of each prediction
     */
-  override def getUncertainty(observational: Boolean): Option[Seq[Any]] = baseResult.getUncertainty(observational)
+  override def uncertainty(observational: Boolean): Option[Seq[Any]] = baseResult.uncertainty(observational)
 
-  override def getGradient(): Option[Seq[Vector[Double]]] = {
-    baseResult.getGradient().map { g =>
+  override def gradient: Option[Seq[Vector[Double]]] = {
+    baseResult.gradient.map { g =>
       FeatureRotator.applyRotation(g, rotatedFeatures, trans.t).asInstanceOf[Seq[Vector[Double]]]
     }
   }

--- a/src/main/scala/io/citrine/lolo/transformers/rotator/MultiTaskFeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/rotator/MultiTaskFeatureRotator.scala
@@ -44,15 +44,13 @@ case class MultiTaskRotatedFeatureTrainingResult(
     trans: DenseMatrix[Double]
 ) extends MultiTaskTrainingResult {
 
-  override def getModel(): MultiTaskModel = new ParallelModels(getModels(), baseTrainingResult.getModel().getRealLabels)
+  override def model: MultiTaskModel = ParallelModels(models, baseTrainingResult.model.realLabels)
 
-  override def getModels(): Seq[Model[Any]] =
-    baseTrainingResult.getModels().map { model =>
-      RotatedFeatureModel(model, rotatedFeatures, trans)
-    }
+  override def models: Seq[Model[Any]] =
+    baseTrainingResult.models.map { model => RotatedFeatureModel(model, rotatedFeatures, trans) }
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Vector[Option[Any]], Vector[Option[Any]])]] = {
-    baseTrainingResult.getPredictedVsActual().map { pva =>
+  override def predictedVsActual: Option[Seq[(Vector[Any], Vector[Option[Any]], Vector[Option[Any]])]] = {
+    baseTrainingResult.predictedVsActual.map { pva =>
       pva.map {
         case (inputs, predicted, actual) =>
           (FeatureRotator.applyOneRotation(inputs, rotatedFeatures, trans), predicted, actual)

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
@@ -40,12 +40,11 @@ case class MultiTaskStandardizerTrainingResult(
     inputTrans: Seq[Option[Standardization]]
 ) extends MultiTaskTrainingResult {
 
-  override def getModel(): MultiTaskModel =
-    new ParallelModels(getModels(), baseTrainingResult.getModel().getRealLabels)
+  override def model: MultiTaskModel = ParallelModels(models, baseTrainingResult.model.realLabels)
 
-  override def getModels(): Seq[StandardizerModel[Any]] = {
-    val realLabels = baseTrainingResult.getModel().getRealLabels
-    baseTrainingResult.getModels().zipWithIndex.map {
+  override def models: Seq[StandardizerModel[Any]] = {
+    val realLabels = baseTrainingResult.model.realLabels
+    baseTrainingResult.models.zipWithIndex.map {
       case (model, idx) =>
         if (realLabels(idx)) {
           RegressionStandardizerModel(model.asInstanceOf[Model[Double]], outputTrans(idx).get, inputTrans)
@@ -55,10 +54,10 @@ case class MultiTaskStandardizerTrainingResult(
     }
   }
 
-  override def getFeatureImportance(): Option[Vector[Double]] = baseTrainingResult.getFeatureImportance()
+  override def featureImportance: Option[Vector[Double]] = baseTrainingResult.featureImportance
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Vector[Option[Any]], Vector[Option[Any]])]] = {
-    baseTrainingResult.getPredictedVsActual().map { pva =>
+  override def predictedVsActual: Option[Seq[(Vector[Any], Vector[Option[Any]], Vector[Option[Any]])]] = {
+    baseTrainingResult.predictedVsActual.map { pva =>
       pva.map {
         case (inputs, predOpt, actualOpt) =>
           val invertedInputs = Standardization.invertMulti(inputs, inputTrans)

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerPrediction.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerPrediction.scala
@@ -14,17 +14,17 @@ case class RegressionStandardizerPrediction(
     inputTrans: Seq[Option[Standardization]]
 ) extends StandardizerPrediction[Double] {
 
-  override def getExpected(): Seq[Double] = basePrediction.getExpected().map(outputTrans.invert)
+  override def expected: Seq[Double] = basePrediction.expected.map(outputTrans.invert)
 
   // TODO: A PredictionResult[Double] should always return a Option[Seq[Double]] for uncertainty
-  override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
-    basePrediction.getUncertainty(includeNoise).map { x =>
+  override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
+    basePrediction.uncertainty(includeNoise).map { x =>
       x.map(_.asInstanceOf[Double] * outputTrans.scale)
     }
   }
 
-  override def getGradient(): Option[Seq[Vector[Double]]] = {
-    basePrediction.getGradient().map { gradients =>
+  override def gradient: Option[Seq[Vector[Double]]] = {
+    basePrediction.gradient.map { gradients =>
       gradients.map { g =>
         g.zip(inputTrans).map {
           case (y, inputStandardization) =>
@@ -44,13 +44,13 @@ case class ClassificationStandardizerPrediction[T](
     inputTrans: Seq[Option[Standardization]]
 ) extends StandardizerPrediction[T] {
 
-  override def getExpected(): Seq[T] = basePrediction.getExpected()
+  override def expected: Seq[T] = basePrediction.expected
 
-  override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] =
-    basePrediction.getUncertainty(includeNoise)
+  override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] =
+    basePrediction.uncertainty(includeNoise)
 
-  override def getGradient(): Option[Seq[Vector[Double]]] = {
-    basePrediction.getGradient().map { gradients =>
+  override def gradient: Option[Seq[Vector[Double]]] = {
+    basePrediction.gradient.map { gradients =>
       gradients.map { g =>
         g.zip(inputTrans).map {
           case (y, inputStandardization) =>

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerTrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerTrainingResult.scala
@@ -7,9 +7,9 @@ trait StandardizerTrainingResult[+T] extends TrainingResult[T] {
 
   def baseTrainingResult: TrainingResult[T]
 
-  override def getModel(): StandardizerModel[T]
+  override def model: StandardizerModel[T]
 
-  override def getFeatureImportance(): Option[Vector[Double]] = baseTrainingResult.getFeatureImportance()
+  override def featureImportance: Option[Vector[Double]] = baseTrainingResult.featureImportance
 }
 
 /**
@@ -25,11 +25,11 @@ case class RegressionStandardizerTrainingResult(
     inputTrans: Seq[Option[Standardization]]
 ) extends StandardizerTrainingResult[Double] {
 
-  override def getModel(): RegressionStandardizerModel =
-    RegressionStandardizerModel(baseTrainingResult.getModel(), outputTrans, inputTrans)
+  override def model: RegressionStandardizerModel =
+    RegressionStandardizerModel(baseTrainingResult.model, outputTrans, inputTrans)
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], Double, Double)]] = {
-    baseTrainingResult.getPredictedVsActual().map { pva =>
+  override def predictedVsActual: Option[Seq[(Vector[Any], Double, Double)]] = {
+    baseTrainingResult.predictedVsActual.map { pva =>
       pva.map {
         case (inputs, pred, actual) =>
           (Standardization.invertMulti(inputs, inputTrans), outputTrans.invert(pred), outputTrans.invert(actual))
@@ -49,11 +49,11 @@ case class ClassificationStandardizerTrainingResult[T](
     inputTrans: Seq[Option[Standardization]]
 ) extends StandardizerTrainingResult[T] {
 
-  override def getModel(): ClassificationStandardizerModel[T] =
-    ClassificationStandardizerModel(baseTrainingResult.getModel(), inputTrans)
+  override def model: ClassificationStandardizerModel[T] =
+    ClassificationStandardizerModel(baseTrainingResult.model, inputTrans)
 
-  override def getPredictedVsActual(): Option[Seq[(Vector[Any], T, T)]] = {
-    baseTrainingResult.getPredictedVsActual().map { pva =>
+  override def predictedVsActual: Option[Seq[(Vector[Any], T, T)]] = {
+    baseTrainingResult.predictedVsActual.map { pva =>
       pva.map {
         case (inputs, pred, actual) => (Standardization.invertMulti(inputs, inputTrans), pred, actual)
       }

--- a/src/main/scala/io/citrine/lolo/trees/ModelNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/ModelNode.scala
@@ -175,7 +175,7 @@ case class ModelLeaf[+T](model: Model[T], depth: Int, trainingWeight: Double) ex
     featureWeights.values.foreach { case FeatureWeightFactor(exclude, include) => set.extend(exclude, include) }
 
     // The contribution is proportional to the leaf's prediction, so grab that
-    this.model.transform(Seq(input)).getExpected().head match {
+    this.model.transform(Seq(input)).expected.head match {
       case v: Double =>
         // For each feature, compute the contribution and store it in shapValues
         featureWeights.foreach {

--- a/src/main/scala/io/citrine/lolo/trees/TrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/TrainingNode.scala
@@ -37,5 +37,5 @@ trait TrainingLeaf[+T] extends TrainingNode[T] {
 
   def modelNode: ModelNode[T] = ModelLeaf(model, depth, trainingData.map(_.weight).sum)
 
-  def model: Model[T] = trainingResult.getModel()
+  def model: Model[T] = trainingResult.model
 }

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -100,14 +100,14 @@ class ClassificationTrainingResult(
     }
   }
 
-  override def getModel(): ClassificationTree = model
+  override def model: ClassificationTree = model
 
   /**
     * Get a measure of the importance of the model features
     *
     * @return feature influences as an array of doubles
     */
-  override def getFeatureImportance(): Option[Vector[Double]] = Some(importanceNormalized.toVector)
+  override def featureImportance: Option[Vector[Double]] = Some(importanceNormalized.toVector)
 }
 
 /**
@@ -146,7 +146,7 @@ class ClassificationResult(
     *
     * @return expected value of each prediction
     */
-  override def getExpected(): Seq[Any] = predictions.map(p => outputEncoder.decode(p._1.getExpected().head))
+  override def expected: Seq[Any] = predictions.map(p => outputEncoder.decode(p._1.expected.head))
 
   def getDepth(): Seq[Int] = {
     predictions.map(_._2.depth)

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -112,21 +112,17 @@ case class MultiTaskTreeLearner(
 }
 
 class MultiTaskTreeTrainingResult(
-    models: Seq[Model[Any]],
-    featureImportance: Vector[Double]
+    override val models: Seq[Model[Any]],
+    nodeImportance: Vector[Double]
 ) extends MultiTaskTrainingResult {
-  val model = new ParallelModels(models, models.map(_.isInstanceOf[RegressionTree]))
-  private lazy val importanceNormalized = {
-    if (Math.abs(featureImportance.sum) > 0) {
-      featureImportance.map(_ / featureImportance.sum)
+
+  override val model: ParallelModels = ParallelModels(models, models.map(_.isInstanceOf[RegressionTree]))
+
+  override lazy val featureImportance: Option[Vector[Double]] = Some(
+    if (Math.abs(nodeImportance.sum) > 0) {
+      nodeImportance.map(_ / nodeImportance.sum)
     } else {
-      featureImportance.map(_ => 1.0 / featureImportance.size)
+      nodeImportance.map(_ => 1.0 / nodeImportance.size)
     }
-  }
-
-  override def model: ParallelModels = model
-
-  override def models: Seq[Model[Any]] = models
-
-  override def featureImportance: Option[Vector[Double]] = Some(importanceNormalized)
+  )
 }

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -124,9 +124,9 @@ class MultiTaskTreeTrainingResult(
     }
   }
 
-  override def getModel(): ParallelModels = model
+  override def model: ParallelModels = model
 
-  override def getModels(): Seq[Model[Any]] = models
+  override def models: Seq[Model[Any]] = models
 
-  override def getFeatureImportance(): Option[Vector[Double]] = Some(importanceNormalized)
+  override def featureImportance: Option[Vector[Double]] = Some(importanceNormalized)
 }

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -87,12 +87,12 @@ case class MultiTaskTreeLearner(
     // Stick the model trees into RegressionTree and ClassificationTree objects
     val models = labelIndices.map { i =>
       if (repOutput(i).isInstanceOf[Double]) {
-        new RegressionTree(
+        RegressionTree(
           nodes(i).asInstanceOf[ModelNode[Double]],
           inputEncoders
         )
       } else {
-        new ClassificationTree(
+        ClassificationTree(
           nodes(i).asInstanceOf[ModelNode[Char]],
           inputEncoders,
           outputEncoders(i).get
@@ -107,11 +107,11 @@ case class MultiTaskTreeLearner(
       }
     }
 
-    new MultiTaskTreeTrainingResult(models, sumFeatureImportance)
+    MultiTaskTreeTrainingResult(models, sumFeatureImportance)
   }
 }
 
-class MultiTaskTreeTrainingResult(
+case class MultiTaskTreeTrainingResult(
     override val models: Seq[Model[Any]],
     nodeImportance: Vector[Double]
 ) extends MultiTaskTrainingResult {

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
@@ -19,7 +19,7 @@ case class RegressionTrainingLeaf(
     * @return feature importance as a vector
     */
   override def featureImportance: mutable.ArraySeq[Double] = {
-    trainingResult.getFeatureImportance() match {
+    trainingResult.featureImportance match {
       case Some(x) =>
         // Compute the weighted sum of the label, the square label, and the weights
         val expectations: (Double, Double, Double) = trainingData

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -102,14 +102,14 @@ class RegressionTreeTrainingResult(
     }
   }
 
-  override def getModel(): RegressionTree = model
+  override def model: RegressionTree = model
 
   /**
     * Return the pre-computed influences
     *
     * @return feature influences as an array of doubles
     */
-  override def getFeatureImportance(): Option[Vector[Double]] = Some(importanceNormalized.toVector)
+  override def featureImportance: Option[Vector[Double]] = Some(importanceNormalized.toVector)
 }
 
 /**
@@ -162,18 +162,18 @@ class RegressionTreeResult(predictions: Seq[(PredictionResult[Double], TreeMeta)
     *
     * @return expected value of each prediction
     */
-  override def getExpected(): Seq[Double] = predictions.map(_._1.getExpected().head)
+  override def expected: Seq[Double] = predictions.map(_._1.expected.head)
 
   /**
     * Get the gradient or sensitivity of each prediction
     *
     * @return a vector of doubles for each prediction
     */
-  override def getGradient(): Option[Seq[Vector[Double]]] = {
-    if (predictions.head._1.getGradient().isEmpty) {
+  override def gradient: Option[Seq[Vector[Double]]] = {
+    if (predictions.head._1.gradient.isEmpty) {
       return None
     }
-    Some(predictions.map(_._1.getGradient().get.head))
+    Some(predictions.map(_._1.gradient.get.head))
   }
 
   def getDepth(): Seq[Int] = {

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -92,24 +92,18 @@ class RegressionTreeTrainingResult(
     rootTrainingNode: TrainingNode[Double],
     encoders: Seq[Option[CategoricalEncoder[Any]]]
 ) extends TrainingResult[Double] {
-  lazy val model = new RegressionTree(rootTrainingNode.modelNode, encoders)
-  lazy val importance: mutable.ArraySeq[Double] = rootTrainingNode.featureImportance
-  private lazy val importanceNormalized = {
-    if (Math.abs(importance.sum) > 0) {
-      importance.map(_ / importance.sum)
+
+  override lazy val model = new RegressionTree(rootTrainingNode.modelNode, encoders)
+
+  lazy val nodeImportance: mutable.ArraySeq[Double] = rootTrainingNode.featureImportance
+
+  override lazy val featureImportance: Option[Vector[Double]] = Some(
+    if (Math.abs(nodeImportance.sum) > 0) {
+      nodeImportance.map(_ / nodeImportance.sum).toVector
     } else {
-      importance.map(_ => 1.0 / importance.size)
+      nodeImportance.map(_ => 1.0 / nodeImportance.size).toVector
     }
-  }
-
-  override def model: RegressionTree = model
-
-  /**
-    * Return the pre-computed influences
-    *
-    * @return feature influences as an array of doubles
-    */
-  override def featureImportance: Option[Vector[Double]] = Some(importanceNormalized.toVector)
+  )
 }
 
 /**
@@ -176,7 +170,5 @@ class RegressionTreeResult(predictions: Seq[(PredictionResult[Double], TreeMeta)
     Some(predictions.map(_._1.gradient.get.head))
   }
 
-  def getDepth(): Seq[Int] = {
-    predictions.map(_._2.depth)
-  }
+  def depth: Seq[Int] = predictions.map(_._2.depth)
 }

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -83,17 +83,17 @@ case class RegressionTreeLearner(
       maxDepth = maxDepth,
       rng = rng
     )
-    new RegressionTreeTrainingResult(rootTrainingNode, encoders)
+    RegressionTreeTrainingResult(rootTrainingNode, encoders)
   }
 
 }
 
-class RegressionTreeTrainingResult(
+case class RegressionTreeTrainingResult(
     rootTrainingNode: TrainingNode[Double],
     encoders: Seq[Option[CategoricalEncoder[Any]]]
 ) extends TrainingResult[Double] {
 
-  override lazy val model = new RegressionTree(rootTrainingNode.modelNode, encoders)
+  override lazy val model: RegressionTree = RegressionTree(rootTrainingNode.modelNode, encoders)
 
   lazy val nodeImportance: mutable.ArraySeq[Double] = rootTrainingNode.featureImportance
 
@@ -112,7 +112,7 @@ class RegressionTreeTrainingResult(
   * @param root     of the tree
   * @param encoders for categorical variables
   */
-class RegressionTree(
+case class RegressionTree(
     root: ModelNode[Double],
     encoders: Seq[Option[CategoricalEncoder[Any]]]
 ) extends Model[Double] {
@@ -123,8 +123,8 @@ class RegressionTree(
     * @param inputs to apply the model to
     * @return a prediction result which includes only the expected outputs
     */
-  override def transform(inputs: Seq[Vector[Any]]): RegressionTreeResult = {
-    new RegressionTreeResult(
+  override def transform(inputs: Seq[Vector[Any]]): RegressionTreePrediction = {
+    RegressionTreePrediction(
       inputs.map(inp => root.transform(CategoricalEncoder.encodeInput(inp, encoders)))
     )
   }
@@ -149,7 +149,8 @@ class RegressionTree(
   *
   * @param predictions sequence of predictions
   */
-class RegressionTreeResult(predictions: Seq[(PredictionResult[Double], TreeMeta)]) extends PredictionResult[Double] {
+case class RegressionTreePrediction(predictions: Seq[(PredictionResult[Double], TreeMeta)])
+    extends PredictionResult[Double] {
 
   /**
     * Get the predictions

--- a/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
+++ b/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
@@ -76,7 +76,7 @@ object LoloPyDataLoader {
     * @return Byte array of doubles in native system order
     */
   def getRegressionExpected(predictionResult: PredictionResult[Any]): Array[Byte] = {
-    val predResults: Seq[Double] = predictionResult.getExpected().asInstanceOf[Seq[Double]]
+    val predResults: Seq[Double] = predictionResult.expected.asInstanceOf[Seq[Double]]
     send1DArray(predResults)
   }
 
@@ -86,7 +86,7 @@ object LoloPyDataLoader {
     * @return Byte array of doubles in native system order (the caller must then reshape the result into a 2d array)
     */
   def getMultiRegressionExpected(predictionResult: MultiTaskModelPredictionResult): Array[Byte] = {
-    val predResults = predictionResult.getExpected().asInstanceOf[Seq[Seq[Double]]].flatten
+    val predResults = predictionResult.expected.asInstanceOf[Seq[Seq[Double]]].flatten
     send1DArray(predResults)
   }
 
@@ -96,7 +96,7 @@ object LoloPyDataLoader {
     * @return Byte of array of doubles in native system order
     */
   def getImportanceScores(predictionResult: PredictionResult[Any]): Array[Byte] = {
-    send1DArray(predictionResult.getImportanceScores().get.flatten)
+    send1DArray(predictionResult.importanceScores.get.flatten)
   }
 
   /**
@@ -105,7 +105,7 @@ object LoloPyDataLoader {
     * @return Byte array of doubles in native system order
     */
   def getRegressionUncertainty(predictionResult: PredictionResult[Any]): Array[Byte] = {
-    val predResults: Seq[Double] = predictionResult.getUncertainty().get.asInstanceOf[Seq[Double]]
+    val predResults: Seq[Double] = predictionResult.uncertainty().get.asInstanceOf[Seq[Double]]
     send1DArray(predResults)
   }
 
@@ -115,7 +115,7 @@ object LoloPyDataLoader {
     * @return Byte array of doubles in native system order (the caller must then reshape the result into a 2d array)
     */
   def getMultiRegressionUncertainty(predictionResult: MultiTaskModelPredictionResult): Array[Byte] = {
-    val uncertaintyResults = predictionResult.getUncertainty().get.asInstanceOf[Seq[Seq[Double]]].flatten
+    val uncertaintyResults = predictionResult.uncertainty().get.asInstanceOf[Seq[Seq[Double]]].flatten
     send1DArray(uncertaintyResults)
   }
 
@@ -130,7 +130,7 @@ object LoloPyDataLoader {
     * @return Byte array of doubles in native system order
     */
   def getRegressionCorrelation(predictionResult: MultiTaskModelPredictionResult, i: Int, j: Int): Array[Byte] = {
-    val correlationResults = predictionResult.getUncertaintyCorrelation(i, j).get
+    val correlationResults = predictionResult.uncertaintyCorrelation(i, j).get
     send1DArray(correlationResults)
   }
 
@@ -154,7 +154,7 @@ object LoloPyDataLoader {
     * @return Bytes of a integer array of the predicted class labels
     */
   def getClassifierExpected(predictionResult: PredictionResult[Any]): Array[Byte] = {
-    val expect = predictionResult.getExpected().asInstanceOf[Seq[Int]]
+    val expect = predictionResult.expected.asInstanceOf[Seq[Int]]
     val buffer = ByteBuffer.allocate(expect.length * 4).order(ByteOrder.nativeOrder())
     expect.foreach(buffer.putInt)
     buffer.array
@@ -173,7 +173,7 @@ object LoloPyDataLoader {
     // Get an iterator over the number of classes
     val classes = 0 until nClasses
     val probs = predictionResult
-      .getUncertainty()
+      .uncertainty()
       .get
       .asInstanceOf[Seq[Map[Int, Double]]]
       .map(x => classes.map(i => x.getOrElse(i, 0.0)))
@@ -223,8 +223,8 @@ object LoloPyDataLoader {
     */
   def makeRegressionPredictionResult(expected: Seq[Double], uncertainty: Seq[Double]): PredictionResult[Double] = {
     new PredictionResult[Double] {
-      override def getExpected(): Seq[Double] = expected
-      override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(uncertainty)
+      override def expected: Seq[Double] = expected
+      override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(uncertainty)
     }
   }
 }

--- a/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
+++ b/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
@@ -217,14 +217,17 @@ object LoloPyDataLoader {
 
   /**
     * Create a PredictionResult object from the mean and uncertainty
-    * @param expected Mean of the predictions of a model
-    * @param uncertainty Uncertainty of the predictions
+    * @param thisExpected    Mean of the predictions of a model
+    * @param thisUncertainty Uncertainty of the predictions
     * @return Prediction result object
     */
-  def makeRegressionPredictionResult(expected: Seq[Double], uncertainty: Seq[Double]): PredictionResult[Double] = {
+  def makeRegressionPredictionResult(
+      thisExpected: Seq[Double],
+      thisUncertainty: Seq[Double]
+  ): PredictionResult[Double] = {
     new PredictionResult[Double] {
-      override def expected: Seq[Double] = expected
-      override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(uncertainty)
+      override def expected: Seq[Double] = thisExpected
+      override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(thisUncertainty)
     }
   }
 }

--- a/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
@@ -60,7 +60,7 @@ case object CrossValidation {
         val (testFolds, trainFolds) = folds.zipWithIndex.partition(_._2 == idx)
         val testData = testFolds.flatMap(_._1)
         val trainData = trainFolds.flatMap(_._1)
-        val model = learner.train(trainData, rng = rng).getModel()
+        val model = learner.train(trainData, rng = rng).model
         val predictions: PredictionResult[T] = model.transform(testData.map(_.inputs))
         (predictions, testData.map(_.label))
       }

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -43,8 +43,7 @@ case object RootMeanSquareError extends Merit[Double] {
       rng: Random = Random()
   ): Double = {
     Math.sqrt(
-      predictionResult
-        .expected
+      predictionResult.expected
         .zip(actual)
         .map {
           case (x, y) => Math.pow(x - y, 2)
@@ -122,8 +121,7 @@ case object UncertaintyCorrelation extends Merit[Double] {
       actual: Seq[Double],
       rng: Random = Random()
   ): Double = {
-    val predictedUncertaintyActual: Seq[(Double, Double, Double)] = predictionResult
-      .expected
+    val predictedUncertaintyActual: Seq[(Double, Double, Double)] = predictionResult.expected
       .lazyZip(predictionResult.uncertainty().get.asInstanceOf[Seq[Double]])
       .lazyZip(actual)
       .toSeq

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -44,12 +44,12 @@ case object RootMeanSquareError extends Merit[Double] {
   ): Double = {
     Math.sqrt(
       predictionResult
-        .getExpected()
+        .expected
         .zip(actual)
         .map {
           case (x, y) => Math.pow(x - y, 2)
         }
-        .sum / predictionResult.getExpected().size
+        .sum / predictionResult.expected.size
     )
   }
 }
@@ -65,7 +65,7 @@ case object CoefficientOfDetermination extends Merit[Double] {
   ): Double = {
     val averageActual = actual.sum / actual.size
     val sumOfSquares = actual.map(x => Math.pow(x - averageActual, 2)).sum
-    val sumOfResiduals = predictionResult.getExpected().zip(actual).map { case (x, y) => Math.pow(x - y, 2.0) }.sum
+    val sumOfResiduals = predictionResult.expected.zip(actual).map { case (x, y) => Math.pow(x - y, 2.0) }.sum
     1.0 - sumOfResiduals / sumOfSquares
   }
 }
@@ -79,11 +79,11 @@ case object StandardConfidence extends Merit[Double] {
       actual: Seq[Double],
       rng: Random = Random()
   ): Double = {
-    if (predictionResult.getUncertainty().isEmpty) return 0.0
+    if (predictionResult.uncertainty().isEmpty) return 0.0
 
-    predictionResult.getExpected().lazyZip(predictionResult.getUncertainty().get).lazyZip(actual).count {
+    predictionResult.expected.lazyZip(predictionResult.uncertainty().get).lazyZip(actual).count {
       case (x, sigma: Double, y) => Math.abs(x - y) < sigma
-    } / predictionResult.getExpected().size.toDouble
+    } / predictionResult.expected.size.toDouble
   }
 }
 
@@ -96,9 +96,9 @@ case class StandardError(rescale: Double = 1.0) extends Merit[Double] {
       actual: Seq[Double],
       rng: Random = Random()
   ): Double = {
-    if (predictionResult.getUncertainty().isEmpty) return Double.PositiveInfinity
+    if (predictionResult.uncertainty().isEmpty) return Double.PositiveInfinity
     val standardized =
-      predictionResult.getExpected().lazyZip(predictionResult.getUncertainty().get).lazyZip(actual).map {
+      predictionResult.expected.lazyZip(predictionResult.uncertainty().get).lazyZip(actual).map {
         case (x, sigma: Double, y) => (x - y) / sigma
       }
     rescale * Math.sqrt(standardized.map(Math.pow(_, 2.0)).sum / standardized.size)
@@ -123,8 +123,8 @@ case object UncertaintyCorrelation extends Merit[Double] {
       rng: Random = Random()
   ): Double = {
     val predictedUncertaintyActual: Seq[(Double, Double, Double)] = predictionResult
-      .getExpected()
-      .lazyZip(predictionResult.getUncertainty().get.asInstanceOf[Seq[Double]])
+      .expected
+      .lazyZip(predictionResult.uncertainty().get.asInstanceOf[Seq[Double]])
       .lazyZip(actual)
       .toSeq
 

--- a/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
@@ -37,7 +37,7 @@ case class StatisticalValidation() {
   ): Iterator[(PredictionResult[T], Seq[T])] = {
     Iterator.tabulate(nRound) { _ =>
       val trainingData = source.take(nTrain).toSeq
-      val model = learner.train(trainingData, rng = rng).getModel()
+      val model = learner.train(trainingData, rng = rng).model
       val testData = source.take(nTest).toSeq
       val predictions: PredictionResult[T] = model.transform(testData.map(_.inputs))
       (predictions, testData.map(_.label))
@@ -74,7 +74,7 @@ case class StatisticalValidation() {
     Iterator.tabulate(nRound) { _ =>
       val subset = rng.shuffle(source).take(nTrain + nTest)
       val (trainingData, testData) = subset.toVector.splitAt(nTrain)
-      val model = learner.train(trainingData, rng = rng).getModel()
+      val model = learner.train(trainingData, rng = rng).model
       val predictions: PredictionResult[T] = model.transform(testData.map(_.inputs))
       (predictions, testData.map(_.label))
     }

--- a/src/main/scala/io/citrine/lolo/validation/Visualization.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Visualization.scala
@@ -39,8 +39,7 @@ case class StandardResidualHistogram(
   override def visualize(data: Iterable[(PredictionResult[Double], Seq[Double])]): CategoryChart = {
     val pua: Seq[(Double, Double, Double)] = data.flatMap {
       case (predictions, actual) =>
-        predictions
-          .expected
+        predictions.expected
           .lazyZip(predictions.uncertainty().get.asInstanceOf[Seq[Double]])
           .lazyZip(actual)
           .toSeq

--- a/src/main/scala/io/citrine/lolo/validation/Visualization.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Visualization.scala
@@ -40,8 +40,8 @@ case class StandardResidualHistogram(
     val pua: Seq[(Double, Double, Double)] = data.flatMap {
       case (predictions, actual) =>
         predictions
-          .getExpected()
-          .lazyZip(predictions.getUncertainty().get.asInstanceOf[Seq[Double]])
+          .expected
+          .lazyZip(predictions.uncertainty().get.asInstanceOf[Seq[Double]])
           .lazyZip(actual)
           .toSeq
     }.toSeq
@@ -90,7 +90,7 @@ case class PredictedVsActual() extends Visualization[Double] {
 
     val flattened: Iterable[(Double, Double, Double)] = data.flatMap {
       case (pred, actual: Seq[Double]) =>
-        actual.lazyZip(pred.getExpected()).lazyZip(pred.getUncertainty().get.asInstanceOf[Seq[Double]]).toSeq
+        actual.lazyZip(pred.expected).lazyZip(pred.uncertainty().get.asInstanceOf[Seq[Double]]).toSeq
     }
 
     val actual = flattened.map(_._1).toArray
@@ -123,8 +123,8 @@ case class ErrorVsUncertainty(magnitude: Boolean = true) extends Visualization[D
 
     val flattened: Iterable[(Double, Double)] = data.flatMap {
       case (pred, actual: Seq[Double]) =>
-        val sigmas = pred.getUncertainty().get.asInstanceOf[Seq[Double]]
-        val errors = actual.zip(pred.getExpected()).map {
+        val sigmas = pred.uncertainty().get.asInstanceOf[Seq[Double]]
+        val errors = actual.zip(pred.expected).map {
           case (x, y) if magnitude => Math.abs(x - y)
           case (x, y)              => y - x
         }

--- a/src/test/scala/io/citrine/lolo/AccuracyTest.scala
+++ b/src/test/scala/io/citrine/lolo/AccuracyTest.scala
@@ -22,7 +22,7 @@ class AccuracyTest extends SeedRandomMixIn {
 
   // Get the out-of-bag RMSE
   private def computeMetrics(learner: Learner[Double], rng: Random): Double = {
-    learner.train(trainingData, rng = rng).getLoss().get
+    learner.train(trainingData, rng = rng).loss.get
   }
 
   /**
@@ -108,11 +108,11 @@ object AccuracyTest extends SeedRandomMixIn {
       minLeafInstances = minInstances
     )
     val learner = RegressionBagger(baseLearner, numBags = nRow * nScal, biasLearner = None)
-    val model = learner.train(trainingData, rng = rng).getModel()
+    val model = learner.train(trainingData, rng = rng).model
     val (features, labels) = trainingData.map(row => (row.inputs, row.label)).unzip
     val predictions = model.transform(features)
-    val expected = predictions.getExpected()
-    val sigma = predictions.getUncertainty().get.asInstanceOf[Seq[Double]]
+    val expected = predictions.expected
+    val sigma = predictions.uncertainty().get.asInstanceOf[Seq[Double]]
     val pva: Seq[(Double, Double, Double)] = labels.indices.map { i =>
       (labels(i), expected(i), sigma(i))
     }

--- a/src/test/scala/io/citrine/lolo/DataGenerator.scala
+++ b/src/test/scala/io/citrine/lolo/DataGenerator.scala
@@ -104,8 +104,8 @@ object DataGenerator {
     require(rho >= -1.0 && rho <= 1.0, "correlation coefficient must be between -1.0 and 1.0")
     val Y = Seq.fill(X.length)(rng.nextGaussian())
     val linearLearner = LinearRegressionLearner()
-    val linearModel = linearLearner.train(X.zip(Y).map { case (x, y) => TrainingRow(Vector(x), y) }).getModel()
-    val yPred = linearModel.transform(X.map(Vector(_))).getExpected()
+    val linearModel = linearLearner.train(X.zip(Y).map { case (x, y) => TrainingRow(Vector(x), y) }).model
+    val yPred = linearModel.transform(X.map(Vector(_))).expected
     val residuals = Y.zip(yPred).map { case (actual, predicted) => actual - predicted }
     val stdX = math.sqrt(variance(X))
     val stdResiduals = math.sqrt(variance(residuals))

--- a/src/test/scala/io/citrine/lolo/PerformanceTest.scala
+++ b/src/test/scala/io/citrine/lolo/PerformanceTest.scala
@@ -25,18 +25,18 @@ class PerformanceTest extends SeedRandomMixIn {
     val inputs = trainingData.map(_.inputs)
     val timeTraining = Stopwatch.time(
       {
-        bagger.train(trainingData).getModel()
+        bagger.train(trainingData).model
       },
       benchmark = "None",
       minRun = 4,
       targetError = 0.1,
       maxRun = 32
     )
-    val model = bagger.train(trainingData).getModel()
+    val model = bagger.train(trainingData).model
 
     val timePredicting = Stopwatch.time(
       {
-        model.transform(inputs).getUncertainty()
+        model.transform(inputs).uncertainty()
       },
       benchmark = "None",
       minRun = 4,
@@ -124,8 +124,8 @@ class PerformanceTest extends SeedRandomMixIn {
 
     val trainSingle: Double = Stopwatch.time(
       {
-        RegressionBagger(RegressionTreeLearner()).train(realRows).getLoss()
-        ClassificationBagger(ClassificationTreeLearner()).train(catRows).getLoss()
+        RegressionBagger(RegressionTreeLearner()).train(realRows).loss
+        ClassificationBagger(ClassificationTreeLearner()).train(catRows).loss
       },
       minRun = 1,
       maxRun = 1
@@ -133,7 +133,7 @@ class PerformanceTest extends SeedRandomMixIn {
 
     val trainMulti: Double = Stopwatch.time(
       {
-        MultiTaskBagger(MultiTaskTreeLearner()).train(multiRows, rng = rng).getLoss()
+        MultiTaskBagger(MultiTaskTreeLearner()).train(multiRows, rng = rng).loss
       },
       minRun = 1,
       maxRun = 1

--- a/src/test/scala/io/citrine/lolo/bags/BaggedPredictionTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedPredictionTest.scala
@@ -50,7 +50,7 @@ class BaggedPredictionTest extends SeedRandomMixIn {
         useJackknife = false
       )
     ).foreach { bagger =>
-      testConsistency(trainingData, bagger.train(trainingData, rng = rng).getModel())
+      testConsistency(trainingData, bagger.train(trainingData, rng = rng).model)
     }
   }
 
@@ -78,17 +78,17 @@ class BaggedPredictionTest extends SeedRandomMixIn {
               }
               val baggedLearner = RegressionBagger(baseLearner, numBags = nBags, uncertaintyCalibration = true)
               val RFMeta = baggedLearner.train(trainingData, rng = rng)
-              val RF = RFMeta.getModel()
+              val RF = RFMeta.model
               val results = RF.transform(trainingData.take(4).map(_.inputs))
 
-              val sigmaMean: Seq[Double] = results.getUncertainty(observational = false).get.asInstanceOf[Seq[Double]]
-              sigmaMean.zip(results.asInstanceOf[RegressionResult].getStdDevMean().get).foreach {
+              val sigmaMean: Seq[Double] = results.uncertainty(observational = false).get.asInstanceOf[Seq[Double]]
+              sigmaMean.zip(results.asInstanceOf[RegressionResult].stdDevMean.get).foreach {
                 case (a, b) =>
                   assert(a == b, s"Expected getUncertainty(observational=false)=getStdDevMean() for $configDescription")
               }
 
-              val sigmaObs: Seq[Double] = results.getUncertainty().get.asInstanceOf[Seq[Double]]
-              sigmaObs.zip(results.asInstanceOf[RegressionResult].getStdDevObs().get).foreach {
+              val sigmaObs: Seq[Double] = results.uncertainty().get.asInstanceOf[Seq[Double]]
+              sigmaObs.zip(results.asInstanceOf[RegressionResult].stdDevObs.get).foreach {
                 case (a, b) =>
                   assert(a == b, s"Expected getUncertainty()=getStdDevObs() for $configDescription")
               }
@@ -175,18 +175,18 @@ class BaggedPredictionTest extends SeedRandomMixIn {
       case TrainingRow(x, _, _) =>
         val res = model.transform(Seq(x))
         (
-          res.getExpected().head,
-          res.getUncertainty(true).get.head.asInstanceOf[Double],
-          res.getUncertainty(false).get.head.asInstanceOf[Double]
+          res.expected.head,
+          res.uncertainty(true).get.head.asInstanceOf[Double],
+          res.uncertainty(false).get.head.asInstanceOf[Double]
         )
     }.unzip3
 
     val (multiValues, multiObsUnc, multiMeanUnc) = {
       val res = model.transform(testSubset.map(_.inputs))
       (
-        res.getExpected(),
-        res.getUncertainty(true).get.map(_.asInstanceOf[Double]),
-        res.getUncertainty(false).get.map(_.asInstanceOf[Double])
+        res.expected,
+        res.uncertainty(true).get.map(_.asInstanceOf[Double]),
+        res.uncertainty(false).get.map(_.asInstanceOf[Double])
       )
     }
 

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -290,7 +290,7 @@ class BaggerTest extends SeedRandomMixIn {
         disableBootstrap = true
       )
         .train(trainingData, rng = rng)
-        .model()
+        .model
       fail("Setting both uncertaintyCalibration and disableBootstrap should throw an exception.")
     } catch {
       case _: Throwable =>
@@ -312,9 +312,9 @@ class BaggerTest extends SeedRandomMixIn {
       val DTLearner = RegressionTreeLearner(numFeatures = 2)
       val sigma = RegressionBagger(DTLearner, numBags = 7)
         .train(trainingData, rng = rng)
-        .model()
+        .model
         .transform(trainingData.map(_.inputs))
-        .getUncertainty()
+        .uncertainty()
         .get
         .asInstanceOf[Seq[Double]]
       assert(sigma.forall(_ > 0.0), s"Found an predicted uncertainty of ${sigma.min} during trial $idx")
@@ -338,9 +338,9 @@ class BaggerTest extends SeedRandomMixIn {
         biasLearner = Some(GuessTheMeanLearner())
       )
         .train(trainingData, rng = rng)
-        .model()
+        .model
         .transform(trainingData.map(_.inputs))
-        .getUncertainty()
+        .uncertainty()
         .get
         .asInstanceOf[Seq[Double]]
       assert(sigma.forall(_ > 0.0), s"Found an predicted uncertainty of ${sigma.min} during trial $idx")
@@ -356,7 +356,7 @@ class BaggerTest extends SeedRandomMixIn {
     val trainingData =
       DataGenerator.generate(64, nCols, noise = 0.0, function = Friedman.friedmanSilverman, rng = rng).data
     val DTLearner = RegressionTreeLearner(numFeatures = nCols)
-    val model = RegressionBagger(DTLearner).train(trainingData, rng = rng).model()
+    val model = RegressionBagger(DTLearner).train(trainingData, rng = rng).model
     val trees = model.ensembleModels
     trainingData.foreach {
       case TrainingRow(x, _, _) =>
@@ -393,7 +393,7 @@ class BaggerTest extends SeedRandomMixIn {
     val learner = FeatureRotator(RegressionTreeLearner(numFeatures = nCols))
     val model = RegressionBagger(learner)
       .train(trainingData, rng = rng)
-      .model()
+      .model
 
     val x = trainingData.head.inputs
     assert(model.shapley(x).isEmpty)
@@ -430,7 +430,7 @@ object BaggerTest extends SeedRandomMixIn {
           println(s"Training model nCols=$nCols\tnRows=$nRows\trepNum=$repNum")
           val model = RegressionBagger(DTLearner)
             .train(trainingData, rng = rng)
-            .model()
+            .model
           println(s"Trained")
 
           rng.shuffle(trainingData).take(16).zipWithIndex.foreach {

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -452,8 +452,7 @@ object BaggerTest extends SeedRandomMixIn {
     val pva = testSet
       .map(_._2)
       .zip(
-        predictions
-          .expected
+        predictions.expected
           .asInstanceOf[Seq[Double]]
           .zip(
             predictions.uncertainty().get.asInstanceOf[Seq[Double]]

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -319,8 +319,7 @@ class MultiTaskBaggerTest extends SeedRandomMixIn {
     val referenceRows = TrainingRow.build(inputs.zip(sparseCat)).filterNot(_.label == null)
     val referenceModel = ClassificationBagger(ClassificationTreeLearner(), numBags = inputs.size)
       .train(referenceRows, rng = rng)
-    val reference = referenceModel
-      .model
+    val reference = referenceModel.model
       .transform(inputs)
       .expected
 

--- a/src/test/scala/io/citrine/lolo/learners/ExtraRandomTreesTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/ExtraRandomTreesTest.scala
@@ -30,7 +30,7 @@ class ExtraRandomTreesTest extends SeedRandomMixIn {
       assert(0 <= loss && loss < 1e-8, "Expected zero loss.")
 
       val results = RF.transform(trainingData.map(_.inputs))
-      // val means = results.getExpected()
+      // val means = results.expected
       val sigma: Seq[Double] = results.uncertainty(observational = false).get.asInstanceOf[Seq[Double]]
       assert(sigma.forall(_ >= 0.0))
 

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -31,7 +31,7 @@ class RandomForestTest extends SeedRandomMixIn {
       assert(RFMeta.loss.get < 1.0, "Loss of bagger is larger than expected")
 
       val results = RF.transform(trainingData.map(_.inputs))
-      // val means = results.getExpected()
+      // val means = results.expected
       val sigma: Seq[Double] = results.uncertainty().get.asInstanceOf[Seq[Double]]
       assert(sigma.forall(_ >= 0.0))
 

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -26,20 +26,20 @@ class RandomForestTest extends SeedRandomMixIn {
     Seq(true, false).foreach { randomlyRotateFeatures =>
       val RFMeta = RandomForestRegressor(randomlyRotateFeatures = randomlyRotateFeatures)
         .train(trainingData)
-      val RF = RFMeta.getModel()
+      val RF = RFMeta.model
 
-      assert(RFMeta.getLoss().get < 1.0, "Loss of bagger is larger than expected")
+      assert(RFMeta.loss.get < 1.0, "Loss of bagger is larger than expected")
 
       val results = RF.transform(trainingData.map(_.inputs))
       // val means = results.getExpected()
-      val sigma: Seq[Double] = results.getUncertainty().get.asInstanceOf[Seq[Double]]
+      val sigma: Seq[Double] = results.uncertainty().get.asInstanceOf[Seq[Double]]
       assert(sigma.forall(_ >= 0.0))
 
-      assert(results.getGradient().isEmpty, "Returned a gradient when there shouldn't be one")
+      assert(results.gradient.isEmpty, "Returned a gradient when there shouldn't be one")
 
       if (!randomlyRotateFeatures) {
         /* The first feature should be the most important */
-        val importances = RFMeta.getFeatureImportance().get
+        val importances = RFMeta.featureImportance.get
         assert(importances(1) == importances.max)
       }
     }
@@ -61,11 +61,11 @@ class RandomForestTest extends SeedRandomMixIn {
     val multiTaskRows = TrainingRow.build(inputs.zip(allLabels))
 
     val RFMeta = MultiTaskRandomForest().train(multiTaskRows, rng = rng)
-    val model = RFMeta.getModel()
+    val model = RFMeta.model
 
     val results = model.transform(inputs).asInstanceOf[MultiTaskBaggedPrediction]
-    assert(results.getUncertainty().isDefined)
-    assert(results.getUncertaintyCorrelation(0, 2).isDefined)
+    assert(results.uncertainty().isDefined)
+    assert(results.uncertaintyCorrelation(0, 2).isDefined)
   }
 
   /**
@@ -83,14 +83,14 @@ class RandomForestTest extends SeedRandomMixIn {
       val RFMeta =
         RandomForestClassifier(numTrees = trainingData.size * 2, randomlyRotateFeatures = randomlyRotateFeatures)
           .train(trainingData, rng = rng)
-      val RF = RFMeta.getModel()
+      val RF = RFMeta.model
 
       /* Inspect the results */
       val results = RF.transform(trainingData.map(_.inputs))
-      val means = results.getExpected()
+      val means = results.expected
       assert(trainingData.map(_.label).zip(means).forall { case (a, p) => a == p })
 
-      val uncertainty = results.getUncertainty()
+      val uncertainty = results.uncertainty()
       assert(uncertainty.isDefined)
       assert(trainingData.map(_.label).zip(uncertainty.get).forall {
         case (a, probs) =>
@@ -110,11 +110,11 @@ class RandomForestTest extends SeedRandomMixIn {
         testInputs: Seq[Vector[Any]],
         seed: Long
     ): Unit = {
-      val model1 = learner.train(trainingData, rng = Random(seed)).getModel()
-      val model2 = learner.train(trainingData, rng = Random(seed)).getModel()
+      val model1 = learner.train(trainingData, rng = Random(seed)).model
+      val model2 = learner.train(trainingData, rng = Random(seed)).model
       val predictions1 = model1.transform(testInputs)
       val predictions2 = model2.transform(testInputs)
-      assert(predictions1.getExpected() == predictions2.getExpected())
+      assert(predictions1.expected == predictions2.expected)
     }
 
     val numTrain = 50
@@ -179,10 +179,10 @@ class RandomForestTest extends SeedRandomMixIn {
           RandomForestClassifier(numTrees = trainingDataSuffixed.size * 2).train(trainingDataSuffixed, rng = rng)
         val RFPrefixed =
           RandomForestClassifier(numTrees = trainingDataPrefixed.size * 2).train(trainingDataPrefixed, rng = rng)
-        val predictedSuffixed = RFSuffixed.getModel().transform(mainTrainingData.map(_.inputs))
-        val predictedPrefixed = RFPrefixed.getModel().transform(mainTrainingData.map(_.inputs))
-        val extraLabelCountSuffixed = predictedSuffixed.getExpected().count { case p: String => p == dupeLabel }
-        val extraLabelCountPrefixed = predictedPrefixed.getExpected().count { case p: String => p == dupeLabel }
+        val predictedSuffixed = RFSuffixed.model.transform(mainTrainingData.map(_.inputs))
+        val predictedPrefixed = RFPrefixed.model.transform(mainTrainingData.map(_.inputs))
+        val extraLabelCountSuffixed = predictedSuffixed.expected.count { case p: String => p == dupeLabel }
+        val extraLabelCountPrefixed = predictedPrefixed.expected.count { case p: String => p == dupeLabel }
 
         if (extraLabelCountSuffixed > extraLabelCountPrefixed) {
           (1, 0)
@@ -228,14 +228,14 @@ class RandomForestTest extends SeedRandomMixIn {
     val lossWithoutRandomization: Double = baseForest
       .copy(randomizePivotLocation = false)
       .train(trainingData, rng = rng)
-      .getLoss()
+      .loss
       .get
 
     // Turn on split randomization and compute the loss (out-of-bag error)
     val lossWithRandomization: Double = baseForest
       .copy(randomizePivotLocation = true)
       .train(trainingData, rng = rng)
-      .getLoss()
+      .loss
       .get
 
     assert(lossWithRandomization < lossWithoutRandomization)
@@ -251,7 +251,7 @@ class RandomForestTest extends SeedRandomMixIn {
     // so this has the effect of creating lots of different sets of weights
     val learner = RandomForestRegressor(numTrees = 16384)
     // the test is that this training doesn't throw an exception
-    learner.train(trainingData, rng = rng).getModel()
+    learner.train(trainingData, rng = rng).model
   }
 
   def shapleyCompare(
@@ -260,7 +260,7 @@ class RandomForestTest extends SeedRandomMixIn {
       expected: Vector[Double],
       rtol: Double = 0.1
   ): Unit = {
-    val actual = RandomForestRegressor().train(trainingData, rng = rng).getModel().shapley(evalLocation) match {
+    val actual = RandomForestRegressor().train(trainingData, rng = rng).model.shapley(evalLocation) match {
       case None => fail("Unexpected None returned by shapley.")
       case x: Option[DenseMatrix[Double]] => {
         val a = x.get

--- a/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
+++ b/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
@@ -35,10 +35,10 @@ class LinearRegressionTest extends SeedRandomMixIn {
 
     val lr = LinearRegressionLearner(fitIntercept = false)
     val lrm = lr.train(trainingData)
-    val model = lrm.getModel()
+    val model = lrm.model
     val output = model.transform(trainingData.map(_.inputs))
-    val predicted = output.getExpected()
-    val beta = output.getGradient().get.head
+    val predicted = output.expected
+    val beta = output.gradient.get.head
 
     assert(norm(new DenseVector(beta.toArray) - beta0) < 1.0e-9, "Coefficients are inaccurate")
     assert(norm(new DenseVector(predicted.toArray) - result) < 1.0e-9, "Predictions are inaccurate")
@@ -58,10 +58,10 @@ class LinearRegressionTest extends SeedRandomMixIn {
 
     val lr = LinearRegressionLearner()
     val lrm = lr.train(trainingData)
-    val model = lrm.getModel()
+    val model = lrm.model
     val output = model.transform(trainingData.map(_.inputs))
-    val predicted = output.getExpected()
-    val beta = output.getGradient().get.head
+    val predicted = output.expected
+    val beta = output.gradient.get.head
 
     assert(norm(new DenseVector(beta.toArray) - beta0) < 1.0e-9, "Coefficients are inaccurate")
     assert(norm(new DenseVector(predicted.toArray) - result) < 1.0e-9, "Predictions are inaccurate")
@@ -81,10 +81,10 @@ class LinearRegressionTest extends SeedRandomMixIn {
 
     val lr = LinearRegressionLearner()
     val lrm = lr.train(trainingData, rng = rng)
-    val model = lrm.getModel()
+    val model = lrm.model
     val output = model.transform(trainingData.map(_.inputs))
-    val predicted = output.getExpected()
-    val beta = output.getGradient().get.head
+    val predicted = output.expected
+    val beta = output.gradient.get.head
 
     assert(norm(new DenseVector(beta.toArray) - beta0) < 1.0e-9, "Coefficients are inaccurate")
     assert(norm(new DenseVector(predicted.toArray) - result) < 1.0e-9, "Predictions are inaccurate")
@@ -115,10 +115,10 @@ class LinearRegressionTest extends SeedRandomMixIn {
 
     val lr = LinearRegressionLearner(fitIntercept = false)
     val lrm = lr.train(trainingData)
-    val model = lrm.getModel()
+    val model = lrm.model
     val output = model.transform(trainingData.map(_.inputs))
-    val predicted = output.getExpected()
-    val beta = output.getGradient().head
+    val predicted = output.expected
+    val beta = output.gradient.head
 
     assert(norm(new DenseVector(predicted.toArray) - result) < 1.0e-9, "Predictions are inaccurate")
   }
@@ -138,11 +138,11 @@ class LinearRegressionTest extends SeedRandomMixIn {
 
     val lr = LinearRegressionLearner()
     val lrm = lr.train(trainingData)
-    val model = lrm.getModel()
+    val model = lrm.model
     val output = model.transform(trainingData.map(_.inputs))
-    val predicted = output.getExpected()
-    val beta = output.getGradient().get.head
-    val importance = lrm.getFeatureImportance().get
+    val predicted = output.expected
+    val beta = output.gradient.get.head
+    val importance = lrm.featureImportance.get
 
     /* Make sure that feature importance matches the gradient */
     val betaScale = beta.map(Math.abs).sum

--- a/src/test/scala/io/citrine/lolo/transformers/rotator/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/rotator/FeatureRotatorTest.scala
@@ -146,7 +146,7 @@ class FeatureRotatorTest extends SeedRandomMixIn {
     val gradient = result.gradient
 
     val rotatedLearner = FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(weightedData, rng).model()
+    val rotatedModel = rotatedLearner.train(weightedData, rng).model
     val rotatedResult = rotatedModel.transform(data.map(_.inputs))
     val rotatedExpected = rotatedResult.expected
     val rotatedGradient = rotatedResult.gradient
@@ -169,11 +169,11 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedRidge(): Unit = {
     val learner = LinearRegressionLearner(regParam = Some(1.0))
-    val model = learner.train(data, rng = rng).model()
-    val result = model.transform(data.map(_.inputs)).getExpected()
+    val model = learner.train(data, rng = rng).model
+    val result = model.transform(data.map(_.inputs)).expected
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(data, rng = rng).model()
+    val rotatedModel = rotatedLearner.train(data, rng = rng).model
     val rotatedResult = rotatedModel.transform(data.map(_.inputs)).expected
 
     result.zip(rotatedResult).foreach {
@@ -188,11 +188,11 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedRegressionTree(): Unit = {
     val learner = RegressionTreeLearner()
-    val model = learner.train(data, rng = rng).model()
-    val result = model.transform(data.map(_.inputs)).getExpected()
+    val model = learner.train(data, rng = rng).model
+    val result = model.transform(data.map(_.inputs)).expected
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(data, rng = rng).model().asInstanceOf[RotatedFeatureModel[Double]]
+    val rotatedModel = rotatedLearner.train(data, rng = rng).model.asInstanceOf[RotatedFeatureModel[Double]]
     var rotatedResult = rotatedModel.transform(data.map(_.inputs)).expected
     result.zip(rotatedResult).foreach {
       case (free: Double, rotated: Double) =>
@@ -225,12 +225,12 @@ class FeatureRotatorTest extends SeedRandomMixIn {
       .data
 
     val learner = ClassificationTreeLearner()
-    val model = learner.train(classificationData, rng = rng).model()
-    val result = model.transform(classificationData.map(_.inputs)).getExpected()
+    val model = learner.train(classificationData, rng = rng).model
+    val result = model.transform(classificationData.map(_.inputs)).expected
 
     val rotatedLearner = new FeatureRotator(learner)
     val rotatedModel =
-      rotatedLearner.train(classificationData, rng = rng).model().asInstanceOf[RotatedFeatureModel[String]]
+      rotatedLearner.train(classificationData, rng = rng).model.asInstanceOf[RotatedFeatureModel[String]]
     var rotatedResult = rotatedModel.transform(classificationData.map(_.inputs)).expected
 
     result.zip(rotatedResult).foreach {

--- a/src/test/scala/io/citrine/lolo/transformers/rotator/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/rotator/FeatureRotatorTest.scala
@@ -101,11 +101,11 @@ class FeatureRotatorTest extends SeedRandomMixIn {
     val rotatedTrainingResult = FeatureRotator(RegressionTreeLearner()).train(data, rng = rng)
 
     assert(
-      rotatedTrainingResult.getLoss() == rotatedTrainingResult.baseTrainingResult.getLoss(),
+      rotatedTrainingResult.loss == rotatedTrainingResult.baseTrainingResult.loss,
       "Function getLoss() should pass through to base learner."
     )
 
-    rotatedTrainingResult.getPredictedVsActual().foreach { x =>
+    rotatedTrainingResult.predictedVsActual.foreach { x =>
       x.zip(data).foreach {
         case (a, b) =>
           assert(a._1 == b.inputs, "getPredictedVsActual must return the correct training inputs.")
@@ -121,12 +121,12 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedGTM(): Unit = {
     val learner = GuessTheMeanLearner()
-    val model = learner.train(data, rng = rng).getModel()
-    val result = model.transform(data.map(_.inputs)).getExpected()
+    val model = learner.train(data, rng = rng).model
+    val result = model.transform(data.map(_.inputs)).expected
 
     val rotatedLearner = FeatureRotator(GuessTheMeanLearner())
-    val rotatedModel = rotatedLearner.train(data, rng = rng).getModel()
-    val rotatedResult = rotatedModel.transform(data.map(_.inputs)).getExpected()
+    val rotatedModel = rotatedLearner.train(data, rng = rng).model
+    val rotatedResult = rotatedModel.transform(data.map(_.inputs)).expected
 
     result.zip(rotatedResult).foreach {
       case (free: Double, rotated: Double) =>
@@ -140,16 +140,16 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedLinear(): Unit = {
     val learner = LinearRegressionLearner()
-    val model = learner.train(weightedData, rng).getModel()
+    val model = learner.train(weightedData, rng).model
     val result = model.transform(data.map(_.inputs))
-    val expected = result.getExpected()
-    val gradient = result.getGradient()
+    val expected = result.expected
+    val gradient = result.gradient
 
     val rotatedLearner = FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(weightedData, rng).getModel()
+    val rotatedModel = rotatedLearner.train(weightedData, rng).model()
     val rotatedResult = rotatedModel.transform(data.map(_.inputs))
-    val rotatedExpected = rotatedResult.getExpected()
-    val rotatedGradient = rotatedResult.getGradient()
+    val rotatedExpected = rotatedResult.expected
+    val rotatedGradient = rotatedResult.gradient
 
     expected.zip(rotatedExpected).foreach {
       case (free: Double, rotated: Double) =>
@@ -169,12 +169,12 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedRidge(): Unit = {
     val learner = LinearRegressionLearner(regParam = Some(1.0))
-    val model = learner.train(data, rng = rng).getModel()
+    val model = learner.train(data, rng = rng).model()
     val result = model.transform(data.map(_.inputs)).getExpected()
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(data, rng = rng).getModel()
-    val rotatedResult = rotatedModel.transform(data.map(_.inputs)).getExpected()
+    val rotatedModel = rotatedLearner.train(data, rng = rng).model()
+    val rotatedResult = rotatedModel.transform(data.map(_.inputs)).expected
 
     result.zip(rotatedResult).foreach {
       case (free: Double, rotated: Double) =>
@@ -188,25 +188,25 @@ class FeatureRotatorTest extends SeedRandomMixIn {
   @Test
   def testRotatedRegressionTree(): Unit = {
     val learner = RegressionTreeLearner()
-    val model = learner.train(data, rng = rng).getModel()
+    val model = learner.train(data, rng = rng).model()
     val result = model.transform(data.map(_.inputs)).getExpected()
 
     val rotatedLearner = new FeatureRotator(learner)
-    val rotatedModel = rotatedLearner.train(data, rng = rng).getModel().asInstanceOf[RotatedFeatureModel[Double]]
-    var rotatedResult = rotatedModel.transform(data.map(_.inputs)).getExpected()
+    val rotatedModel = rotatedLearner.train(data, rng = rng).model().asInstanceOf[RotatedFeatureModel[Double]]
+    var rotatedResult = rotatedModel.transform(data.map(_.inputs)).expected
     result.zip(rotatedResult).foreach {
       case (free: Double, rotated: Double) =>
         assert(Math.abs(free - rotated) < 1.0e-9, s"${free} and ${rotated} should be the same")
     }
 
     val rotatedData = FeatureRotator.applyRotation(data.map(_.inputs), rotatedModel.rotatedFeatures, rotatedModel.trans)
-    rotatedResult = rotatedModel.transform(rotatedData).getExpected()
+    rotatedResult = rotatedModel.transform(rotatedData).expected
     // Check that labels change when we feed in different data.
     assert(
       rotatedResult.zip(result).map { case (a: Double, b: Double) => a - b }.count { x => Math.abs(x) > 1e-9 } > 0,
       "Rotated data passed to rotated model should not map to the same predictions."
     )
-    val baseResult = rotatedModel.baseModel.transform(rotatedData).getExpected()
+    val baseResult = rotatedModel.baseModel.transform(rotatedData).expected
     // Check that labels are the same as feeding rotated data into base learner.
     assert(
       baseResult.zip(result).map { case (a: Double, b: Double) => a - b }.count { x => Math.abs(x) > 1e-9 } == 0,
@@ -225,13 +225,13 @@ class FeatureRotatorTest extends SeedRandomMixIn {
       .data
 
     val learner = ClassificationTreeLearner()
-    val model = learner.train(classificationData, rng = rng).getModel()
+    val model = learner.train(classificationData, rng = rng).model()
     val result = model.transform(classificationData.map(_.inputs)).getExpected()
 
     val rotatedLearner = new FeatureRotator(learner)
     val rotatedModel =
-      rotatedLearner.train(classificationData, rng = rng).getModel().asInstanceOf[RotatedFeatureModel[String]]
-    var rotatedResult = rotatedModel.transform(classificationData.map(_.inputs)).getExpected()
+      rotatedLearner.train(classificationData, rng = rng).model().asInstanceOf[RotatedFeatureModel[String]]
+    var rotatedResult = rotatedModel.transform(classificationData.map(_.inputs)).expected
 
     result.zip(rotatedResult).foreach {
       case (free: Any, rotated: Any) =>
@@ -240,13 +240,13 @@ class FeatureRotatorTest extends SeedRandomMixIn {
 
     val rotatedData =
       FeatureRotator.applyRotation(classificationData.map(_.inputs), rotatedModel.rotatedFeatures, rotatedModel.trans)
-    rotatedResult = rotatedModel.transform(rotatedData).getExpected()
+    rotatedResult = rotatedModel.transform(rotatedData).expected
     // Check that labels change when we feed in different data.
     assert(
       rotatedResult.zip(result).count { case (a: String, b: String) => a != b } > 0,
       "Rotated data passed to rotated model should not map to the same predictions."
     )
-    val baseResult = rotatedModel.baseModel.transform(rotatedData).getExpected()
+    val baseResult = rotatedModel.baseModel.transform(rotatedData).expected
     // Check that labels are the same as feeding rotated data into base learner.
     assert(
       baseResult.zip(result).count { case (a: String, b: String) => a != b } == 0,

--- a/src/test/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizerTest.scala
@@ -37,8 +37,8 @@ class MultiTaskStandardizerTest extends SeedRandomMixIn {
 
     // Train and evaluate standard models on original and rescaled labels
     val standardizer = MultiTaskStandardizer(MultiTaskTreeLearner())
-    val baseRes = standardizer.train(baseRows).getModels().last.transform(inputs).getExpected()
-    val standardRes = standardizer.train(rescaledRows).getModels().last.transform(inputs).getExpected()
+    val baseRes = standardizer.train(baseRows).models.last.transform(inputs).expected
+    val standardRes = standardizer.train(rescaledRows).models.last.transform(inputs).expected
     // Train and evaluate unstandardized model on rescaled labels
 
     // Compute metrics for each of the models

--- a/src/test/scala/io/citrine/lolo/transformers/standardizer/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/standardizer/StandardizerTest.scala
@@ -51,12 +51,12 @@ class StandardizerTest extends SeedRandomMixIn {
   @Test
   def testStandardGTM(): Unit = {
     val learner = GuessTheMeanLearner()
-    val model = learner.train(data, rng = rng).getModel()
-    val result = model.transform(data.map(_.inputs)).getExpected()
+    val model = learner.train(data, rng = rng).model
+    val result = model.transform(data.map(_.inputs)).expected
 
     val standardLearner = RegressionStandardizer(GuessTheMeanLearner())
-    val standardModel = standardLearner.train(data, rng = rng).getModel()
-    val standardResult = standardModel.transform(data.map(_.inputs)).getExpected()
+    val standardModel = standardLearner.train(data, rng = rng).model
+    val standardResult = standardModel.transform(data.map(_.inputs)).expected
 
     result.zip(standardResult).foreach {
       case (free: Double, standard: Double) =>
@@ -70,16 +70,16 @@ class StandardizerTest extends SeedRandomMixIn {
   @Test
   def testStandardLinear(): Unit = {
     val learner = LinearRegressionLearner()
-    val model = learner.train(weightedData).getModel()
+    val model = learner.train(weightedData).model
     val result = model.transform(data.map(_.inputs))
-    val expected = result.getExpected()
-    val gradient = result.getGradient()
+    val expected = result.expected
+    val gradient = result.gradient
 
     val standardLearner = RegressionStandardizer(learner)
-    val standardModel = standardLearner.train(weightedData).getModel()
+    val standardModel = standardLearner.train(weightedData).model
     val standardResult = standardModel.transform(data.map(_.inputs))
-    val standardExpected = standardResult.getExpected()
-    val standardGradient = standardResult.getGradient()
+    val standardExpected = standardResult.expected
+    val standardGradient = standardResult.gradient
 
     expected.zip(standardExpected).foreach {
       case (free: Double, standard: Double) =>
@@ -101,16 +101,16 @@ class StandardizerTest extends SeedRandomMixIn {
   @Test
   def testStandardWithConstantFeature(): Unit = {
     val learner = LinearRegressionLearner()
-    val model = learner.train(weightedDataWithConstant).getModel()
+    val model = learner.train(weightedDataWithConstant).model
     val result = model.transform(dataWithConstant.map(_.inputs))
-    val expected = result.getExpected()
-    val gradient = result.getGradient()
+    val expected = result.expected
+    val gradient = result.gradient
 
     val standardLearner = RegressionStandardizer(learner)
-    val standardModel = standardLearner.train(weightedDataWithConstant).getModel()
+    val standardModel = standardLearner.train(weightedDataWithConstant).model
     val standardResult = standardModel.transform(dataWithConstant.map(_.inputs))
-    val standardExpected = standardResult.getExpected()
-    val standardGradient = standardResult.getGradient()
+    val standardExpected = standardResult.expected
+    val standardGradient = standardResult.gradient
 
     gradient.get.toList.flatten.zip(standardGradient.get.toList.flatten).foreach {
       case (free: Double, standard: Double) =>
@@ -143,12 +143,12 @@ class StandardizerTest extends SeedRandomMixIn {
   @Test
   def testStandardRidge(): Unit = {
     val learner = LinearRegressionLearner(regParam = Some(1.0))
-    val model = learner.train(data).getModel()
-    val result = model.transform(data.map(_.inputs)).getExpected()
+    val model = learner.train(data).model
+    val result = model.transform(data.map(_.inputs)).expected
 
     val standardLearner = RegressionStandardizer(learner)
-    val standardModel = standardLearner.train(data).getModel()
-    val standardResult = standardModel.transform(data.map(_.inputs)).getExpected()
+    val standardModel = standardLearner.train(data).model
+    val standardResult = standardModel.transform(data.map(_.inputs)).expected
 
     result.zip(standardResult).foreach {
       case (free: Double, standard: Double) =>
@@ -164,12 +164,12 @@ class StandardizerTest extends SeedRandomMixIn {
       .data
 
     val learner = ClassificationTreeLearner()
-    val model = learner.train(trainingData).getModel()
-    val result = model.transform(trainingData.map(_.inputs)).getExpected()
+    val model = learner.train(trainingData).model
+    val result = model.transform(trainingData.map(_.inputs)).expected
 
     val standardLearner = ClassificationStandardizer(learner)
-    val standardModel = standardLearner.train(trainingData).getModel()
-    val standardResult = standardModel.transform(trainingData.map(_.inputs)).getExpected()
+    val standardModel = standardLearner.train(trainingData).model
+    val standardResult = standardModel.transform(trainingData.map(_.inputs)).expected
     result.zip(standardResult).foreach {
       case (free: String, standard: String) =>
         assert(free == standard, s"Standard classification tree should be the same")

--- a/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
@@ -41,7 +41,7 @@ class ClassificationTreeTest extends SeedRandomMixIn {
         assert(row.label == p, s"${row.label} != $p for ${row.inputs}")
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().foreach(d => assert(d > 0))
+    output.depth.foreach(d => assert(d > 0))
 
     /* The first features should be the most important */
     val importances = DTMeta.featureImportance.get
@@ -74,7 +74,7 @@ class ClassificationTreeTest extends SeedRandomMixIn {
       case (row, p) => assert(row.label == p, s"${row.label} != $p for ${row.inputs}")
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().foreach(d => assert(d > 4 && d < 17, s"Depth is ${d}"))
+    output.depth.foreach(d => assert(d > 4 && d < 17, s"Depth is ${d}"))
 
     /* The first feature should be the most important */
     val importances = DTMeta.featureImportance.get
@@ -108,7 +108,7 @@ class ClassificationTreeTest extends SeedRandomMixIn {
         assert(row.label == p)
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().foreach(d => assert(d > 3 && d < 18, s"Depth is ${d}"))
+    output.depth.foreach(d => assert(d > 3 && d < 18, s"Depth is ${d}"))
   }
 }
 

--- a/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
@@ -20,7 +20,7 @@ class ClassificationTreeTest extends SeedRandomMixIn {
 
     val DTLearner = ClassificationTreeLearner()
     val DTMeta = DTLearner.train(X)
-    assert(DTMeta.getFeatureImportance().get.forall(v => !v.isNaN))
+    assert(DTMeta.featureImportance.get.forall(v => !v.isNaN))
   }
 
   @Test
@@ -32,19 +32,19 @@ class ClassificationTreeTest extends SeedRandomMixIn {
 
     val DTLearner = ClassificationTreeLearner()
     val DTMeta = DTLearner.train(trainingData)
-    val DT = DTMeta.getModel()
+    val DT = DTMeta.model
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) =>
         assert(row.label == p, s"${row.label} != $p for ${row.inputs}")
     }
-    assert(output.getGradient().isEmpty)
+    assert(output.gradient.isEmpty)
     output.getDepth().foreach(d => assert(d > 0))
 
     /* The first features should be the most important */
-    val importances = DTMeta.getFeatureImportance().get
+    val importances = DTMeta.featureImportance.get
     assert(importances.slice(0, 5).min > importances.slice(5, importances.size).max)
   }
 
@@ -62,7 +62,7 @@ class ClassificationTreeTest extends SeedRandomMixIn {
     val N = 100
     val start = System.nanoTime()
     val DTMeta = DTLearner.train(trainingData)
-    val DT = DTMeta.getModel()
+    val DT = DTMeta.model
     (0 until N).map(i => DTLearner.train(trainingData))
     val duration = (System.nanoTime() - start) / 1.0e9
 
@@ -70,14 +70,14 @@ class ClassificationTreeTest extends SeedRandomMixIn {
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) => assert(row.label == p, s"${row.label} != $p for ${row.inputs}")
     }
-    assert(output.getGradient().isEmpty)
+    assert(output.gradient.isEmpty)
     output.getDepth().foreach(d => assert(d > 4 && d < 17, s"Depth is ${d}"))
 
     /* The first feature should be the most important */
-    val importances = DTMeta.getFeatureImportance().get
+    val importances = DTMeta.featureImportance.get
     assert(importances.slice(0, 5).min > importances.slice(5, importances.size).max)
   }
 
@@ -95,7 +95,7 @@ class ClassificationTreeTest extends SeedRandomMixIn {
     val DTLearner = ClassificationTreeLearner()
     val N = 100
     val start = System.nanoTime()
-    val DT = DTLearner.train(trainingData).getModel()
+    val DT = DTLearner.train(trainingData).model
     (0 until N).map(i => DTLearner.train(trainingData))
     val duration = (System.nanoTime() - start) / 1.0e9
 
@@ -103,11 +103,11 @@ class ClassificationTreeTest extends SeedRandomMixIn {
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) =>
         assert(row.label == p)
     }
-    assert(output.getGradient().isEmpty)
+    assert(output.gradient.isEmpty)
     output.getDepth().foreach(d => assert(d > 3 && d < 18, s"Depth is ${d}"))
   }
 }

--- a/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
@@ -26,12 +26,12 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
   @Test
   def testTwoLabels(): Unit = {
     val learner = MultiTaskTreeLearner()
-    val models = learner.train(multiRows, rng = rng).getModels()
+    val models = learner.train(multiRows, rng = rng).models
     assert(models.size == 2)
     assert(models.head.isInstanceOf[RegressionTree])
     assert(models.last.isInstanceOf[ClassificationTree])
-    val realResults = models.head.transform(inputs).getExpected().asInstanceOf[Seq[Double]]
-    val catResults = models.last.transform(inputs).getExpected().asInstanceOf[Seq[Boolean]]
+    val realResults = models.head.transform(inputs).expected.asInstanceOf[Seq[Double]]
+    val catResults = models.last.transform(inputs).expected.asInstanceOf[Seq[Boolean]]
 
     assert(realLabel.zip(realResults).forall(p => p._1 == p._2))
     assert(catLabel.zip(catResults).forall(p => p._1 == p._2))
@@ -53,9 +53,9 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
     val sparseRows = TrainingRow.build(inputs.zip(sparseLabels))
 
     val learner = MultiTaskTreeLearner()
-    val models = learner.train(sparseRows).getModels()
-    val realResults = models.head.transform(inputs).getExpected().asInstanceOf[Seq[Double]]
-    val catResults = models.last.transform(inputs).getExpected().asInstanceOf[Seq[Boolean]]
+    val models = learner.train(sparseRows).models
+    val realResults = models.head.transform(inputs).expected.asInstanceOf[Seq[Double]]
+    val catResults = models.last.transform(inputs).expected.asInstanceOf[Seq[Boolean]]
 
     assert(realLabel.zip(realResults).forall(p => p._1 == p._2))
     assert(sparseCat.zip(catResults).forall(p => p._1 == null || p._1 == p._2))
@@ -79,14 +79,14 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
     val sparseMultiRows = TrainingRow.build(inputs.zip(sparseLabels)).filterNot(_.label == null)
 
     val learner = MultiTaskTreeLearner()
-    val models = learner.train(sparseMultiRows, rng = rng).getModels()
-    val catResults = models.last.transform(inputs).getExpected().asInstanceOf[Seq[Boolean]]
+    val models = learner.train(sparseMultiRows, rng = rng).models
+    val catResults = models.last.transform(inputs).expected.asInstanceOf[Seq[Boolean]]
 
     val reference = ClassificationTreeLearner()
       .train(sparseCatRows, rng = rng)
-      .getModel()
+      .model
       .transform(inputs)
-      .getExpected()
+      .expected
 
     val singleF1 = ClassificationMetrics.f1scores(reference, catLabel)
     val multiF1 = ClassificationMetrics.f1scores(catResults, catLabel)
@@ -103,18 +103,18 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
     val combinedModelRng = Random(seed)
     val learner = MultiTaskTreeLearner()
     val combinedModelLearner = MultiTaskTreeLearner()
-    val models = learner.train(TrainingRow.build(inputs.zip(labels)), rng = trainRng).getModels()
+    val models = learner.train(TrainingRow.build(inputs.zip(labels)), rng = trainRng).models
     val combinedModel =
-      combinedModelLearner.train(TrainingRow.build(inputs.zip(labels)), rng = combinedModelRng).getModel()
+      combinedModelLearner.train(TrainingRow.build(inputs.zip(labels)), rng = combinedModelRng).model
 
     // Generate new inputs to test equality on.
     val testInputs = DataGenerator
       .generate(32, 12, noise = 0.1, function = Friedman.friedmanSilverman, rng = rng)
       .data
       .map(_.inputs)
-    val realResults = models.head.transform(testInputs).getExpected().asInstanceOf[Seq[Double]]
-    val catResults = models.last.transform(testInputs).getExpected().asInstanceOf[Seq[Boolean]]
-    val allResults = combinedModel.transform(testInputs).getExpected().asInstanceOf[Seq[Seq[Any]]]
+    val realResults = models.head.transform(testInputs).expected.asInstanceOf[Seq[Double]]
+    val catResults = models.last.transform(testInputs).expected.asInstanceOf[Seq[Boolean]]
+    val allResults = combinedModel.transform(testInputs).expected.asInstanceOf[Seq[Seq[Any]]]
     assert(Seq(realResults, catResults).transpose == allResults)
   }
 
@@ -123,7 +123,7 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
   def testFeatureImportance(): Unit = {
     val multiTaskLearner = MultiTaskTreeLearner()
     val multiTaskTrainingResult = multiTaskLearner.train(TrainingRow.build(inputs.zip(labels)), rng = rng)
-    val importances = multiTaskTrainingResult.getFeatureImportance().get
+    val importances = multiTaskTrainingResult.featureImportance.get
     assert(importances(1) == importances.max)
   }
 }

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -44,7 +44,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().foreach(d => assert(d > 3 && d < 9, s"Depth is $d"))
+    output.depth.foreach(d => assert(d > 3 && d < 9, s"Depth is $d"))
   }
 
   /**
@@ -65,7 +65,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().foreach(d => assert(d > 3 && d < 9, s"Depth is $d"))
+    output.depth.foreach(d => assert(d > 3 && d < 9, s"Depth is $d"))
   }
 
   /**
@@ -92,7 +92,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().foreach(d => assert(d > 4 && d < 20, s"Depth is ${d}"))
+    output.depth.foreach(d => assert(d > 4 && d < 20, s"Depth is ${d}"))
 
     /* The first feature should be the most important */
     val importances = DTMeta.featureImportance.get
@@ -130,7 +130,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().foreach(d => assert(d > 4 && d < 21, s"Depth is ${d}"))
+    output.depth.foreach(d => assert(d > 4 && d < 21, s"Depth is ${d}"))
 
     /* The first feature should be the most important */
     val importances = DTMeta.featureImportance.get
@@ -160,7 +160,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
     assert(output.gradient.isDefined)
-    output.getDepth().foreach(d => assert(d > 4 && d < 18, s"Depth is $d"))
+    output.depth.foreach(d => assert(d > 4 && d < 18, s"Depth is $d"))
 
     /* The first feature should be the most important */
     val importances = DTMeta.featureImportance.get
@@ -203,7 +203,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
     )
 
     val result = DT.transform(trainingData.map(_.inputs))
-    assert(result.getDepth().forall(_ == 0), s"Expected all the predictions to be depth 0")
+    assert(result.depth.forall(_ == 0), s"Expected all the predictions to be depth 0")
   }
 
   /**
@@ -240,7 +240,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
       case (row, p) => assert(Math.abs(row.label - p) < 1.0e-9)
     }
     assert(output.gradient.isEmpty)
-    output.getDepth().zip(output.expected).foreach {
+    output.depth.zip(output.expected).foreach {
       case (d, y) => assert(d > 3 && d < 9, s"Depth is $d at y=$y")
     }
   }
@@ -258,7 +258,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
       expected: Vector[Double],
       omitFeatures: Set[Int] = Set()
   ): Unit = {
-    val actual = RegressionTreeLearner().train(trainingData).model().shapley(evalLocation, omitFeatures) match {
+    val actual = RegressionTreeLearner().train(trainingData).model.shapley(evalLocation, omitFeatures) match {
       case None => fail("Unexpected None returned by shapley.")
       case x: Option[DenseMatrix[Double]] => {
         val a = x.get
@@ -334,6 +334,6 @@ class RegressionTreeTest extends SeedRandomMixIn {
     shapleyCompare(trainingData2, Vector[Any](1.0, 1.0), expected2b, omitFeatures = Set(1))
 
     // Ensure we don't crash when restricting number of features.
-    RegressionTreeLearner(numFeatures = 1).train(trainingData4).model().shapley(Vector.fill[Any](5)(0.0), Set())
+    RegressionTreeLearner(numFeatures = 1).train(trainingData4).model.shapley(Vector.fill[Any](5)(0.0), Set())
   }
 }

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -24,7 +24,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
 
     val DTLearner = RegressionTreeLearner()
     val DTMeta = DTLearner.train(X)
-    assert(DTMeta.getFeatureImportance().get.forall(v => !v.isNaN))
+    assert(DTMeta.featureImportance.get.forall(v => !v.isNaN))
   }
 
   /**
@@ -35,15 +35,15 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val csv = TestUtils.readCsv("double_example.csv")
     val trainingData = csv.map(vec => TrainingRow(vec.init, vec.last.asInstanceOf[Double]))
     val DTLearner = RegressionTreeLearner()
-    val DT = DTLearner.train(trainingData).getModel()
+    val DT = DTLearner.train(trainingData).model
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) =>
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
-    assert(output.getGradient().isEmpty)
+    assert(output.gradient.isEmpty)
     output.getDepth().foreach(d => assert(d > 3 && d < 9, s"Depth is $d"))
   }
 
@@ -56,15 +56,15 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val csv = TestUtils.readCsv("double_example.csv")
     val trainingData = csv.map(vec => TrainingRow(vec.init, vec.last.asInstanceOf[Double], 1.0))
     val DTLearner = RegressionTreeLearner(splitter = RegressionSplitter(randomizePivotLocation = true))
-    val DT = DTLearner.train(trainingData).getModel()
+    val DT = DTLearner.train(trainingData).model
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) =>
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
-    assert(output.getGradient().isEmpty)
+    assert(output.gradient.isEmpty)
     output.getDepth().foreach(d => assert(d > 3 && d < 9, s"Depth is $d"))
   }
 
@@ -79,23 +79,23 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val N = 100
     val start = System.nanoTime()
     val DTMeta = DTLearner.train(trainingData)
-    val DT = DTMeta.getModel()
-    (0 until N).map(i => DTLearner.train(trainingData).getModel())
+    val DT = DTMeta.model
+    (0 until N).map(i => DTLearner.train(trainingData).model)
     val duration = (System.nanoTime() - start) / 1.0e9
 
     println(s"Training large case took ${duration / N} s")
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) =>
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
-    assert(output.getGradient().isEmpty)
+    assert(output.gradient.isEmpty)
     output.getDepth().foreach(d => assert(d > 4 && d < 20, s"Depth is ${d}"))
 
     /* The first feature should be the most important */
-    val importances = DTMeta.getFeatureImportance().get
+    val importances = DTMeta.featureImportance.get
     assert(importances(1) == importances.max)
 
     val tmpFile: File = File.createTempFile("tmp", ".csv")
@@ -117,23 +117,23 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val N = 100
     val start = System.nanoTime()
     val DTMeta = DTLearner.train(trainingData)
-    val DT = DTMeta.getModel()
-    (0 until N).map(i => DTLearner.train(trainingData).getModel())
+    val DT = DTMeta.model
+    (0 until N).map(i => DTLearner.train(trainingData).model)
     val duration = (System.nanoTime() - start) / 1.0e9
 
     println(s"Training large case took ${duration / N} s")
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) =>
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
-    assert(output.getGradient().isEmpty)
+    assert(output.gradient.isEmpty)
     output.getDepth().foreach(d => assert(d > 4 && d < 21, s"Depth is ${d}"))
 
     /* The first feature should be the most important */
-    val importances = DTMeta.getFeatureImportance().get
+    val importances = DTMeta.featureImportance.get
     assert(importances(1) == importances.max)
     val tmpFile: File = File.createTempFile("tmp", ".csv")
     val oos = new ObjectOutputStream(new FileOutputStream(tmpFile))
@@ -151,19 +151,19 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val linearLearner = LinearRegressionLearner(regParam = Some(0.0))
     val DTLearner = RegressionTreeLearner(leafLearner = Some(linearLearner), minLeafInstances = 2)
     val DTMeta = DTLearner.train(trainingData)
-    val DT = DTMeta.getModel()
+    val DT = DTMeta.model
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) =>
         assert(Math.abs(row.label - p) < 1.0e-9)
     }
-    assert(output.getGradient().isDefined)
+    assert(output.gradient.isDefined)
     output.getDepth().foreach(d => assert(d > 4 && d < 18, s"Depth is $d"))
 
     /* The first feature should be the most important */
-    val importances = DTMeta.getFeatureImportance().get
+    val importances = DTMeta.featureImportance.get
     assert(importances(1) == importances.max)
     /* They should all be non-zero */
     assert(importances.min > 0.0)
@@ -186,11 +186,11 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val linearLearner = LinearRegressionLearner(regParam = Some(1.0))
     val DTLearner = RegressionTreeLearner(leafLearner = Some(linearLearner), maxDepth = 0)
     val DTMeta = DTLearner.train(trainingData)
-    val DT = DTMeta.getModel()
+    val DT = DTMeta.model
 
-    val linearImportance = linearLearner.train(trainingData).getFeatureImportance().get
+    val linearImportance = linearLearner.train(trainingData).featureImportance.get
 
-    val importances = DTMeta.getFeatureImportance().get
+    val importances = DTMeta.featureImportance.get
 
     /* The first feature should be the most important */
     assert(importances(1) == importances.max)
@@ -220,7 +220,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val DTMeta = DTLearner.train(weightedData)
 
     /* The first feature should be the most important */
-    val importances = DTMeta.getFeatureImportance().get
+    val importances = DTMeta.featureImportance.get
     assert(importances.forall(_ >= 0.0), "Found negative feature importance")
   }
 
@@ -232,15 +232,15 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val csv = TestUtils.readCsv("double_example.csv")
     val trainingData = csv.map(vec => TrainingRow(vec.init, vec.last.asInstanceOf[Double], 1.0))
     val DTLearner = RegressionTreeLearner(splitter = BoltzmannSplitter(1e-4))
-    val DT = DTLearner.train(trainingData, rng = rng).getModel()
+    val DT = DTLearner.train(trainingData, rng = rng).model
 
     /* We should be able to memorize the inputs */
     val output = DT.transform(trainingData.map(_.inputs))
-    trainingData.zip(output.getExpected()).foreach {
+    trainingData.zip(output.expected).foreach {
       case (row, p) => assert(Math.abs(row.label - p) < 1.0e-9)
     }
-    assert(output.getGradient().isEmpty)
-    output.getDepth().zip(output.getExpected()).foreach {
+    assert(output.gradient.isEmpty)
+    output.getDepth().zip(output.expected).foreach {
       case (d, y) => assert(d > 3 && d < 9, s"Depth is $d at y=$y")
     }
   }
@@ -258,7 +258,7 @@ class RegressionTreeTest extends SeedRandomMixIn {
       expected: Vector[Double],
       omitFeatures: Set[Int] = Set()
   ): Unit = {
-    val actual = RegressionTreeLearner().train(trainingData).getModel().shapley(evalLocation, omitFeatures) match {
+    val actual = RegressionTreeLearner().train(trainingData).model().shapley(evalLocation, omitFeatures) match {
       case None => fail("Unexpected None returned by shapley.")
       case x: Option[DenseMatrix[Double]] => {
         val a = x.get
@@ -334,6 +334,6 @@ class RegressionTreeTest extends SeedRandomMixIn {
     shapleyCompare(trainingData2, Vector[Any](1.0, 1.0), expected2b, omitFeatures = Set(1))
 
     // Ensure we don't crash when restricting number of features.
-    RegressionTreeLearner(numFeatures = 1).train(trainingData4).getModel().shapley(Vector.fill[Any](5)(0.0), Set())
+    RegressionTreeLearner(numFeatures = 1).train(trainingData4).model().shapley(Vector.fill[Any](5)(0.0), Set())
   }
 }

--- a/src/test/scala/io/citrine/lolo/util/LoloPyDataLoaderTest.scala
+++ b/src/test/scala/io/citrine/lolo/util/LoloPyDataLoaderTest.scala
@@ -39,18 +39,18 @@ class LoloPyDataLoaderTest {
   @Test
   def testGetRegression(): Unit = {
     val results = new PredictionResult[Double] {
-      override def getExpected(): Seq[Double] = {
+      override def expected: Seq[Double] = {
         1.0 :: 2.0 :: 3.0 :: Nil
       }
 
-      override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
+      override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
         Some(0.1 :: 0.2 :: 0.3 :: Nil)
       }
     }
 
     // Get the expected results
-    val means = results.getExpected()
-    val sigma = results.getUncertainty().get.asInstanceOf[Seq[Double]]
+    val means = results.expected
+    val sigma = results.uncertainty().get.asInstanceOf[Seq[Double]]
 
     // Get the results as a byte array, and convert them back
     val reproMeans = LoloPyDataLoader
@@ -69,21 +69,21 @@ class LoloPyDataLoaderTest {
   def testGetClassification(): Unit = {
     // Get the base results
     val results = new PredictionResult[Int] {
-      override def getExpected(): Seq[Int] = {
+      override def expected: Seq[Int] = {
         0 :: 1 :: 0 :: 1 :: Nil
       }
 
-      override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
+      override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = {
         Some(Map(0 -> 1.0) :: Map(1 -> 0.5, 0 -> 0.2, 2 -> 0.3) :: Map(0 -> 1.0) :: Map(1 -> 1.0) :: Nil)
       }
 
-      override def getImportanceScores(): Option[Seq[Seq[Double]]] = {
+      override def importanceScores: Option[Seq[Seq[Double]]] = {
         Some((0.1 :: 0.2 :: Nil) :: (0.4 :: 0.8 :: Nil) :: (0.1 :: 0.5 :: Nil) :: (0.8 :: 0.2 :: Nil) :: Nil)
       }
     }
-    val means = results.getExpected()
+    val means = results.expected
     val probs: Seq[Double] = results
-      .getUncertainty()
+      .uncertainty()
       .get
       .asInstanceOf[Seq[Map[Int, Double]]]
       .flatMap(x => 0.until(3).map(i => x.getOrElse(i, 0.0)))

--- a/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
@@ -237,8 +237,8 @@ object CalibrationStudy extends SeedRandomMixIn {
     val data: Seq[(Double, Double, Double)] = source.flatMap {
       case (predictions, actual) =>
         predictions
-          .getExpected()
-          .lazyZip(predictions.getUncertainty().get.asInstanceOf[Seq[Double]])
+          .expected
+          .lazyZip(predictions.uncertainty().get.asInstanceOf[Seq[Double]])
           .lazyZip(actual)
           .toSeq
     }.toSeq

--- a/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
@@ -236,8 +236,7 @@ object CalibrationStudy extends SeedRandomMixIn {
   ): CategoryChart = {
     val data: Seq[(Double, Double, Double)] = source.flatMap {
       case (predictions, actual) =>
-        predictions
-          .expected
+        predictions.expected
           .lazyZip(predictions.uncertainty().get.asInstanceOf[Seq[Double]])
           .lazyZip(actual)
           .toSeq

--- a/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
@@ -24,12 +24,12 @@ class CrossValidationTest extends SeedRandomMixIn {
     val trainingResult = learner.train(data)
     val rmseFromPVA = Math.sqrt(
       trainingResult
-        .getPredictedVsActual()
+        .predictedVsActual
         .get
         .map {
           case (_, p: Double, a: Double) => Math.pow(p - a, 2.0)
         }
-        .sum / trainingResult.getPredictedVsActual().get.size
+        .sum / trainingResult.predictedVsActual.get.size
     )
 
     // These have a false negative rate less than 1/100 at the time of original authorship

--- a/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CrossValidationTest.scala
@@ -23,13 +23,9 @@ class CrossValidationTest extends SeedRandomMixIn {
 
     val trainingResult = learner.train(data)
     val rmseFromPVA = Math.sqrt(
-      trainingResult
-        .predictedVsActual
-        .get
-        .map {
-          case (_, p: Double, a: Double) => Math.pow(p - a, 2.0)
-        }
-        .sum / trainingResult.predictedVsActual.get.size
+      trainingResult.predictedVsActual.get.map {
+        case (_, p: Double, a: Double) => Math.pow(p - a, 2.0)
+      }.sum / trainingResult.predictedVsActual.get.size
     )
 
     // These have a false negative rate less than 1/100 at the time of original authorship

--- a/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
@@ -54,9 +54,9 @@ class MeritTest extends SeedRandomMixIn {
         (y + error, uncertainty, y)
       }
       val predictionResult = new PredictionResult[Double] {
-        override def getExpected(): Seq[Double] = pua.map(_._1)
+        override def expected: Seq[Double] = pua.map(_._1)
 
-        override def getUncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(pua.map(_._2))
+        override def uncertainty(includeNoise: Boolean = true): Option[Seq[Any]] = Some(pua.map(_._2))
       }
       (predictionResult, pua.map(_._3))
     }


### PR DESCRIPTION
Changes the `getXYZ` syntax to `xyz` on the core API interfaces in the library. 

In some cases, this required some logic updating to avoid name clashes with other class-defined variables. I leave comments on those sections in the file view.