### PR TITLE
Move API to api folder

### DIFF
--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -92,7 +92,7 @@ class BaseLoloLearner(BaseEstimator, metaclass=ABCMeta):
         assert weights_java.length() == len(X), "Weights copy failed"
 
         # Train the model
-        train_rows = self.gateway.jvm.io.citrine.lolo.TrainingRow.build(
+        train_rows = self.gateway.jvm.io.citrine.lolo.api.TrainingRow.build(
             train_data, self.gateway.jvm.scala.Some(weights_java)
         )
         rng = self.gateway.jvm.io.citrine.lolo.util.LoloPyRandom.getRng(random_seed) if random_seed \

--- a/src/main/scala/io/citrine/lolo/api/Learner.scala
+++ b/src/main/scala/io/citrine/lolo/api/Learner.scala
@@ -1,4 +1,4 @@
-package io.citrine.lolo
+package io.citrine.lolo.api
 
 import io.citrine.random.Random
 

--- a/src/main/scala/io/citrine/lolo/api/Model.scala
+++ b/src/main/scala/io/citrine/lolo/api/Model.scala
@@ -1,4 +1,4 @@
-package io.citrine.lolo
+package io.citrine.lolo.api
 
 import breeze.linalg.DenseMatrix
 

--- a/src/main/scala/io/citrine/lolo/api/PredictionResult.scala
+++ b/src/main/scala/io/citrine/lolo/api/PredictionResult.scala
@@ -1,4 +1,4 @@
-package io.citrine.lolo
+package io.citrine.lolo.api
 
 /**
   * Container for prediction results; must include expected values

--- a/src/main/scala/io/citrine/lolo/api/TrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/api/TrainingResult.scala
@@ -1,4 +1,4 @@
-package io.citrine.lolo
+package io.citrine.lolo.api
 
 trait TrainingResult[+T] extends Serializable {
 

--- a/src/main/scala/io/citrine/lolo/api/TrainingRow.scala
+++ b/src/main/scala/io/citrine/lolo/api/TrainingRow.scala
@@ -1,4 +1,4 @@
-package io.citrine.lolo
+package io.citrine.lolo.api
 
 /**
   * A bundle of (inputs, label, weight) used for training a [[Learner]].

--- a/src/main/scala/io/citrine/lolo/bags/BaggedModel.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedModel.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.bags
 
 import breeze.linalg.DenseMatrix
-import io.citrine.lolo.Model
+import io.citrine.lolo.api.Model
 
 import scala.collection.parallel.immutable.ParSeq
 

--- a/src/main/scala/io/citrine/lolo/bags/BaggedPrediction.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedPrediction.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.bags
 
 import breeze.linalg.{norm, DenseMatrix, DenseVector}
-import io.citrine.lolo.{PredictionResult, RegressionResult}
+import io.citrine.lolo.api.{PredictionResult, RegressionResult}
 import org.slf4j.{Logger, LoggerFactory}
 
 /**

--- a/src/main/scala/io/citrine/lolo/bags/BaggedTrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggedTrainingResult.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.bags
 
+import io.citrine.lolo.api.{Model, TrainingResult, TrainingRow}
 import io.citrine.lolo.stats.metrics.{ClassificationMetrics, RegressionMetrics}
-import io.citrine.lolo.{Model, TrainingResult, TrainingRow}
 
 import scala.collection.parallel.immutable.ParSeq
 

--- a/src/main/scala/io/citrine/lolo/bags/Bagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/Bagger.scala
@@ -1,8 +1,8 @@
 package io.citrine.lolo.bags
 
 import breeze.stats.distributions.Poisson
+import io.citrine.lolo.api.{Learner, Model, TrainingRow}
 import io.citrine.lolo.bags.Bagger.BaggedEnsemble
-import io.citrine.lolo.{Learner, Model, TrainingRow}
 import io.citrine.lolo.stats.StatsUtils
 import io.citrine.random.Random
 

--- a/src/main/scala/io/citrine/lolo/bags/BaggerHelper.scala
+++ b/src/main/scala/io/citrine/lolo/bags/BaggerHelper.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.bags
 
 import io.citrine.lolo.stats.{MathUtils, StatsUtils}
-import io.citrine.lolo.{Model, TrainingRow}
+import io.citrine.lolo.api.{Model, TrainingRow}
 
 import scala.collection.parallel.immutable.ParSeq
 

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -1,18 +1,8 @@
 package io.citrine.lolo.bags
 
 import breeze.stats.distributions.Poisson
+import io.citrine.lolo.api.{Learner, Model, MultiTaskLearner, MultiTaskModel, MultiTaskModelPredictionResult, MultiTaskTrainingResult, ParallelModelsPredictionResult, PredictionResult, TrainingRow}
 import io.citrine.lolo.stats.StatsUtils
-import io.citrine.lolo.{
-  Learner,
-  Model,
-  MultiTaskLearner,
-  MultiTaskModel,
-  MultiTaskModelPredictionResult,
-  MultiTaskTrainingResult,
-  ParallelModelsPredictionResult,
-  PredictionResult,
-  TrainingRow
-}
 import io.citrine.random.Random
 import io.citrine.lolo.stats.metrics.{ClassificationMetrics, RegressionMetrics}
 

--- a/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
+++ b/src/main/scala/io/citrine/lolo/bags/MultiTaskBagger.scala
@@ -1,7 +1,17 @@
 package io.citrine.lolo.bags
 
 import breeze.stats.distributions.Poisson
-import io.citrine.lolo.api.{Learner, Model, MultiTaskLearner, MultiTaskModel, MultiTaskModelPredictionResult, MultiTaskTrainingResult, ParallelModelsPredictionResult, PredictionResult, TrainingRow}
+import io.citrine.lolo.api.{
+  Learner,
+  Model,
+  MultiTaskLearner,
+  MultiTaskModel,
+  MultiTaskModelPredictionResult,
+  MultiTaskTrainingResult,
+  ParallelModelsPredictionResult,
+  PredictionResult,
+  TrainingRow
+}
 import io.citrine.lolo.stats.StatsUtils
 import io.citrine.random.Random
 import io.citrine.lolo.stats.metrics.{ClassificationMetrics, RegressionMetrics}

--- a/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/GridHyperOptimizer.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.hypers
 
-import io.citrine.lolo.{Learner, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingRow}
 import io.citrine.random.Random
 
 /** Brute force search over the grid of hypers. */

--- a/src/main/scala/io/citrine/lolo/hypers/HyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/HyperOptimizer.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.hypers
 
-import io.citrine.lolo.{Learner, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingRow}
 import io.citrine.random.Random
 
 /**

--- a/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
+++ b/src/main/scala/io/citrine/lolo/hypers/RandomHyperOptimizer.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.hypers
 
-import io.citrine.lolo.{Learner, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingRow}
 import io.citrine.random.Random
 
 /**

--- a/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
+++ b/src/main/scala/io/citrine/lolo/learners/ExtraRandomTrees.scala
@@ -1,12 +1,12 @@
 package io.citrine.lolo.learners
 
+import io.citrine.lolo.api.{Learner, TrainingResult, TrainingRow}
 import io.citrine.random.Random
 import io.citrine.lolo.bags.{ClassificationBagger, RegressionBagger}
 import io.citrine.lolo.transformers.rotator.FeatureRotator
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import io.citrine.lolo.trees.splits.{ExtraRandomClassificationSplitter, ExtraRandomRegressionSplitter}
-import io.citrine.lolo.{Learner, TrainingResult, TrainingRow}
 
 /**
   * Extremely randomized tree ensemble for regression.

--- a/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
+++ b/src/main/scala/io/citrine/lolo/learners/RandomForest.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo.learners
 
+import io.citrine.lolo.api.{Learner, MultiTaskLearner, MultiTaskTrainingResult, TrainingResult, TrainingRow}
 import io.citrine.random.Random
 import io.citrine.lolo.bags.{ClassificationBagger, MultiTaskBagger, RegressionBagger}
 import io.citrine.lolo.transformers.rotator.{FeatureRotator, MultiTaskFeatureRotator}
@@ -8,7 +9,6 @@ import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import io.citrine.lolo.trees.splits.{ClassificationSplitter, MultiTaskSplitter, RegressionSplitter}
-import io.citrine.lolo.{Learner, MultiTaskLearner, MultiTaskTrainingResult, TrainingResult, TrainingRow}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.linear
 
+import io.citrine.lolo.api.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 import io.citrine.random.Random
-import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 
 case class GuessTheMeanLearner() extends Learner[Double] {
 

--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMode.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMode.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.linear
 
+import io.citrine.lolo.api.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 import io.citrine.random.Random
-import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 
 case class GuessTheModeLearner[T]() extends Learner[T] {
 

--- a/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
+++ b/src/main/scala/io/citrine/lolo/linear/LinearRegression.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.linear
 
 import breeze.linalg.{diag, sum, DenseMatrix, DenseVector}
-import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
+import io.citrine.lolo.api.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 import io.citrine.random.Random
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/io/citrine/lolo/transformers/rotator/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/rotator/FeatureRotator.scala
@@ -2,10 +2,11 @@ package io.citrine.lolo.transformers.rotator
 
 import io.citrine.lolo._
 import io.citrine.random.Random
-import breeze.linalg.{diag, qr, DenseMatrix, DenseVector}
+import breeze.linalg.{DenseMatrix, DenseVector, diag, qr}
 import breeze.linalg.qr.QR
 import breeze.numerics.signum
 import breeze.stats.distributions.Gaussian
+import io.citrine.lolo.api.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 import io.citrine.lolo.stats.StatsUtils.breezeRandBasis
 
 /**

--- a/src/main/scala/io/citrine/lolo/transformers/rotator/FeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/rotator/FeatureRotator.scala
@@ -2,7 +2,7 @@ package io.citrine.lolo.transformers.rotator
 
 import io.citrine.lolo._
 import io.citrine.random.Random
-import breeze.linalg.{DenseMatrix, DenseVector, diag, qr}
+import breeze.linalg.{diag, qr, DenseMatrix, DenseVector}
 import breeze.linalg.qr.QR
 import breeze.numerics.signum
 import breeze.stats.distributions.Gaussian

--- a/src/main/scala/io/citrine/lolo/transformers/rotator/MultiTaskFeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/rotator/MultiTaskFeatureRotator.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.transformers.rotator
 
 import breeze.linalg.DenseMatrix
-import io.citrine.lolo.{Model, MultiTaskLearner, MultiTaskModel, MultiTaskTrainingResult, ParallelModels, TrainingRow}
+import io.citrine.lolo.api.{Model, MultiTaskLearner, MultiTaskModel, MultiTaskTrainingResult, ParallelModels, TrainingRow}
 import io.citrine.random.Random
 
 case class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiTaskLearner {

--- a/src/main/scala/io/citrine/lolo/transformers/rotator/MultiTaskFeatureRotator.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/rotator/MultiTaskFeatureRotator.scala
@@ -1,7 +1,14 @@
 package io.citrine.lolo.transformers.rotator
 
 import breeze.linalg.DenseMatrix
-import io.citrine.lolo.api.{Model, MultiTaskLearner, MultiTaskModel, MultiTaskTrainingResult, ParallelModels, TrainingRow}
+import io.citrine.lolo.api.{
+  Model,
+  MultiTaskLearner,
+  MultiTaskModel,
+  MultiTaskTrainingResult,
+  ParallelModels,
+  TrainingRow
+}
 import io.citrine.random.Random
 
 case class MultiTaskFeatureRotator(baseLearner: MultiTaskLearner) extends MultiTaskLearner {

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
@@ -1,6 +1,5 @@
 package io.citrine.lolo.transformers.standardizer
 
-import io.citrine.lolo.api
 import io.citrine.lolo.api.{
   Model,
   MultiTaskLearner,
@@ -48,7 +47,7 @@ case class MultiTaskStandardizerTrainingResult(
     inputTrans: Seq[Option[Standardization]]
 ) extends MultiTaskTrainingResult {
 
-  override def model: MultiTaskModel = api.ParallelModels(models, baseTrainingResult.model.realLabels)
+  override def model: MultiTaskModel = ParallelModels(models, baseTrainingResult.model.realLabels)
 
   override def models: Seq[StandardizerModel[Any]] = {
     val realLabels = baseTrainingResult.model.realLabels

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
@@ -1,7 +1,14 @@
 package io.citrine.lolo.transformers.standardizer
 
 import io.citrine.lolo.api
-import io.citrine.lolo.api.{Model, MultiTaskLearner, MultiTaskModel, MultiTaskTrainingResult, ParallelModels, TrainingRow}
+import io.citrine.lolo.api.{
+  Model,
+  MultiTaskLearner,
+  MultiTaskModel,
+  MultiTaskTrainingResult,
+  ParallelModels,
+  TrainingRow
+}
 import io.citrine.random.Random
 
 /**

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizer.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.transformers.standardizer
 
-import io.citrine.lolo.{Model, MultiTaskLearner, MultiTaskModel, MultiTaskTrainingResult, ParallelModels, TrainingRow}
+import io.citrine.lolo.api
+import io.citrine.lolo.api.{Model, MultiTaskLearner, MultiTaskModel, MultiTaskTrainingResult, ParallelModels, TrainingRow}
 import io.citrine.random.Random
 
 /**
@@ -40,7 +41,7 @@ case class MultiTaskStandardizerTrainingResult(
     inputTrans: Seq[Option[Standardization]]
 ) extends MultiTaskTrainingResult {
 
-  override def model: MultiTaskModel = ParallelModels(models, baseTrainingResult.model.realLabels)
+  override def model: MultiTaskModel = api.ParallelModels(models, baseTrainingResult.model.realLabels)
 
   override def models: Seq[StandardizerModel[Any]] = {
     val realLabels = baseTrainingResult.model.realLabels

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/Standardizer.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/Standardizer.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.transformers.standardizer
 
-import io.citrine.lolo.{Learner, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingRow}
 import io.citrine.random.Random
 
 trait Standardizer[T] extends Learner[T] {

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.transformers.standardizer
 
-import io.citrine.lolo.Model
+import io.citrine.lolo.api.Model
 
 trait StandardizerModel[+T] extends Model[T] {
 

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerPrediction.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerPrediction.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.transformers.standardizer
 
-import io.citrine.lolo.PredictionResult
+import io.citrine.lolo.api.PredictionResult
 
 trait StandardizerPrediction[+T] extends PredictionResult[T] {
 

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerTrainingResult.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerTrainingResult.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.transformers.standardizer
 
-import io.citrine.lolo.TrainingResult
+import io.citrine.lolo.api.TrainingResult
 
 /** Training result wrapping the base learner's training result next to the transformations. */
 trait StandardizerTrainingResult[+T] extends TrainingResult[T] {

--- a/src/main/scala/io/citrine/lolo/trees/ModelNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/ModelNode.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.trees
 
 import breeze.linalg.DenseMatrix
-import io.citrine.lolo.{Model, PredictionResult}
+import io.citrine.lolo.api.{Model, PredictionResult}
 import io.citrine.lolo.trees.splits.Split
 
 trait ModelNode[+T] extends Serializable {

--- a/src/main/scala/io/citrine/lolo/trees/TrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/TrainingNode.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees
 
-import io.citrine.lolo.{Model, TrainingResult, TrainingRow}
+import io.citrine.lolo.api.{Model, TrainingResult, TrainingRow}
 
 import scala.collection.mutable
 

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingLeaf.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.classification
 
-import io.citrine.lolo.{Learner, TrainingResult, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingResult, TrainingRow}
 import io.citrine.lolo.trees.TrainingLeaf
 import io.citrine.random.Random
 

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTrainingNode.scala
@@ -2,7 +2,7 @@ package io.citrine.lolo.trees.classification
 
 import io.citrine.lolo.trees.splits.{NoSplit, Split, Splitter}
 import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingNode}
-import io.citrine.lolo.{Learner, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingRow}
 import io.citrine.random.Random
 
 import scala.collection.mutable

--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -1,11 +1,11 @@
 package io.citrine.lolo.trees.classification
 
+import io.citrine.lolo.api.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 import io.citrine.random.Random
 import io.citrine.lolo.encoders.CategoricalEncoder
 import io.citrine.lolo.linear.GuessTheModeLearner
 import io.citrine.lolo.trees.splits.{ClassificationSplitter, Splitter}
 import io.citrine.lolo.trees.{ModelNode, TrainingNode, TreeMeta}
-import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 
 import scala.collection.mutable
 

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTrainingNode.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.multitask
 
-import io.citrine.lolo.{PredictionResult, TrainingRow}
+import io.citrine.lolo.api.{PredictionResult, TrainingRow}
 import io.citrine.lolo.linear.{GuessTheMeanLearner, GuessTheModeLearner}
 import io.citrine.lolo.trees.classification.ClassificationTrainingLeaf
 import io.citrine.lolo.trees.regression.RegressionTrainingLeaf

--- a/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/multitask/MultiTaskTree.scala
@@ -1,12 +1,12 @@
 package io.citrine.lolo.trees.multitask
 
+import io.citrine.lolo.api.{Model, MultiTaskLearner, MultiTaskTrainingResult, ParallelModels, TrainingRow}
 import io.citrine.random.Random
 import io.citrine.lolo.encoders.CategoricalEncoder
 import io.citrine.lolo.trees.ModelNode
 import io.citrine.lolo.trees.classification.ClassificationTree
 import io.citrine.lolo.trees.regression.RegressionTree
 import io.citrine.lolo.trees.splits.MultiTaskSplitter
-import io.citrine.lolo.{Model, MultiTaskLearner, MultiTaskTrainingResult, ParallelModels, TrainingRow}
 
 /**
   * A tree learner that operates on multiple labels.

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingLeaf.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.trees.regression
 
+import io.citrine.lolo.api.{Learner, TrainingResult, TrainingRow}
 import io.citrine.lolo.trees.TrainingLeaf
-import io.citrine.lolo.{Learner, TrainingResult, TrainingRow}
 import io.citrine.random.Random
 
 import scala.collection.mutable

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTrainingNode.scala
@@ -2,7 +2,7 @@ package io.citrine.lolo.trees.regression
 
 import io.citrine.lolo.trees.splits.{NoSplit, Split, Splitter}
 import io.citrine.lolo.trees.{InternalModelNode, ModelNode, TrainingNode}
-import io.citrine.lolo.{Learner, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingRow}
 import io.citrine.random.Random
 
 case class RegressionTrainingNode(

--- a/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/regression/RegressionTree.scala
@@ -1,12 +1,12 @@
 package io.citrine.lolo.trees.regression
 
 import breeze.linalg.DenseMatrix
+import io.citrine.lolo.api.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 import io.citrine.random.Random
 import io.citrine.lolo.encoders.CategoricalEncoder
 import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.trees.splits.{RegressionSplitter, Splitter}
 import io.citrine.lolo.trees.{ModelNode, TrainingNode, TreeMeta}
-import io.citrine.lolo.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 
 import scala.collection.mutable
 

--- a/src/main/scala/io/citrine/lolo/trees/splits/BoltzmannSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/BoltzmannSplitter.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.TrainingRow
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.VarianceCalculator
 import io.citrine.lolo.trees.splits.BoltzmannSplitter.SplitterResult

--- a/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ClassificationSplitter.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.TrainingRow
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.GiniCalculator
 

--- a/src/main/scala/io/citrine/lolo/trees/splits/ExtraRandomClassificationSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ExtraRandomClassificationSplitter.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.TrainingRow
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.{GiniCalculator, ImpurityCalculator}
 

--- a/src/main/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitter.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.TrainingRow
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.{ImpurityCalculator, VarianceCalculator}
 

--- a/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/MultiTaskSplitter.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.TrainingRow
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.random.Random
 import io.citrine.lolo.trees.impurity.MultiImpurityCalculator
 

--- a/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/RegressionSplitter.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.TrainingRow
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.trees.impurity.VarianceCalculator
 import io.citrine.random.Random
 

--- a/src/main/scala/io/citrine/lolo/trees/splits/Splitter.scala
+++ b/src/main/scala/io/citrine/lolo/trees/splits/Splitter.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.TrainingRow
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.trees.impurity.ImpurityCalculator
 import io.citrine.random.Random
 

--- a/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
+++ b/src/main/scala/io/citrine/lolo/util/LoloPyDataLoader.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.zip._
-import io.citrine.lolo.{MultiTaskModelPredictionResult, PredictionResult}
+import io.citrine.lolo.api.{MultiTaskModelPredictionResult, PredictionResult}
 
 /**
   * Tool used to transfer data from LoloPy to the JVM

--- a/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/CrossValidation.scala
@@ -1,7 +1,7 @@
 package io.citrine.lolo.validation
 
+import io.citrine.lolo.api.{Learner, PredictionResult, TrainingRow}
 import io.citrine.random.Random
-import io.citrine.lolo.{Learner, PredictionResult, TrainingRow}
 
 /**
   * Methods tha use cross-validation to calculate predicted-vs-actual data and metric estimates

--- a/src/main/scala/io/citrine/lolo/validation/Merit.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Merit.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.validation
 
-import io.citrine.lolo.PredictionResult
+import io.citrine.lolo.api.PredictionResult
 import io.citrine.random.Random
 import org.knowm.xchart.XYChart
 

--- a/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
+++ b/src/main/scala/io/citrine/lolo/validation/StatisticalValidation.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.validation
 
-import io.citrine.lolo.{Learner, PredictionResult, TrainingRow}
+import io.citrine.lolo.api.{Learner, PredictionResult, TrainingRow}
 import io.citrine.random.Random
 
 /**

--- a/src/main/scala/io/citrine/lolo/validation/Visualization.scala
+++ b/src/main/scala/io/citrine/lolo/validation/Visualization.scala
@@ -1,6 +1,6 @@
 package io.citrine.lolo.validation
 
-import io.citrine.lolo.PredictionResult
+import io.citrine.lolo.api.PredictionResult
 import org.apache.commons.math3.distribution.CauchyDistribution
 import org.knowm.xchart.XYSeries.XYSeriesRenderStyle
 import org.knowm.xchart._

--- a/src/test/scala/io/citrine/lolo/AccuracyTest.scala
+++ b/src/test/scala/io/citrine/lolo/AccuracyTest.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo
 
+import io.citrine.lolo.api.{Learner, TrainingRow}
 import io.citrine.lolo.bags.{Bagger, RegressionBagger}
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import io.citrine.lolo.trees.splits.{BoltzmannSplitter, RegressionSplitter}

--- a/src/test/scala/io/citrine/lolo/DataGenerator.scala
+++ b/src/test/scala/io/citrine/lolo/DataGenerator.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo
 
 import breeze.stats.variance
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.linear.LinearRegressionLearner
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.random.Random

--- a/src/test/scala/io/citrine/lolo/PerformanceTest.scala
+++ b/src/test/scala/io/citrine/lolo/PerformanceTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo
 
 import io.citrine.lolo.DataGenerator.TrainingData
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.bags.{Bagger, ClassificationBagger, MultiTaskBagger, RegressionBagger}
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner

--- a/src/test/scala/io/citrine/lolo/bags/BaggedPredictionTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggedPredictionTest.scala
@@ -1,7 +1,8 @@
 package io.citrine.lolo.bags
 
 import breeze.stats.distributions.{Beta, RandBasis}
-import io.citrine.lolo.{DataGenerator, RegressionResult, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.{RegressionResult, TrainingRow}
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.regression.RegressionTreeLearner

--- a/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/BaggerTest.scala
@@ -1,7 +1,8 @@
 package io.citrine.lolo.bags
 
 import breeze.linalg.DenseMatrix
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TestUtils, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TestUtils}
 import io.citrine.lolo.linear.{GuessTheMeanLearner, LinearRegressionLearner}
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.transformers.rotator.FeatureRotator

--- a/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
+++ b/src/test/scala/io/citrine/lolo/bags/MultiTaskBaggerTest.scala
@@ -1,7 +1,8 @@
 package io.citrine.lolo.bags
 
 import breeze.stats.distributions.{Beta, RandBasis}
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.lolo.linear.GuessTheMeanLearner
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics

--- a/src/test/scala/io/citrine/lolo/learners/ExtraRandomTreesTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/ExtraRandomTreesTest.scala
@@ -1,7 +1,8 @@
 package io.citrine.lolo.learners
 
 import breeze.stats.distributions.{Beta, RandBasis}
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import io.citrine.random.Random

--- a/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
+++ b/src/test/scala/io/citrine/lolo/learners/RandomForestTest.scala
@@ -2,7 +2,8 @@ package io.citrine.lolo.learners
 
 import breeze.linalg.DenseMatrix
 import breeze.stats.distributions.{Beta, RandBasis}
-import io.citrine.lolo.{DataGenerator, Learner, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.{Learner, TrainingRow}
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.lolo.bags.MultiTaskBaggedPrediction
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.regression.RegressionTreeLearner

--- a/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
+++ b/src/test/scala/io/citrine/lolo/linear/LinearRegressionTest.scala
@@ -1,7 +1,8 @@
 package io.citrine.lolo.linear
 
 import breeze.linalg.{norm, DenseMatrix, DenseVector}
-import io.citrine.lolo.{SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.SeedRandomMixIn
+import io.citrine.lolo.api.TrainingRow
 import org.junit.Test
 
 /**

--- a/src/test/scala/io/citrine/lolo/transformers/rotator/FeatureRotatorTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/rotator/FeatureRotatorTest.scala
@@ -1,11 +1,12 @@
 package io.citrine.lolo.transformers.rotator
 
 import breeze.linalg.{det, DenseMatrix}
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.linear.{GuessTheMeanLearner, LinearRegressionLearner}
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import org.junit.Test
 
 /**

--- a/src/test/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/standardizer/MultiTaskStandardizerTest.scala
@@ -1,9 +1,10 @@
 package io.citrine.lolo.transformers.standardizer
 
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.trees.multitask.MultiTaskTreeLearner
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import org.junit.Test
 
 class MultiTaskStandardizerTest extends SeedRandomMixIn {

--- a/src/test/scala/io/citrine/lolo/transformers/standardizer/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/standardizer/StandardizerTest.scala
@@ -1,9 +1,10 @@
 package io.citrine.lolo.transformers.standardizer
 
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.linear.{GuessTheMeanLearner, LinearRegressionLearner}
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import org.junit.Test
 
 @Test

--- a/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.classification
 
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.lolo.stats.functions.Friedman
 import org.junit.Test
 import org.scalatest.Assertions._

--- a/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.multitask
 
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.stats.metrics.ClassificationMetrics
 import io.citrine.lolo.trees.classification.{ClassificationTree, ClassificationTreeLearner}

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -2,7 +2,8 @@ package io.citrine.lolo.trees.regression
 
 import java.io.{File, FileOutputStream, ObjectOutputStream}
 import breeze.linalg.DenseMatrix
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TestUtils, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TestUtils}
 import io.citrine.lolo.linear.LinearRegressionLearner
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.splits.{BoltzmannSplitter, RegressionSplitter}

--- a/src/test/scala/io/citrine/lolo/trees/splits/BoltzmannSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/BoltzmannSplitterTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.{SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.SeedRandomMixIn
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.random.Random
 import org.junit.Test
 

--- a/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/ClassificationSplitterTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.lolo.encoders.CategoricalEncoder
 import io.citrine.theta.Stopwatch
 

--- a/src/test/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/ExtraRandomRegressionSplitterTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.api.TrainingRow
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import io.citrine.random.Random
 import org.junit.Test
 

--- a/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/MultiTaskSplitterTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.{SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.SeedRandomMixIn
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.trees.impurity.MultiImpurityCalculator
 import org.junit.Test
 

--- a/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/splits/SplitterTest.scala
@@ -1,6 +1,7 @@
 package io.citrine.lolo.trees.splits
 
-import io.citrine.lolo.{SeedRandomMixIn, TrainingRow}
+import io.citrine.lolo.SeedRandomMixIn
+import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.trees.impurity.VarianceCalculator
 import org.junit.Test
 

--- a/src/test/scala/io/citrine/lolo/util/LoloPyDataLoaderTest.scala
+++ b/src/test/scala/io/citrine/lolo/util/LoloPyDataLoaderTest.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo.util
-import io.citrine.lolo.PredictionResult
+
+import io.citrine.lolo.api.PredictionResult
 import io.citrine.lolo.learners.RandomForestRegressor
 import org.junit.Test
 

--- a/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
+++ b/src/test/scala/io/citrine/lolo/validation/CalibrationStudy.scala
@@ -1,9 +1,10 @@
 package io.citrine.lolo.validation
 
+import io.citrine.lolo.api.{PredictionResult, TrainingRow}
 import io.citrine.lolo.bags.{Bagger, RegressionBagger}
 import io.citrine.lolo.stats.functions.{Friedman, Linear}
 import io.citrine.lolo.trees.regression.RegressionTreeLearner
-import io.citrine.lolo.{DataGenerator, PredictionResult, SeedRandomMixIn, TestUtils, TrainingRow}
+import io.citrine.lolo.{DataGenerator, SeedRandomMixIn, TestUtils}
 import org.apache.commons.math3.distribution.CauchyDistribution
 import org.knowm.xchart.BitmapEncoder.BitmapFormat
 import org.knowm.xchart.{BitmapEncoder, CategoryChart, CategoryChartBuilder}

--- a/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
+++ b/src/test/scala/io/citrine/lolo/validation/MeritTest.scala
@@ -1,7 +1,8 @@
 package io.citrine.lolo.validation
 
 import io.citrine.random.Random
-import io.citrine.lolo.{PredictionResult, SeedRandomMixIn}
+import io.citrine.lolo.SeedRandomMixIn
+import io.citrine.lolo.api.PredictionResult
 import org.apache.commons.math3.distribution.MultivariateNormalDistribution
 import org.apache.commons.math3.random.MersenneTwister
 import org.junit.Test


### PR DESCRIPTION
A straight refactor, moving the top-level interfaces into their own `api` folder. The only code update is in `learners.py` to correct a path calling `TrainingRow.build`.