### PR TITLE
Update testing to use os / version matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,18 @@ jobs:
         sbt -Dsbt.log.noformat=true scalafmtCheckAll
         sbt -Dsbt.log.noformat=true +test
 
+  test-python-package-version:
+    name: Check Python package version
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.12
+    - name: Check version
+      run: python .github/scripts/validate_version_bump.py
+
   test-python:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -75,8 +87,6 @@ jobs:
         make
         pip install --only-binary=numpy,scipy -r requirements.txt
         pip install -r test_requirements.txt
-    - name: Check version
-      run: python .github/scripts/validate_version_bump.py
     - name: Run Python tests
       run: |
         cd python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,10 @@ jobs:
       with:
         python-version: 3.12
     - name: Check version
-      run: python .github/scripts/validate_version_bump.py
+      run: |
+        python -m pip install --upgrade pip
+        pip install packaging
+        python .github/scripts/validate_version_bump.py
 
   test-python:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.12"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/python/lolopy/version.py
+++ b/python/lolopy/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/discussions/single-source-version/
-__version__ = "3.0.3"
+__version__ = "3.0.4"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 numpy
-scikit-learn==1.6.1
+scikit-learn==1.3.2;python_version<"3.9"
+scikit-learn==1.6.1;python_version>="3.9"
 py4j==0.10.9.9

--- a/python/setup.py
+++ b/python/setup.py
@@ -46,9 +46,9 @@ setup(
     include_package_data=True,
     package_data={"lolopy.jar": ["*.jar"]},
     install_requires=[
-        "numpy",
-        "scikit-learn<1.7",
-        "py4j<0.10.10"
+        "numpy>=1.21",
+        "scikit-learn>=1.2.2,<1.7",
+        "py4j>=0.10.9,<0.10.10"
     ],
     description="Python wrapper for the Lolo machine learning library",
     long_description=about["long_description"],
@@ -60,5 +60,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )

--- a/python/tests/test_learners.py
+++ b/python/tests/test_learners.py
@@ -11,7 +11,6 @@ from sklearn.exceptions import NotFittedError
 from sklearn.metrics import r2_score, accuracy_score, log_loss
 from sklearn.datasets import load_iris, load_diabetes, load_linnerud
 from unittest import TestCase, main
-import pickle as pkl
 import numpy as np
 
 import logging

--- a/python/tests/test_metrics.py
+++ b/python/tests/test_metrics.py
@@ -1,4 +1,3 @@
-from lolopy.loloserver import get_java_gateway
 from lolopy.metrics import (root_mean_squared_error, standard_confidence, standard_error, uncertainty_correlation)
 from numpy.random import multivariate_normal, uniform, normal, seed
 from unittest import TestCase


### PR DESCRIPTION
Updates the actions testing to include a range of python versions and to test 3.12 on a range of os's.  Also updates requirements to match the actual range of Python versions.