### PR TITLE
PNE 363 Emit Shapley Values

### DIFF
--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
@@ -12,8 +12,7 @@ trait StandardizerModel[+T] extends Model[T] {
   override def transform(inputs: Seq[Vector[Any]]): StandardizerPrediction[T]
 
   override def shapley(input: Vector[Any], omitFeatures: Set[Int] = Set()): Option[DenseMatrix[Double]] = {
-      val baseModel_ = baseModel
-      baseModel_.shapley(input, omitFeatures)
+    baseModel.shapley(input, omitFeatures)
   }
 }
 

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo.transformers.standardizer
 
+import breeze.linalg.DenseMatrix
 import io.citrine.lolo.api.Model
 
 trait StandardizerModel[+T] extends Model[T] {
@@ -9,6 +10,11 @@ trait StandardizerModel[+T] extends Model[T] {
 
   /** Standardize the inputs and apply the base model. */
   override def transform(inputs: Seq[Vector[Any]]): StandardizerPrediction[T]
+
+  override def shapley(input: Vector[Any], omitFeatures: Set[Int] = Set()): Option[DenseMatrix[Double]] = {
+      val baseModel_ = baseModel
+      baseModel_.shapley(input, omitFeatures)
+  }
 }
 
 case class RegressionStandardizerModel(

--- a/src/test/scala/io/citrine/lolo/transformers/standardizer/StandardizerTest.scala
+++ b/src/test/scala/io/citrine/lolo/transformers/standardizer/StandardizerTest.scala
@@ -4,6 +4,7 @@ import io.citrine.lolo.api.TrainingRow
 import io.citrine.lolo.linear.{GuessTheMeanLearner, LinearRegressionLearner}
 import io.citrine.lolo.stats.functions.Friedman
 import io.citrine.lolo.trees.classification.ClassificationTreeLearner
+import io.citrine.lolo.trees.regression.RegressionTreeLearner
 import io.citrine.lolo.{DataGenerator, SeedRandomMixIn}
 import org.junit.Test
 
@@ -174,6 +175,21 @@ class StandardizerTest extends SeedRandomMixIn {
     result.zip(standardResult).foreach {
       case (free: String, standard: String) =>
         assert(free == standard, s"Standard classification tree should be the same")
+    }
+  }
+
+  /**
+    * Shapley values should be calculated on the standardized tree
+    */
+  @Test
+  def testStandardTreeShapley(): Unit = {
+    val learner = RegressionTreeLearner()
+    val standardLearner = RegressionStandardizer(learner)
+    val standardModel = standardLearner.train(data).model
+
+    data.foreach {
+      case row =>
+        assert(standardModel.shapley(row.inputs).isDefined, "Shapley should be defined")
     }
   }
 }


### PR DESCRIPTION
Fixes a bug in which `RegressionStandardizerModel`s did not call the shapley correctly. Added an override shapley method to `RegressionStandardizerModel` so that the models call the shapley method based on the base model type instead of the generic `Model[T].shapley()` which always returns None.