### PR TITLE
Modify publish actions so publishing happens upon releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,19 @@
 name: Deploy-Maven
 
 on:
-  push:
-    branches: [main]
-    tags: ['*']
+  release:
+    types: [published]
 
 env:
   JAVA_VERSION: 11
 
 jobs:
-  release:
+  publish:
+    name: Publish package to Maven
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out repository code
+      uses: actions/checkout@v4
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/deployPyPi.yml
+++ b/.github/workflows/deployPyPi.yml
@@ -1,9 +1,12 @@
 name: Deploy to PyPI
 
 on:
-  push:
-    branches: [main]
-    tags: ['*']
+  release:
+    types: [published]
+
+env:
+  JAVA_VERSION: 11
+  PYTHON_VERSION: 3.12
 
 jobs:
   publish:
@@ -13,20 +16,20 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'adopt'
       - name: Install SBT
         uses: olafurpg/setup-scala@v11
         with:
-          java-version: '11'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Build Scala project
         run: sbt assembly
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,16 +5,16 @@ on:
     branches: [main]
 
 env:
-  SCALA_VERSION: 2.13.8
   JAVA_VERSION: 11
 
 jobs:
   test-scala:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out repository code
+      uses: actions/checkout@v4
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'adopt'
@@ -64,33 +64,34 @@ jobs:
           - os: windows-latest
             python-version: "3.12"
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set up JDK  # Add Java setup
-      uses: actions/setup-java@v2
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'adopt'
-    - name: Install SBT  # Add SBT setup
-      uses: olafurpg/setup-scala@v11
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-    - name: Cache pip dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        cd python
-        make
-        pip install --only-binary=numpy,scipy -r requirements.txt
-        pip install -r test_requirements.txt
-    - name: Run Python tests
-      run: |
-        cd python
-        pytest tests
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up JDK  # Add Java setup
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'adopt'
+      - name: Install SBT  # Add SBT setup
+        uses: olafurpg/setup-scala@v11
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+      - name: Cache pip dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          cd python
+          make
+          pip install --only-binary=numpy,scipy -r requirements.txt
+          pip install -r test_requirements.txt
+      - name: Run Python tests
+        run: |
+          cd python
+          pytest tests

--- a/python/lolopy/version.py
+++ b/python/lolopy/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/discussions/single-source-version/
-__version__ = "3.0.4"
+__version__ = "3.0.5"


### PR DESCRIPTION
This modifies both publish actions so that they only run when we manually trigger a release.

This also homogenizes the various actions so that dependencies between the various actions are consistent.