### PR TITLE
Update mixin order per scikit-learn 1.6 release

### DIFF
--- a/python/lolopy/learners.py
+++ b/python/lolopy/learners.py
@@ -32,6 +32,7 @@ class BaseLoloLearner(BaseEstimator, metaclass=ABCMeta):
     The pattern for creating a scikit-learn compatible learner is to first implement the `_make_learner` and `__init__`
     operations in a special "Mixin" class that inherits from `BaseLoloLearner`, and then create a regression- or
     classification-specific class that inherits from both `BaseClassifier` or `BaseRegressor` and your new "Mixin".
+    Note that the "Mixin" must be earlier in the method resolution order, as of scikit-learn 1.6.
     See the RandomForest models as an example of this approach.
     """
 
@@ -277,7 +278,7 @@ class BaseLoloLearner(BaseEstimator, metaclass=ABCMeta):
         return model
 
 
-class BaseLoloRegressor(BaseLoloLearner, RegressorMixin):
+class BaseLoloRegressor(RegressorMixin, BaseLoloLearner):
     """Abstract class for models that produce regression models.
 
     As written, this allows for both single-task and multi-task models.
@@ -350,7 +351,7 @@ class BaseLoloRegressor(BaseLoloLearner, RegressorMixin):
         return corr_matrix
 
 
-class BaseLoloClassifier(BaseLoloLearner, ClassifierMixin):
+class BaseLoloClassifier(ClassifierMixin, BaseLoloLearner):
     """Base class for classification models
 
     Implements a modification to the fit operation that stores the number of classes

--- a/python/lolopy/version.py
+++ b/python/lolopy/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn==1.5.0
-py4j==0.10.9.7
+scikit-learn==1.6.1
+py4j==0.10.9.9


### PR DESCRIPTION
With the Tag abstraction introduced in scikit-learn 1.6, method resolution order grabs the tags from [BaseEstimator](https://github.com/scikit-learn/scikit-learn/blob/d8932866b6f4b2dee508a54b79f1122ff5f5459d/sklearn/base.py#L421) instead of [RegressorMixin](https://github.com/scikit-learn/scikit-learn/blob/d8932866b6f4b2dee508a54b79f1122ff5f5459d/sklearn/base.py#L614), resulting in a py4j casting error on targets.