### PR TITLE
PNE-6481/shapley-standardization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
       with:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'adopt'
+    - name: Install SBT
+      uses: olafurpg/setup-scala@v11
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
     - name: Release to Maven Central
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,15 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up JDK  # Add Java setup
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: 'adopt'
+    - name: Install SBT  # Add SBT setup
+      uses: olafurpg/setup-scala@v11
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
     - name: Cache pip dependencies
       uses: actions/cache@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,10 @@ jobs:
       with:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'adopt'
+    - name: Install SBT
+      uses: olafurpg/setup-scala@v11
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
     - name: Cache SBT dependencies
       uses: actions/cache@v2
       with:

--- a/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
+++ b/src/main/scala/io/citrine/lolo/transformers/standardizer/StandardizerModel.scala
@@ -11,9 +11,6 @@ trait StandardizerModel[+T] extends Model[T] {
   /** Standardize the inputs and apply the base model. */
   override def transform(inputs: Seq[Vector[Any]]): StandardizerPrediction[T]
 
-  override def shapley(input: Vector[Any], omitFeatures: Set[Int] = Set()): Option[DenseMatrix[Double]] = {
-    baseModel.shapley(input, omitFeatures)
-  }
 }
 
 case class RegressionStandardizerModel(
@@ -26,7 +23,14 @@ case class RegressionStandardizerModel(
     val standardInputs = inputs.map { input => Standardization.applyMulti(input, inputTrans) }
     RegressionStandardizerPrediction(baseModel.transform(standardInputs), outputTrans, inputTrans)
   }
+
+  override def shapley(input: Vector[Any], omitFeatures: Set[Int] = Set()): Option[DenseMatrix[Double]] = {
+    val standardInput = Standardization.applyMulti(input, inputTrans)
+    baseModel.shapley(standardInput, omitFeatures)
+  }
 }
+
+
 
 case class ClassificationStandardizerModel[T](
     baseModel: Model[T],
@@ -37,4 +41,10 @@ case class ClassificationStandardizerModel[T](
     val standardInputs = inputs.map { input => Standardization.applyMulti(input, inputTrans) }
     ClassificationStandardizerPrediction(baseModel.transform(standardInputs), inputTrans)
   }
+
+  override def shapley(input: Vector[Any], omitFeatures: Set[Int] = Set()): Option[DenseMatrix[Double]] = {
+    val standardInput = Standardization.applyMulti(input, inputTrans)
+    baseModel.shapley(standardInput, omitFeatures)
+  }
+  
 }

--- a/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
+++ b/src/test/scala/io/citrine/lolo/trees/regression/RegressionTreeTest.scala
@@ -328,6 +328,62 @@ class RegressionTreeTest extends SeedRandomMixIn {
     val expected4 = Vector(0.0333333333333333, 0.2, 0.8666666666666667, 3.533333333333333, 16.866666666666667)
     shapleyCompare(trainingData4, Vector.fill[Any](5)(1.0), expected4)
 
+    // Referenced against SHAP documentation TreeExplainer Single Split example
+    val N = 100
+    val M = 4
+    val trainingData5 = Seq.fill(N / 2)(TrainingRow(Vector(1.0, 0.0, 0.0, 0.0, 0.0), 1.0)) ++
+      Seq.fill(N / 2)(TrainingRow(Vector(0.0, 0.0, 0.0, 0.0, 0.0), 0.0))
+
+    val expected5a = Vector(0.5, 0.0, 0.0, 0.0, 0.0)
+    val expected5b = Vector(-0.5, 0.0, 0.0, 0.0, 0.0)
+    shapleyCompare(trainingData5, Vector(1.0, 1.0, 1.0, 1.0, 1.0), expected5a)
+    shapleyCompare(trainingData5, Vector(0.0, 0.0, 0.0, 0.0, 0.0), expected5b)
+
+    // Referenced against SHAP documentation TreeExplainer Two feature AND example
+    val trainingData6 = Seq.tabulate(N) { i =>
+      val features = Vector
+        .fill(M)(0.0)
+        .updated(0, if (i < N / 2) 1.0 else 0.0)
+        .updated(1, if (i < N / 4 || (i >= N / 2 && i < 3 * N / 4)) 1.0 else 0.0)
+      val label = if (i < N / 4) 1.0 else 0.0
+      TrainingRow(features, label)
+    }
+
+    val expected6a = Vector(0.375, 0.375, 0.0, 0.0, 0.0)
+    val expected6b = Vector(-0.125, -0.125, 0.0, 0.0, 0.0)
+    shapleyCompare(trainingData6, Vector(1.0, 1.0, 1.0, 1.0, 1.0), expected6a)
+    shapleyCompare(trainingData6, Vector(0.0, 0.0, 0.0, 0.0, 0.0), expected6b)
+
+    // Referenced against SHAP documentation TreeExplainer Two feature OR example
+    val trainingData7 = Seq.tabulate(N) { i =>
+      val features = Vector
+        .fill(M)(0.0)
+        .updated(0, if (i < N / 2) 1.0 else 0.0)
+        .updated(1, if (i < N / 4 || (i >= N / 2 && i < 3 * N / 4)) 1.0 else 0.0)
+      val label = if (i < N / 2 || (i >= N / 2 && i < 3 * N / 4)) 1.0 else 0.0
+      TrainingRow(features, label)
+    }
+
+    val expected7a = Vector(0.125, 0.125, 0.0, 0.0)
+    val expected7b = Vector(-0.375, -0.375, 0.0, 0.0)
+    shapleyCompare(trainingData7, Vector(1.0, 1.0, 1.0, 1.0), expected7a)
+    shapleyCompare(trainingData7, Vector(0.0, 0.0, 0.0, 0.0), expected7b)
+
+    // Referenced against SHAP documentation TreeExplainer Two feature XOR example
+    val trainingData8 = Seq.tabulate(N) { i =>
+      val features = Vector
+        .fill(M)(0.0)
+        .updated(0, if (i < N / 2) 1.0 else 0.0)
+        .updated(1, if (i < N / 4 || (i >= N / 2 && i < 3 * N / 4)) 1.0 else 0.0)
+      val label = if ((i >= N / 4 && i < N / 2) || (i >= N / 2 && i < 3 * N / 4)) 1.0 else 0.0
+      TrainingRow(features, label)
+    }
+
+    val expected8a = Vector(-0.25, -0.25, 0.0, 0.0)
+    val expected8b = Vector(-0.25, -0.25, 0.0, 0.0)
+    shapleyCompare(trainingData8, Vector(1.0, 1.0, 1.0, 1.0), expected8a)
+    shapleyCompare(trainingData8, Vector(0.0, 0.0, 0.0, 0.0), expected8b)
+
     // Test omitted features
     val expected2a = Vector(0.0, 20.0)
     shapleyCompare(trainingData2, Vector[Any](1.0, 1.0), expected2a, omitFeatures = Set(0))


### PR DESCRIPTION
Currently in our standardized models the inputs and outputs are not handled properly for shapley calculations. We need to standardize input for shapley so that the inputs are correctly scaled to what the model is actually trained on. We also need to  invert the standardization of the final shapley values so the scale is the same as the target values.