### PR TITLE
Fix roundoff error in GTM learner

### DIFF
--- a/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
+++ b/src/main/scala/io/citrine/lolo/linear/GuessTheMean.scala
@@ -7,8 +7,14 @@ import io.citrine.random.Random
 case class GuessTheMeanLearner() extends Learner[Double] {
 
   override def train(trainingData: Seq[TrainingRow[Double]], rng: Random): GuessTheMeanTrainingResult[Double] = {
-    val totalWeight = trainingData.map(_.weight).sum
-    val mean = trainingData.map { case TrainingRow(_, label, weight) => label * weight }.sum / totalWeight
+    val trainingLabels = trainingData.map(_.label)
+    val allEqual = trainingLabels.forall(_ == trainingLabels.head)
+    val mean = if (allEqual) {
+      trainingLabels.head
+    } else {
+      val totalWeight = trainingData.map(_.weight).sum
+      trainingData.map { case TrainingRow(_, label, weight) => label * weight }.sum / totalWeight
+    }
     GuessTheMeanTrainingResult(GuessTheMeanModel(mean))
   }
 }

--- a/src/test/scala/io/citrine/lolo/linear/GuessTheMeanTest.scala
+++ b/src/test/scala/io/citrine/lolo/linear/GuessTheMeanTest.scala
@@ -1,0 +1,31 @@
+package io.citrine.lolo.linear
+
+import io.citrine.lolo.api.TrainingRow
+import org.junit.Test
+
+class GuessTheMeanTest {
+
+  val learner = GuessTheMeanLearner()
+
+  /** GuessTheMeanLearner should compute the weighted mean of training data. */
+  @Test
+  def testMean(): Unit = {
+    val trainingData = Seq(
+      TrainingRow[Double](Vector(), label = 0.0, weight = 1.0),
+      TrainingRow[Double](Vector(), label = 6.0, weight = 2.0),
+      TrainingRow[Double](Vector(), label = 10.0, weight = 0.0)
+    )
+    val expectedMean = 4.0 // (0.0 * 1.0 + 6.0 * 2.0 + 10.0 * 0.0) / (1.0 + 2.0 + 0.0)
+    val model = learner.train(trainingData).model
+    assert(model.value == expectedMean, s"weighted mean not calculated correctly, expected $expectedMean, got ${model.value}")
+  }
+
+  /** If the training values are identical then the mean should be identical (no roundoff error). */
+  @Test
+  def testIdenticalTrainingValues(): Unit = {
+    val label = -0.9248073518671174
+    val trainingData = Seq.fill(3)(TrainingRow[Double](Vector(), label = label, weight = 1.0))
+    val model = learner.train(trainingData).model
+    assert(model.value == label, s"GuessTheMean learner experiences roundoff error, expected $label, got ${model.value}")
+  }
+}

--- a/src/test/scala/io/citrine/lolo/linear/GuessTheMeanTest.scala
+++ b/src/test/scala/io/citrine/lolo/linear/GuessTheMeanTest.scala
@@ -17,7 +17,10 @@ class GuessTheMeanTest {
     )
     val expectedMean = 4.0 // (0.0 * 1.0 + 6.0 * 2.0 + 10.0 * 0.0) / (1.0 + 2.0 + 0.0)
     val model = learner.train(trainingData).model
-    assert(model.value == expectedMean, s"weighted mean not calculated correctly, expected $expectedMean, got ${model.value}")
+    assert(
+      model.value == expectedMean,
+      s"weighted mean not calculated correctly, expected $expectedMean, got ${model.value}"
+    )
   }
 
   /** If the training values are identical then the mean should be identical (no roundoff error). */
@@ -26,6 +29,9 @@ class GuessTheMeanTest {
     val label = -0.9248073518671174
     val trainingData = Seq.fill(3)(TrainingRow[Double](Vector(), label = label, weight = 1.0))
     val model = learner.train(trainingData).model
-    assert(model.value == label, s"GuessTheMean learner experiences roundoff error, expected $label, got ${model.value}")
+    assert(
+      model.value == label,
+      s"GuessTheMean learner experiences roundoff error, expected $label, got ${model.value}"
+    )
   }
 }


### PR DESCRIPTION
The `GuessTheMeanLearner` exhibits roundoff error when the training data are identical. This can be an issue when the training data value in question is extremal and coupled with a `Standardizer`. The roundoff error can push the resulting prediction out of bounds.