### PR TITLE
Pne 6240 add transient decorator to shapley

### DIFF
--- a/.github/workflows/deployPyPi.yml
+++ b/.github/workflows/deployPyPi.yml
@@ -1,7 +1,9 @@
 name: Deploy to PyPI
 
 on:
-  workflow_call:
+  push:
+    branches: [main]
+    tags: ['*']
 
 jobs:
   publish:

--- a/src/main/scala/io/citrine/lolo/trees/ModelNode.scala
+++ b/src/main/scala/io/citrine/lolo/trees/ModelNode.scala
@@ -68,8 +68,8 @@ case class InternalModelNode[+T](
     trainingWeight: Double
 ) extends ModelNode[T] {
 
-  private val leftPortion = left.trainingWeight / trainingWeight
-  private val rightPortion = right.trainingWeight / trainingWeight
+  @transient private lazy val leftPortion = left.trainingWeight / trainingWeight
+  @transient private lazy val rightPortion = right.trainingWeight / trainingWeight
 
   /**
     * Just propagate the prediction call through the appropriate child


### PR DESCRIPTION
This change adds a `@transient lazy private val` decorator to the `leftPortion` and `rightPortion` in `ModelNode`. This keeps us from serializing the portions which will break SerDe