### PR TITLE
Drop 3.8 support to resole dependabot alert

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest

--- a/python/lolopy/version.py
+++ b/python/lolopy/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/discussions/single-source-version/
-__version__ = "3.0.5"
+__version__ = "3.0.6"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,3 @@
 numpy
-scikit-learn==1.3.2;python_version<"3.9"
-scikit-learn==1.6.1;python_version>="3.9"
+scikit-learn==1.6.1
 py4j==0.10.9.9

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,7 +35,7 @@ copy(JAR_FILE[0], jar_path / "lolo-jar-with-dependencies.jar")
 setup(
     name="lolopy",
     version=about["__version__"],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     url="https://github.com/CitrineInformatics/lolo",
     maintainer="Maxwell Venetos",
     maintainer_email="mvenetos@citrine.io",
@@ -47,7 +47,7 @@ setup(
     package_data={"lolopy.jar": ["*.jar"]},
     install_requires=[
         "numpy>=1.21",
-        "scikit-learn>=1.2.2,<1.7",
+        "scikit-learn>=1.3.2,<1.7",
         "py4j>=0.10.9,<0.10.10"
     ],
     description="Python wrapper for the Lolo machine learning library",
@@ -55,7 +55,6 @@ setup(
     long_description_content_type="text/markdown",
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
https://github.com/CitrineInformatics/lolo/security/dependabot/1

Support for 3.8 required potentially depending on a vulnerable version of scikit-learn.