### PR TITLE
Pne 424 multitask classification shapley

### DIFF
--- a/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
+++ b/src/main/scala/io/citrine/lolo/trees/classification/ClassificationTree.scala
@@ -1,5 +1,6 @@
 package io.citrine.lolo.trees.classification
 
+import breeze.linalg.DenseMatrix
 import io.citrine.lolo.api.{Learner, Model, PredictionResult, TrainingResult, TrainingRow}
 import io.citrine.random.Random
 import io.citrine.lolo.encoders.CategoricalEncoder
@@ -124,6 +125,19 @@ case class ClassificationTree(
       inputs.map(inp => rootModelNode.transform(CategoricalEncoder.encodeInput(inp, inputEncoders))),
       outputEncoder
     )
+  }
+
+  /**
+    * Compute Shapley feature attributions for a given input
+    *
+    * @param input for which to compute feature attributions.
+    * @param omitFeatures feature indices to omit in computing Shapley values
+    * @return array of Shapley feature attributions, one per input feature, each a vector of
+    *         One Vector[Double] per feature, each of length equal to the output dimension.
+    *         The output dimension is 1 for single-task regression, or equal to the number of classification categories.
+    */
+  override def shapley(input: Vector[Any], omitFeatures: Set[Int] = Set()): Option[DenseMatrix[Double]] = {
+    rootModelNode.shapley(CategoricalEncoder.encodeInput(input, inputEncoders), omitFeatures)
   }
 }
 

--- a/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
@@ -128,28 +128,30 @@ class ClassificationTreeTest extends SeedRandomMixIn {
     val DTLearner = ClassificationTreeLearner()
     val DTMeta = DTLearner.train(shapTrainingData)
     val DT = DTMeta.model
-    // baseValue is the average of the training labels
-    val baseValue = 0.5
+    // baseValue is the average of the training labels.
+    // Note that labels are internally encoded as 1 and 2 not 0 and 1
+    val baseValue = 1.5
 
     // Assert we obtain Shapley values
-    val shapley1 = DT.shapley(Vector.fill[Any](5)(1.0))
+    val shapley1 = DT.shapley(Vector.fill[Any](5)(0.0))
     assert(shapley1.isDefined, "Shapley values should be defined")
     // Shapley values should sum to the difference between the prediction and the base value
     val shapley1Sum = shapley1.get.valuesIterator.sum
-    assert(shapley1Sum + baseValue - 1 < 1e-6, s"Shapley sum is $shapley1Sum")
+    assert(math.abs(shapley1Sum + baseValue - 1) < 1e-6, s"Shapley sum is $shapley1Sum")
     // Double check that the prediction is as expected
     val pred1 = DT.transform(Seq(Vector.fill[Any](5)(0.0))).expected.head
     assert(pred1 == "1", "Prediction should be 1")
 
     // Same as above, but with all zeros
-    val shapley0 = DT.shapley(Vector.fill[Any](5)(0.0))
+    val shapley0 = DT.shapley(Vector(0.0, 0.0, 0.0, 0.0, 1.0))
     assert(shapley0.isDefined, "Shapley values should be defined")
 
     val shapley0Sum = shapley0.get.valuesIterator.sum
-    assert(shapley0Sum + baseValue - 0 < 1e-6, s"Shapley sum is $shapley0Sum")
+    assert(math.abs(shapley0Sum + baseValue - 2) < 1e-6, s"Shapley sum is $shapley0Sum")
 
-    val pred0 = DT.transform(Seq(Vector.fill[Any](5)(1.0))).expected.head
+    val pred0 = DT.transform(Seq(Vector(0.0, 0.0, 0.0, 0.0, 1.0))).expected.head
     assert(pred0 == "0", "Prediction should be 0")
+
   }
 }
 
@@ -165,5 +167,6 @@ object ClassificationTreeTest {
     new ClassificationTreeTest().testBinary()
     new ClassificationTreeTest().longerTest()
     new ClassificationTreeTest().testCategorical()
+    new ClassificationTreeTest().testShapley()
   }
 }

--- a/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
@@ -142,7 +142,7 @@ class ClassificationTreeTest extends SeedRandomMixIn {
     assert(pred1 == "1", "Prediction should be 1")
 
     // Same as above, but with all zeros
-    val shapley0 = DT.shapley1(Vector.fill[Any](5)(0.0))
+    val shapley0 = DT.shapley(Vector.fill[Any](5)(0.0))
     assert(shapley0.isDefined, "Shapley values should be defined")
 
     val shapley0Sum = shapley0.get.valuesIterator.sum

--- a/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/classification/ClassificationTreeTest.scala
@@ -111,6 +111,46 @@ class ClassificationTreeTest extends SeedRandomMixIn {
     assert(output.gradient.isEmpty)
     output.depth.foreach(d => assert(d > 3 && d < 18, s"Depth is ${d}"))
   }
+
+  @Test
+  def testShapley(): Unit = {
+
+    val shapTrainingData = Seq(
+      TrainingRow(Vector(0.0, 0.0, 0.0, 0.0, 0.0), "1"),
+      TrainingRow(Vector(1.0, 0.0, 0.0, 0.0, 0.0), "1"),
+      TrainingRow(Vector(0.0, 1.0, 0.0, 0.0, 0.0), "1"),
+      TrainingRow(Vector(0.0, 0.0, 1.0, 0.0, 0.0), "0"),
+      TrainingRow(Vector(0.0, 0.0, 0.0, 1.0, 0.0), "0"),
+      TrainingRow(Vector(0.0, 0.0, 0.0, 0.0, 1.0), "0")
+    )
+
+    // Create learner and train
+    val DTLearner = ClassificationTreeLearner()
+    val DTMeta = DTLearner.train(shapTrainingData)
+    val DT = DTMeta.model
+    // baseValue is the average of the training labels
+    val baseValue = 0.5
+
+    // Assert we obtain Shapley values
+    val shapley1 = DT.shapley(Vector.fill[Any](5)(1.0))
+    assert(shapley1.isDefined, "Shapley values should be defined")
+    // Shapley values should sum to the difference between the prediction and the base value
+    val shapley1Sum = shapley1.get.valuesIterator.sum
+    assert(shapley1Sum + baseValue - 1 < 1e-6, s"Shapley sum is $shapley1Sum")
+    // Double check that the prediction is as expected
+    val pred1 = DT.transform(Seq(Vector.fill[Any](5)(0.0))).expected.head
+    assert(pred1 == "1", "Prediction should be 1")
+
+    // Same as above, but with all zeros
+    val shapley0 = DT.shapley1(Vector.fill[Any](5)(0.0))
+    assert(shapley0.isDefined, "Shapley values should be defined")
+
+    val shapley0Sum = shapley0.get.valuesIterator.sum
+    assert(shapley0Sum + baseValue - 0 < 1e-6, s"Shapley sum is $shapley0Sum")
+
+    val pred0 = DT.transform(Seq(Vector.fill[Any](5)(1.0))).expected.head
+    assert(pred0 == "0", "Prediction should be 0")
+  }
 }
 
 /** Companion driver */

--- a/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/multitask/MultiTaskTreeTest.scala
@@ -127,4 +127,20 @@ class MultiTaskTreeTest extends SeedRandomMixIn {
     val importances = multiTaskTrainingResult.featureImportance.get
     assert(importances(1) == importances.max)
   }
+
+  /** Test that shapley values exist for both the regression and classification trees.
+    * Correctness of the shapley values is tested in the ClassificationTreeTest and RegressionTreeTest.
+    */
+  @Test
+  def testShapley(): Unit = {
+    val multiTaskLearner = MultiTaskTreeLearner()
+    val multiTaskTrainingResult = multiTaskLearner.train(TrainingRow.build(inputs.zip(labels)), rng = rng)
+    val models = multiTaskTrainingResult.models
+    // Test shapley values for each individual model.
+    models.foreach { model =>
+      val shapley = model.shapley(inputs.head)
+      assert(shapley.isDefined)
+
+    }
+  }
 }


### PR DESCRIPTION
Extends Shapley to `MultiTaskTree` and `ClassificationTree` models. For the `MultiTaskTree` models Shapley Values are returned for each individual task label (e.g. if model predicts y_1 and y_2, we obtain separate Shapley values for y_1 and y_2). `ClassificationTree` models follow the same implementation as regression trees but are based on numeric class labels.